### PR TITLE
Correct spelling of GitHub in nav

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -10,7 +10,7 @@
   href: /docs/tutorial
   category: tutorial
 
-- title: Github
+- title: GitHub
   href: http://github.com/facebook/litho
   category: external
 


### PR DESCRIPTION
Noticed a little typo 😸 

![image](https://cloud.githubusercontent.com/assets/121322/25219913/e8606cfa-2564-11e7-9f53-de6095d1c0f8.png)

Cheers,
  Lee :beers: