### PR TITLE
Fix Edit on GitHub links

### DIFF
--- a/docs/_includes/doc-getting-started.html
+++ b/docs/_includes/doc-getting-started.html
@@ -9,7 +9,7 @@
     </div>
     {{ content }}
     <block class="gradle buck" />
-    <p><a class="edit-page-link" href="https://github.com/{{ site.ghrepo }}/tree/gh-pages/{{ page.path }}" target="_blank">Edit on GitHub</a></p>
+    <p><a class="edit-page-link" href="https://github.com/{{ site.ghrepo }}/tree/master/docs/{{ page.path }}" target="_blank">Edit on GitHub</a></p>
   </article>
   {% include doc_paging.html %}
 </div>

--- a/docs/_includes/doc.html
+++ b/docs/_includes/doc.html
@@ -18,7 +18,7 @@
     {% else %}
       {{ content }}
 
-      <p><a class="edit-page-link" href="https://github.com/{{ site.ghrepo }}/tree/gh-pages/{{ page.path }}" target="_blank">Edit on GitHub</a></p>
+      <p><a class="edit-page-link" href="https://github.com/{{ site.ghrepo }}/tree/master/docs/{{ page.path }}" target="_blank">Edit on GitHub</a></p>
     {% endif %}
   </article>
   {% include doc_paging.html %}

--- a/docs/_includes/powered_by.html
+++ b/docs/_includes/powered_by.html
@@ -22,7 +22,7 @@
       </div>
       {% endfor %}
     </div>
-    <div class="poweredByMessage">Does your app use {{ site.title }}? Add it to this list with <a href="https://github.com/{{ site.ghrepo }}/edit/gh-pages/_data/powered_by.yml" target="_blank">a pull request!</a></div>
+    <div class="poweredByMessage">Does your app use {{ site.title }}? Add it to this list with <a href="https://github.com/{{ site.ghrepo }}/edit/master/docs/_data/powered_by.yml" target="_blank">a pull request!</a></div>
   </div>
 </div>
 {% endif %}


### PR DESCRIPTION
`gh-pages` has been moved to `master/docs`, the links are broken.