### PR TITLE
Fix search bar style

### DIFF
--- a/docs/_sass/_search.scss
+++ b/docs/_sass/_search.scss
@@ -6,7 +6,6 @@ input[type="search"] {
 .navSearchWrapper {
   align-self: center;
   position: relative;
-  margin-bottom: -8px;
 
   &::before {
     border: 3px solid $primary-overlay-special;


### PR DESCRIPTION
The search input doesn't align correctly.

before
![2017-04-20 10 57 03](https://cloud.githubusercontent.com/assets/3193344/25211521/2e02dd9e-25b8-11e7-9ef9-3f59fc1ddb18.png)

after
![2017-04-20 10 58 10](https://cloud.githubusercontent.com/assets/3193344/25211542/483c2828-25b8-11e7-938a-b553afbda24d.png)

