### PR TITLE
Fix the path for the release.gradle

### DIFF
--- a/litho-annotations/build.gradle
+++ b/litho-annotations/build.gradle
@@ -19,4 +19,4 @@ dependencies {
     compile deps.supportAnnotations
 }
 
-apply from: rootProject.file('release.gradle')
+apply from: rootProject.file('gradle/release.gradle')

--- a/litho-fresco/build.gradle
+++ b/litho-fresco/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     compile deps.supportCoreUi
 }
 
-apply from: rootProject.file('release.gradle')
+apply from: rootProject.file('gradle/release.gradle')
 
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs

--- a/litho-processor/build.gradle
+++ b/litho-processor/build.gradle
@@ -19,4 +19,4 @@ dependencies {
     compile deps.javapoet
 }
 
-apply from: rootProject.file('release.gradle')
+apply from: rootProject.file('gradle/release.gradle')

--- a/litho-stetho/build.gradle
+++ b/litho-stetho/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     compile deps.stetho
 }
 
-apply from: rootProject.file('release.gradle')
+apply from: rootProject.file('gradle/release.gradle')
 
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs

--- a/litho-testing/build.gradle
+++ b/litho-testing/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     compile deps.robolectric
 }
 
-apply from: rootProject.file('release.gradle')
+apply from: rootProject.file('gradle/release.gradle')
 
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs

--- a/litho-widget/build.gradle
+++ b/litho-widget/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     testCompile deps.powermockXstream
 }
 
-apply from: rootProject.file('release.gradle')
+apply from: rootProject.file('gradle/release.gradle')
 
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs


### PR DESCRIPTION
The sample doesn't build with gradle.
Looks like every gradle file point to a wrong path for the release.gradle file.

```
➜  litho git:(master) ✗ ./gradlew :sample:installDebug                                                              

FAILURE: Build failed with an exception.

* Where:
Build file '/usr/local/google/home/thagikura/github/litho/litho-annotations/build.gradle' line: 22

* What went wrong:
A problem occurred evaluating project ':litho-annotations'.
> Could not read script '/usr/local/google/home/thagikura/github/litho/release.gradle' as it does not exist.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 1.202 secs
```