### PR TITLE
Fix typo in documentation (uses.md)

### DIFF
--- a/docs/_docs/uses.md
+++ b/docs/_docs/uses.md
@@ -10,7 +10,7 @@ great scroll performance even with complex items with a wide variety of
 content, which is quite challenging to achieve using traditional Android views.
 
 You might also consider adopting Litho simply for its declarative API for
-building user interfaces. Litho's functional programming model with an
+building user interfaces. Litho's functional programming model with a
 unidirectional data flow tends to be much easier to reason about even as your
 product gets more complex.
 


### PR DESCRIPTION
Proper english grammar dictates the use of the article "a" instead of "an", despite the fact that the following word begins with a vowel.  Yes, the rules of english grammar are confusing.

For reference, look at "Use 5" at: http://www.englishpage.com/articles/a-vs-an.htm