### PR TITLE
Remove redundant dependencies.

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -9,4 +9,4 @@
 
 [android]
   target = android-25
-  build_tools_version = 23.0.2
+  build_tools_version = 25.0.2

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ ext {
 ext.deps = [
         // Android support
         supportAnnotations : 'com.android.support:support-annotations:25.3.1',
-        supportCompat      : 'com.android.support:support-compat:25.3.1',
         supportAppCompat   : 'com.android.support:appcompat-v7:25.3.1',
         supportCoreUi      : 'com.android.support:support-core-ui:25.3.1',
         supportRecyclerView: 'com.android.support:recyclerview-v7:25.3.1',

--- a/lib/android-support/BUCK
+++ b/lib/android-support/BUCK
@@ -19,17 +19,6 @@ remote_file(
 )
 
 android_prebuilt_aar(
-    name = "android-support-v4-aar",
-    aar = ":android-support-v4.aar",
-)
-
-remote_file(
-    name = "android-support-v4.aar",
-    sha1 = "e8f2835adcd883b3778f34121368892a5d1c188e",
-    url = "mvn:com.android.support:support-v4:aar:25.3.1",
-)
-
-android_prebuilt_aar(
     name = "android-support-core-ui-aar",
     aar = ":android-support-core-ui.aar",
 )
@@ -103,7 +92,6 @@ java_library(
         ":android-support-core-ui-aar",
         ":android-support-core-utils-aar",
         ":android-support-fragment-aar",
-        ":android-support-v4-aar",
         ":android-support-vector-drawable-aar",
     ],
     visibility = [

--- a/litho-core/build.gradle
+++ b/litho-core/build.gradle
@@ -52,7 +52,6 @@ dependencies {
 
     // Android Support Library
     provided deps.supportAnnotations
-    compile deps.supportCompat
     compile deps.supportCoreUi
     compile deps.supportRecyclerView
 

--- a/litho-fresco/build.gradle
+++ b/litho-fresco/build.gradle
@@ -28,7 +28,6 @@ dependencies {
     compile deps.fresco
 
     // Android Support Library
-    compile deps.supportCompat
     compile deps.supportCoreUi
 }
 

--- a/litho-widget/build.gradle
+++ b/litho-widget/build.gradle
@@ -52,7 +52,6 @@ dependencies {
     compile deps.textlayoutbuilder
 
     // Android Support Library
-    compile deps.supportCompat
     compile deps.supportCoreUi
 
     // Testing


### PR DESCRIPTION
The support-v4 library was modularized into distinct components like
support-compat, support-core-ui, support-fragment. We should not depend
on the modules as well as the unmodularized version.

I got errors when running a buck build unrelated to this change so ill need to verify that this compiles with buck. `./gradlew assemble` succeeds.