### PR TITLE
Disallow ComponentBuilder mutations once build() is called

### DIFF
--- a/litho-core/src/main/java/com/facebook/litho/InternalNode.java
+++ b/litho-core/src/main/java/com/facebook/litho/InternalNode.java
@@ -140,6 +140,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   // When this flag is set, border color was explicitly set on this node.
   private static final long PFLAG_BORDER_COLOR_IS_SET = 1L << 29;
 
+  private static final String ILLEGAL_MODIFY_OPERATION = "Should not modify ComponentLayout properties on a built object";
+
   private final ResourceResolver mResourceResolver = new ResourceResolver();
 
   YogaNode mYogaNode;
@@ -188,6 +190,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   private boolean mCachedMeasuresValid;
   private TreeProps mPendingTreeProps;
 
+  private boolean mIsBuilt;
+
   void init(YogaNode yogaNode, ComponentContext componentContext, Resources resources) {
     yogaNode.setData(this);
     yogaNode.setOverflow(YogaOverflow.HIDDEN);
@@ -205,6 +209,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     mResourceResolver.init(
         mComponentContext,
         componentContext.getResourceCache());
+
+    mIsBuilt = false;
   }
 
   @Px
@@ -245,70 +251,6 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     }
 
     return (int) mResolvedHeight;
-  }
-
-  private class InternalLayoutFrozen implements ComponentLayout {
-
-    private int x, y, width, height;
-    private int paddingTop, paddingRight, paddingBottom, paddingLeft;
-    private YogaDirection resolvedLayoutDirection;
-
-    InternalLayoutFrozen(InternalNode node) {
-      this.x = node.getX();
-      this.y = node.getY();
-      this.height = node.getHeight();
-      this.width = node.getWidth();
-      this.paddingBottom = node.getPaddingBottom();
-      this.paddingTop = node.getPaddingTop();
-      this.paddingLeft = node.getPaddingLeft();
-      this.paddingRight = node.getPaddingRight();
-      this.resolvedLayoutDirection = node.getResolvedLayoutDirection();
-    }
-
-    @Override
-    public int getX() {
-      return x;
-    }
-
-    @Override
-    public int getY() {
-      return y;
-    }
-
-    @Override
-    public int getWidth() {
-      return width;
-    }
-
-    @Override
-    public int getHeight() {
-      return height;
-    }
-
-    @Override
-    public int getPaddingTop() {
-      return paddingTop;
-    }
-
-    @Override
-    public int getPaddingRight() {
-      return paddingRight;
-    }
-
-    @Override
-    public int getPaddingBottom() {
-      return paddingBottom;
-    }
-
-    @Override
-    public int getPaddingLeft() {
-      return paddingLeft;
-    }
-
-    @Override
-    public YogaDirection getResolvedLayoutDirection() {
-      return resolvedLayoutDirection;
-    }
   }
 
   @Px
@@ -440,6 +382,9 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode layoutDirection(YogaDirection direction) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     mPrivateFlags |= PFLAG_LAYOUT_DIRECTION_IS_SET;
     mYogaNode.setDirection(direction);
     return this;
@@ -452,30 +397,45 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode wrap(YogaWrap wrap) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     mYogaNode.setWrap(wrap);
     return this;
   }
 
   @Override
   public InternalNode justifyContent(YogaJustify justifyContent) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     mYogaNode.setJustifyContent(justifyContent);
     return this;
   }
 
   @Override
   public InternalNode alignItems(YogaAlign alignItems) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     mYogaNode.setAlignItems(alignItems);
     return this;
   }
 
   @Override
   public InternalNode alignContent(YogaAlign alignContent) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     mYogaNode.setAlignContent(alignContent);
     return this;
   }
 
   @Override
   public InternalNode alignSelf(YogaAlign alignSelf) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     mPrivateFlags |= PFLAG_ALIGN_SELF_IS_SET;
     mYogaNode.setAlignSelf(alignSelf);
     return this;
@@ -483,6 +443,9 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode positionType(YogaPositionType positionType) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     mPrivateFlags |= PFLAG_POSITION_TYPE_IS_SET;
     mYogaNode.setPositionType(positionType);
     return this;
@@ -490,6 +453,9 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode flex(float flex) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     mPrivateFlags |= PFLAG_FLEX_IS_SET;
     mYogaNode.setFlex(flex);
     return this;
@@ -497,6 +463,9 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode flexGrow(float flexGrow) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     mPrivateFlags |= PFLAG_FLEX_GROW_IS_SET;
     mYogaNode.setFlexGrow(flexGrow);
     return this;
@@ -504,6 +473,9 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode flexShrink(float flexShrink) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     mPrivateFlags |= PFLAG_FLEX_SHRINK_IS_SET;
     mYogaNode.setFlexShrink(flexShrink);
     return this;
@@ -511,6 +483,9 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode flexBasisPx(@Px int flexBasis) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     mPrivateFlags |= PFLAG_FLEX_BASIS_IS_SET;
     mYogaNode.setFlexBasis(flexBasis);
     return this;
@@ -524,6 +499,9 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode flexBasisPercent(float percent) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     mPrivateFlags |= PFLAG_FLEX_BASIS_IS_SET;
     mYogaNode.setFlexBasisPercent(percent);
     return this;
@@ -531,26 +509,41 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode flexBasisAttr(@AttrRes int resId, @DimenRes int defaultResId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     return flexBasisPx(mResourceResolver.resolveDimenOffsetAttr(resId, defaultResId));
   }
 
   @Override
   public InternalNode flexBasisAttr(@AttrRes int resId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     return flexBasisAttr(resId, 0);
   }
 
   @Override
   public InternalNode flexBasisRes(@DimenRes int resId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     return flexBasisPx(mResourceResolver.resolveDimenOffsetRes(resId));
   }
 
   @Override
   public InternalNode flexBasisDip(@Dimension(unit = DP) int flexBasis) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     return flexBasisPx(mResourceResolver.dipsToPixels(flexBasis));
   }
 
   @Override
   public InternalNode importantForAccessibility(int importantForAccessibility) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     mPrivateFlags |= PFLAG_IMPORTANT_FOR_ACCESSIBILITY_IS_SET;
     mImportantForAccessibility = importantForAccessibility;
     return this;
@@ -558,6 +551,9 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode duplicateParentState(boolean duplicateParentState) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     mPrivateFlags |= PFLAG_DUPLICATE_PARENT_STATE_IS_SET;
     mDuplicateParentState = duplicateParentState;
     return this;
@@ -565,6 +561,9 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode marginPx(YogaEdge edge, @Px int margin) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     mPrivateFlags |= PFLAG_MARGIN_IS_SET;
     mYogaNode.setMargin(edge, margin);
     return this;
@@ -572,6 +571,9 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode marginPercent(YogaEdge edge, float percent) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     mPrivateFlags |= PFLAG_MARGIN_IS_SET;
     mYogaNode.setMarginPercent(edge, percent);
     return this;
@@ -579,6 +581,9 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode marginAuto(YogaEdge edge) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     mPrivateFlags |= PFLAG_MARGIN_IS_SET;
     mYogaNode.setMarginAuto(edge);
     return this;
@@ -589,6 +594,9 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
       YogaEdge edge,
       @AttrRes int resId,
       @DimenRes int defaultResId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     return marginPx(edge, mResourceResolver.resolveDimenOffsetAttr(resId, defaultResId));
   }
 
@@ -596,16 +604,25 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   public InternalNode marginAttr(
       YogaEdge edge,
       @AttrRes int resId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     return marginAttr(edge, resId, 0);
   }
 
   @Override
   public InternalNode marginRes(YogaEdge edge, @DimenRes int resId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     return marginPx(edge, mResourceResolver.resolveDimenOffsetRes(resId));
   }
 
   @Override
   public InternalNode marginDip(YogaEdge edge, @Dimension(unit = DP) int margin) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     return marginPx(edge, mResourceResolver.dipsToPixels(margin));
   }
 
@@ -619,6 +636,9 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode paddingPx(YogaEdge edge, @Px int padding) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     mPrivateFlags |= PFLAG_PADDING_IS_SET;
 
     if (mIsNestedTreeHolder) {
@@ -633,6 +653,9 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode paddingPercent(YogaEdge edge, float percent) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     mPrivateFlags |= PFLAG_PADDING_IS_SET;
 
     if (mIsNestedTreeHolder) {
@@ -650,6 +673,9 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
       YogaEdge edge,
       @AttrRes int resId,
       @DimenRes int defaultResId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     return paddingPx(edge, mResourceResolver.resolveDimenOffsetAttr(resId, defaultResId));
   }
 
@@ -657,21 +683,33 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   public InternalNode paddingAttr(
       YogaEdge edge,
       @AttrRes int resId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     return paddingAttr(edge, resId, 0);
   }
 
   @Override
   public InternalNode paddingRes(YogaEdge edge, @DimenRes int resId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     return paddingPx(edge, mResourceResolver.resolveDimenOffsetRes(resId));
   }
 
   @Override
   public InternalNode paddingDip(YogaEdge edge, @Dimension(unit = DP) int padding) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     return paddingPx(edge, mResourceResolver.dipsToPixels(padding));
   }
 
   @Override
   public InternalNode borderWidthPx(YogaEdge edge, @Px int borderWidth) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     mPrivateFlags |= PFLAG_BORDER_WIDTH_IS_SET;
 
     if (mIsNestedTreeHolder) {
@@ -692,6 +730,9 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
       YogaEdge edge,
       @AttrRes int resId,
       @DimenRes int defaultResId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     return borderWidthPx(edge, mResourceResolver.resolveDimenOffsetAttr(resId, defaultResId));
   }
 
@@ -699,11 +740,17 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   public InternalNode borderWidthAttr(
       YogaEdge edge,
       @AttrRes int resId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     return borderWidthAttr(edge, resId, 0);
   }
 
   @Override
   public InternalNode borderWidthRes(YogaEdge edge, @DimenRes int resId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     return borderWidthPx(edge, mResourceResolver.resolveDimenOffsetRes(resId));
   }
 
@@ -711,11 +758,17 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   public InternalNode borderWidthDip(
       YogaEdge edge,
       @Dimension(unit = DP) int borderWidth) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     return borderWidthPx(edge, mResourceResolver.dipsToPixels(borderWidth));
   }
 
   @Override
   public Builder borderColor(@ColorInt int borderColor) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     mPrivateFlags |= PFLAG_BORDER_COLOR_IS_SET;
     mBorderColor = borderColor;
     return this;
@@ -723,6 +776,9 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode positionPx(YogaEdge edge, @Px int position) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     mPrivateFlags |= PFLAG_POSITION_IS_SET;
     mYogaNode.setPosition(edge, position);
     return this;
@@ -730,6 +786,9 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode positionPercent(YogaEdge edge, float percent) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     mPrivateFlags |= PFLAG_POSITION_IS_SET;
     mYogaNode.setPositionPercent(edge, percent);
     return this;
@@ -740,16 +799,25 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
       YogaEdge edge,
       @AttrRes int resId,
       @DimenRes int defaultResId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     return positionPx(edge, mResourceResolver.resolveDimenOffsetAttr(resId, defaultResId));
   }
 
   @Override
   public InternalNode positionAttr(YogaEdge edge, @AttrRes int resId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     return positionAttr(edge, resId, 0);
   }
 
   @Override
   public InternalNode positionRes(YogaEdge edge, @DimenRes int resId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     return positionPx(edge, mResourceResolver.resolveDimenOffsetRes(resId));
   }
 
@@ -757,11 +825,17 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   public InternalNode positionDip(
       YogaEdge edge,
       @Dimension(unit = DP) int position) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     return positionPx(edge, mResourceResolver.dipsToPixels(position));
   }
 
   @Override
   public InternalNode widthPx(@Px int width) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     mPrivateFlags |= PFLAG_WIDTH_IS_SET;
     mYogaNode.setWidth(width);
     return this;
@@ -775,6 +849,9 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode widthPercent(float percent) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     mPrivateFlags |= PFLAG_WIDTH_IS_SET;
     mYogaNode.setWidthPercent(percent);
     return this;
@@ -782,26 +859,41 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode widthRes(@DimenRes int resId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     return widthPx(mResourceResolver.resolveDimenSizeRes(resId));
   }
 
   @Override
   public InternalNode widthAttr(@AttrRes int resId, @DimenRes int defaultResId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     return widthPx(mResourceResolver.resolveDimenSizeAttr(resId, defaultResId));
   }
 
   @Override
   public InternalNode widthAttr(@AttrRes int resId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     return widthAttr(resId, 0);
   }
 
   @Override
   public InternalNode widthDip(@Dimension(unit = DP) int width) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     return widthPx(mResourceResolver.dipsToPixels(width));
   }
 
   @Override
   public InternalNode minWidthPx(@Px int minWidth) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     mPrivateFlags |= PFLAG_MIN_WIDTH_IS_SET;
     mYogaNode.setMinWidth(minWidth);
     return this;
@@ -809,6 +901,9 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode minWidthPercent(float percent) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     mPrivateFlags |= PFLAG_MIN_WIDTH_IS_SET;
     mYogaNode.setMinWidthPercent(percent);
     return this;
@@ -816,26 +911,42 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode minWidthAttr(@AttrRes int resId, @DimenRes int defaultResId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     return minWidthPx(mResourceResolver.resolveDimenSizeAttr(resId, defaultResId));
   }
 
   @Override
   public InternalNode minWidthAttr(@AttrRes int resId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     return minWidthAttr(resId, 0);
   }
 
   @Override
   public InternalNode minWidthRes(@DimenRes int resId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     return minWidthPx(mResourceResolver.resolveDimenSizeRes(resId));
   }
 
   @Override
   public InternalNode minWidthDip(@Dimension(unit = DP) int minWidth) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
     return minWidthPx(mResourceResolver.dipsToPixels(minWidth));
   }
 
   @Override
   public InternalNode maxWidthPx(@Px int maxWidth) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     mPrivateFlags |= PFLAG_MAX_WIDTH_IS_SET;
     mYogaNode.setMaxWidth(maxWidth);
     return this;
@@ -843,6 +954,10 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode maxWidthPercent(float percent) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     mPrivateFlags |= PFLAG_MAX_WIDTH_IS_SET;
     mYogaNode.setMaxWidthPercent(percent);
     return this;
@@ -850,26 +965,46 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode maxWidthAttr(@AttrRes int resId, @DimenRes int defaultResId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return maxWidthPx(mResourceResolver.resolveDimenSizeAttr(resId, defaultResId));
   }
 
   @Override
   public InternalNode maxWidthAttr(@AttrRes int resId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return maxWidthAttr(resId, 0);
   }
 
   @Override
   public InternalNode maxWidthRes(@DimenRes int resId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return maxWidthPx(mResourceResolver.resolveDimenSizeRes(resId));
   }
 
   @Override
   public InternalNode maxWidthDip(@Dimension(unit = DP) int maxWidth) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return maxWidthPx(mResourceResolver.dipsToPixels(maxWidth));
   }
 
   @Override
   public InternalNode heightPx(@Px int height) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     mPrivateFlags |= PFLAG_HEIGHT_IS_SET;
     mYogaNode.setHeight(height);
     return this;
@@ -877,12 +1012,20 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   // Used by stetho to re-set auto value
   InternalNode heightAuto() {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     mYogaNode.setHeightAuto();
     return this;
   }
 
   @Override
   public InternalNode heightPercent(float percent) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     mPrivateFlags |= PFLAG_HEIGHT_IS_SET;
     mYogaNode.setHeightPercent(percent);
     return this;
@@ -890,26 +1033,46 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode heightRes(@DimenRes int resId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return heightPx(mResourceResolver.resolveDimenSizeRes(resId));
   }
 
   @Override
   public InternalNode heightAttr(@AttrRes int resId, @DimenRes int defaultResId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return heightPx(mResourceResolver.resolveDimenSizeAttr(resId, defaultResId));
   }
 
   @Override
   public InternalNode heightAttr(@AttrRes int resId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return heightAttr(resId, 0);
   }
 
   @Override
   public InternalNode heightDip(@Dimension(unit = DP) int height) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return heightPx(mResourceResolver.dipsToPixels(height));
   }
 
   @Override
   public InternalNode minHeightPx(@Px int minHeight) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     mPrivateFlags |= PFLAG_MIN_HEIGHT_IS_SET;
     mYogaNode.setMinHeight(minHeight);
     return this;
@@ -917,6 +1080,10 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode minHeightPercent(float percent) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     mPrivateFlags |= PFLAG_MIN_HEIGHT_IS_SET;
     mYogaNode.setMinHeightPercent(percent);
     return this;
@@ -924,26 +1091,46 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode minHeightAttr(@AttrRes int resId, @DimenRes int defaultResId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return minHeightPx(mResourceResolver.resolveDimenSizeAttr(resId, defaultResId));
   }
 
   @Override
   public InternalNode minHeightAttr(@AttrRes int resId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return minHeightAttr(resId, 0);
   }
 
   @Override
   public InternalNode minHeightRes(@DimenRes int resId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return minHeightPx(mResourceResolver.resolveDimenSizeRes(resId));
   }
 
   @Override
   public InternalNode minHeightDip(@Dimension(unit = DP) int minHeight) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return minHeightPx(mResourceResolver.dipsToPixels(minHeight));
   }
 
   @Override
   public InternalNode maxHeightPx(@Px int maxHeight) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     mPrivateFlags |= PFLAG_MAX_HEIGHT_IS_SET;
     mYogaNode.setMaxHeight(maxHeight);
     return this;
@@ -951,6 +1138,10 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode maxHeightPercent(float percent) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     mPrivateFlags |= PFLAG_MAX_HEIGHT_IS_SET;
     mYogaNode.setMaxHeightPercent(percent);
     return this;
@@ -958,26 +1149,46 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode maxHeightAttr(@AttrRes int resId, @DimenRes int defaultResId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return maxHeightPx(mResourceResolver.resolveDimenSizeAttr(resId, defaultResId));
   }
 
   @Override
   public InternalNode maxHeightAttr(@AttrRes int resId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return maxHeightAttr(resId, 0);
   }
 
   @Override
   public InternalNode maxHeightRes(@DimenRes int resId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return maxHeightPx(mResourceResolver.resolveDimenSizeRes(resId));
   }
 
   @Override
   public InternalNode maxHeightDip(@Dimension(unit = DP) int maxHeight) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return maxHeightPx(mResourceResolver.dipsToPixels(maxHeight));
   }
 
   @Override
   public InternalNode aspectRatio(float aspectRatio) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     mPrivateFlags |= PFLAG_ASPECT_RATIO_IS_SET;
     if (mYogaNode instanceof YogaNode) {
       mYogaNode.setAspectRatio(aspectRatio);
@@ -1041,6 +1252,10 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode touchExpansionPx(YogaEdge edge, @Px int touchExpansion) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     if (mTouchExpansion == null) {
       mTouchExpansion = ComponentsPools.acquireEdges();
     }
@@ -1056,6 +1271,10 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
       YogaEdge edge,
       @AttrRes int resId,
       @DimenRes int defaultResId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return touchExpansionPx(
         edge,
         mResourceResolver.resolveDimenOffsetAttr(resId, defaultResId));
@@ -1065,11 +1284,19 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   public InternalNode touchExpansionAttr(
       YogaEdge edge,
       @AttrRes int resId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return touchExpansionAttr(edge, resId, 0);
   }
 
   @Override
   public InternalNode touchExpansionRes(YogaEdge edge, @DimenRes int resId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return touchExpansionPx(edge, mResourceResolver.resolveDimenOffsetRes(resId));
   }
 
@@ -1077,11 +1304,19 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   public InternalNode touchExpansionDip(
       YogaEdge edge,
       @Dimension(unit = DP) int touchExpansion) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return touchExpansionPx(edge, mResourceResolver.dipsToPixels(touchExpansion));
   }
 
   @Override
   public InternalNode child(ComponentLayout child) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     if (child != null && child != NULL_LAYOUT) {
       addChildAt((InternalNode) child, mYogaNode.getChildCount());
     }
@@ -1090,6 +1325,10 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode child(ComponentLayout.Builder child) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     if (child != null && child != NULL_LAYOUT) {
       child(child.build());
     }
@@ -1098,6 +1337,10 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode child(Component<?> child) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     if (child != null) {
       child(Layout.create(mComponentContext, child).flexShrink(0));
     }
@@ -1106,6 +1349,10 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode child(Component.Builder<?> child) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     if (child != null) {
       child(child.build());
     }
@@ -1114,6 +1361,10 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode background(Reference<? extends Drawable> background) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     mPrivateFlags |= PFLAG_BACKGROUND_IS_SET;
     mBackground = background;
     setPaddingFromDrawableReference(background);
@@ -1122,26 +1373,46 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode background(Reference.Builder<? extends Drawable> builder) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return background(builder.build());
   }
 
   @Override
   public InternalNode background(Drawable background) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return background(DrawableReference.create().drawable(background));
   }
 
   @Override
   public InternalNode backgroundAttr(@AttrRes int resId, @DrawableRes int defaultResId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return backgroundRes(mResourceResolver.resolveResIdAttr(resId, defaultResId));
   }
 
   @Override
   public InternalNode backgroundAttr(@AttrRes int resId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return backgroundAttr(resId, 0);
   }
 
   @Override
   public InternalNode backgroundRes(@DrawableRes int resId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     if (resId == 0) {
       return background((Reference<Drawable>) null);
     }
@@ -1154,6 +1425,10 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode backgroundColor(@ColorInt int backgroundColor) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return background(
         ColorDrawableReference.create(mComponentContext)
             .color(backgroundColor)
@@ -1162,6 +1437,10 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode foreground(Drawable foreground) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     mPrivateFlags |= PFLAG_FOREGROUND_IS_SET;
     mForeground = foreground;
     return this;
@@ -1169,16 +1448,28 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode foregroundAttr(@AttrRes int resId, @DrawableRes int defaultResId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return foregroundRes(mResourceResolver.resolveResIdAttr(resId, defaultResId));
   }
 
   @Override
   public InternalNode foregroundAttr(@AttrRes int resId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return foregroundAttr(resId, 0);
   }
 
   @Override
   public InternalNode foregroundRes(@DrawableRes int resId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     if (resId == 0) {
       return foreground(null);
     }
@@ -1188,11 +1479,19 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode foregroundColor(@ColorInt int foregroundColor) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return foreground(new ColorDrawable(foregroundColor));
   }
 
   @Override
   public InternalNode wrapInView() {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     mForceViewWrapping = true;
     return this;
   }
@@ -1203,30 +1502,50 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode clickHandler(EventHandler clickHandler) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     getOrCreateNodeInfo().setClickHandler(clickHandler);
     return this;
   }
 
   @Override
   public InternalNode longClickHandler(EventHandler longClickHandler) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     getOrCreateNodeInfo().setLongClickHandler(longClickHandler);
     return this;
   }
 
   @Override
   public InternalNode touchHandler(EventHandler touchHandler) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     getOrCreateNodeInfo().setTouchHandler(touchHandler);
     return this;
   }
 
   @Override
   public ContainerBuilder focusable(boolean isFocusable) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     getOrCreateNodeInfo().setFocusable(isFocusable);
     return this;
   }
 
   @Override
   public InternalNode visibleHandler(EventHandler visibleHandler) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     mPrivateFlags |= PFLAG_VISIBLE_HANDLER_IS_SET;
     mVisibleHandler = visibleHandler;
     return this;
@@ -1238,6 +1557,10 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode focusedHandler(EventHandler focusedHandler) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     mPrivateFlags |= PFLAG_FOCUSED_HANDLER_IS_SET;
     mFocusedHandler = focusedHandler;
     return this;
@@ -1249,6 +1572,10 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode unfocusedHandler(EventHandler unfocusedHandler) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     mPrivateFlags |= PFLAG_UNFOCUSED_HANDLER_IS_SET;
     mUnfocusedHandler = unfocusedHandler;
     return this;
@@ -1260,6 +1587,10 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode fullImpressionHandler(EventHandler fullImpressionHandler) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     mPrivateFlags |= PFLAG_FULL_IMPRESSION_HANDLER_IS_SET;
     mFullImpressionHandler = fullImpressionHandler;
     return this;
@@ -1271,6 +1602,10 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode invisibleHandler(EventHandler invisibleHandler) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     mPrivateFlags |= PFLAG_INVISIBLE_HANDLER_IS_SET;
     mInvisibleHandler = invisibleHandler;
     return this;
@@ -1282,22 +1617,38 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode contentDescription(CharSequence contentDescription) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     getOrCreateNodeInfo().setContentDescription(contentDescription);
     return this;
   }
 
   @Override
   public InternalNode contentDescription(@StringRes int stringId) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return contentDescription(mResources.getString(stringId));
   }
 
   @Override
   public InternalNode contentDescription(@StringRes int stringId, Object... formatArgs) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return contentDescription(mResources.getString(stringId, formatArgs));
   }
 
   @Override
   public InternalNode viewTag(Object viewTag) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     getOrCreateNodeInfo().setViewTag(viewTag);
     return this;
   }
@@ -1310,6 +1661,10 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode testKey(String testKey) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     mTestKey = testKey;
     return this;
   }
@@ -1320,6 +1675,10 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
           dispatchPopulateAccessibilityEventHandler) {
     getOrCreateNodeInfo().setDispatchPopulateAccessibilityEventHandler(
         dispatchPopulateAccessibilityEventHandler);
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return this;
   }
 
@@ -1328,6 +1687,10 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
       EventHandler<OnInitializeAccessibilityEventEvent> onInitializeAccessibilityEventHandler) {
     getOrCreateNodeInfo().setOnInitializeAccessibilityEventHandler(
         onInitializeAccessibilityEventHandler);
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     return this;
   }
 
@@ -1335,6 +1698,10 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   public InternalNode onInitializeAccessibilityNodeInfoHandler(
       EventHandler<OnInitializeAccessibilityNodeInfoEvent>
           onInitializeAccessibilityNodeInfoHandler) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     getOrCreateNodeInfo().setOnInitializeAccessibilityNodeInfoHandler(
         onInitializeAccessibilityNodeInfoHandler);
     return this;
@@ -1343,6 +1710,10 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   @Override
   public InternalNode onPopulateAccessibilityEventHandler(
       EventHandler<OnPopulateAccessibilityEventEvent> onPopulateAccessibilityEventHandler) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     getOrCreateNodeInfo().setOnPopulateAccessibilityEventHandler(
         onPopulateAccessibilityEventHandler);
     return this;
@@ -1351,6 +1722,10 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   @Override
   public InternalNode onRequestSendAccessibilityEventHandler(
       EventHandler<OnRequestSendAccessibilityEventEvent> onRequestSendAccessibilityEventHandler) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     getOrCreateNodeInfo().setOnRequestSendAccessibilityEventHandler(
         onRequestSendAccessibilityEventHandler);
     return this;
@@ -1359,6 +1734,10 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   @Override
   public InternalNode performAccessibilityActionHandler(
       EventHandler<PerformAccessibilityActionEvent> performAccessibilityActionHandler) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     getOrCreateNodeInfo().setPerformAccessibilityActionHandler(performAccessibilityActionHandler);
     return this;
   }
@@ -1366,6 +1745,10 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   @Override
   public InternalNode sendAccessibilityEventHandler(
       EventHandler<SendAccessibilityEventEvent> sendAccessibilityEventHandler) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     getOrCreateNodeInfo().setSendAccessibilityEventHandler(sendAccessibilityEventHandler);
     return this;
   }
@@ -1373,6 +1756,10 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   @Override
   public InternalNode sendAccessibilityEventUncheckedHandler(
       EventHandler<SendAccessibilityEventUncheckedEvent> sendAccessibilityEventUncheckedHandler) {
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+
     getOrCreateNodeInfo().setSendAccessibilityEventUncheckedHandler(
         sendAccessibilityEventUncheckedHandler);
     return this;
@@ -1512,7 +1899,11 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public ComponentLayout build() {
-    return new InternalLayoutFrozen(this);
+    if (mIsBuilt) {
+      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
+    }
+    mIsBuilt = true;
+    return this;
   }
 
   private float resolveHorizontalEdges(Edges spacing, YogaEdge edge) {

--- a/litho-core/src/main/java/com/facebook/litho/InternalNode.java
+++ b/litho-core/src/main/java/com/facebook/litho/InternalNode.java
@@ -140,8 +140,6 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   // When this flag is set, border color was explicitly set on this node.
   private static final long PFLAG_BORDER_COLOR_IS_SET = 1L << 29;
 
-  private static final String ILLEGAL_MODIFY_OPERATION = "Should not modify ComponentLayout properties on a built object";
-
   private final ResourceResolver mResourceResolver = new ResourceResolver();
 
   YogaNode mYogaNode;
@@ -382,10 +380,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode layoutDirection(YogaDirection direction) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+	checkIfBuilt();
     mPrivateFlags |= PFLAG_LAYOUT_DIRECTION_IS_SET;
     mYogaNode.setDirection(direction);
     return this;
@@ -398,50 +393,35 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode wrap(YogaWrap wrap) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mYogaNode.setWrap(wrap);
     return this;
   }
 
   @Override
   public InternalNode justifyContent(YogaJustify justifyContent) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mYogaNode.setJustifyContent(justifyContent);
     return this;
   }
 
   @Override
   public InternalNode alignItems(YogaAlign alignItems) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mYogaNode.setAlignItems(alignItems);
     return this;
   }
 
   @Override
   public InternalNode alignContent(YogaAlign alignContent) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mYogaNode.setAlignContent(alignContent);
     return this;
   }
 
   @Override
   public InternalNode alignSelf(YogaAlign alignSelf) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_ALIGN_SELF_IS_SET;
     mYogaNode.setAlignSelf(alignSelf);
     return this;
@@ -449,10 +429,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode positionType(YogaPositionType positionType) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+	checkIfBuilt();
     mPrivateFlags |= PFLAG_POSITION_TYPE_IS_SET;
     mYogaNode.setPositionType(positionType);
     return this;
@@ -460,10 +437,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode flex(float flex) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_FLEX_IS_SET;
     mYogaNode.setFlex(flex);
     return this;
@@ -471,10 +445,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode flexGrow(float flexGrow) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_FLEX_GROW_IS_SET;
     mYogaNode.setFlexGrow(flexGrow);
     return this;
@@ -482,10 +453,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode flexShrink(float flexShrink) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_FLEX_SHRINK_IS_SET;
     mYogaNode.setFlexShrink(flexShrink);
     return this;
@@ -493,10 +461,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode flexBasisPx(@Px int flexBasis) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_FLEX_BASIS_IS_SET;
     mYogaNode.setFlexBasis(flexBasis);
     return this;
@@ -510,10 +475,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode flexBasisPercent(float percent) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_FLEX_BASIS_IS_SET;
     mYogaNode.setFlexBasisPercent(percent);
     return this;
@@ -521,46 +483,27 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode flexBasisAttr(@AttrRes int resId, @DimenRes int defaultResId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return flexBasisPx(mResourceResolver.resolveDimenOffsetAttr(resId, defaultResId));
   }
 
   @Override
   public InternalNode flexBasisAttr(@AttrRes int resId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return flexBasisAttr(resId, 0);
   }
 
   @Override
   public InternalNode flexBasisRes(@DimenRes int resId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return flexBasisPx(mResourceResolver.resolveDimenOffsetRes(resId));
   }
 
   @Override
   public InternalNode flexBasisDip(@Dimension(unit = DP) int flexBasis) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return flexBasisPx(mResourceResolver.dipsToPixels(flexBasis));
   }
 
   @Override
   public InternalNode importantForAccessibility(int importantForAccessibility) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_IMPORTANT_FOR_ACCESSIBILITY_IS_SET;
     mImportantForAccessibility = importantForAccessibility;
     return this;
@@ -568,10 +511,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode duplicateParentState(boolean duplicateParentState) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_DUPLICATE_PARENT_STATE_IS_SET;
     mDuplicateParentState = duplicateParentState;
     return this;
@@ -579,10 +519,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode marginPx(YogaEdge edge, @Px int margin) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_MARGIN_IS_SET;
     mYogaNode.setMargin(edge, margin);
     return this;
@@ -590,10 +527,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode marginPercent(YogaEdge edge, float percent) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_MARGIN_IS_SET;
     mYogaNode.setMarginPercent(edge, percent);
     return this;
@@ -601,10 +535,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode marginAuto(YogaEdge edge) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_MARGIN_IS_SET;
     mYogaNode.setMarginAuto(edge);
     return this;
@@ -615,10 +546,6 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
       YogaEdge edge,
       @AttrRes int resId,
       @DimenRes int defaultResId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return marginPx(edge, mResourceResolver.resolveDimenOffsetAttr(resId, defaultResId));
   }
 
@@ -626,28 +553,16 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   public InternalNode marginAttr(
       YogaEdge edge,
       @AttrRes int resId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return marginAttr(edge, resId, 0);
   }
 
   @Override
   public InternalNode marginRes(YogaEdge edge, @DimenRes int resId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return marginPx(edge, mResourceResolver.resolveDimenOffsetRes(resId));
   }
 
   @Override
   public InternalNode marginDip(YogaEdge edge, @Dimension(unit = DP) int margin) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return marginPx(edge, mResourceResolver.dipsToPixels(margin));
   }
 
@@ -662,10 +577,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode paddingPx(YogaEdge edge, @Px int padding) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_PADDING_IS_SET;
 
     if (mIsNestedTreeHolder) {
@@ -680,9 +592,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode paddingPercent(YogaEdge edge, float percent) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
+    checkIfBuilt();
 
     mPrivateFlags |= PFLAG_PADDING_IS_SET;
 
@@ -701,10 +611,6 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
       YogaEdge edge,
       @AttrRes int resId,
       @DimenRes int defaultResId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return paddingPx(edge, mResourceResolver.resolveDimenOffsetAttr(resId, defaultResId));
   }
 
@@ -712,37 +618,22 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   public InternalNode paddingAttr(
       YogaEdge edge,
       @AttrRes int resId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return paddingAttr(edge, resId, 0);
   }
 
   @Override
   public InternalNode paddingRes(YogaEdge edge, @DimenRes int resId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return paddingPx(edge, mResourceResolver.resolveDimenOffsetRes(resId));
   }
 
   @Override
   public InternalNode paddingDip(YogaEdge edge, @Dimension(unit = DP) int padding) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return paddingPx(edge, mResourceResolver.dipsToPixels(padding));
   }
 
   @Override
   public InternalNode borderWidthPx(YogaEdge edge, @Px int borderWidth) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_BORDER_WIDTH_IS_SET;
 
     if (mIsNestedTreeHolder) {
@@ -763,10 +654,6 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
       YogaEdge edge,
       @AttrRes int resId,
       @DimenRes int defaultResId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return borderWidthPx(edge, mResourceResolver.resolveDimenOffsetAttr(resId, defaultResId));
   }
 
@@ -774,19 +661,11 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   public InternalNode borderWidthAttr(
       YogaEdge edge,
       @AttrRes int resId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return borderWidthAttr(edge, resId, 0);
   }
 
   @Override
   public InternalNode borderWidthRes(YogaEdge edge, @DimenRes int resId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return borderWidthPx(edge, mResourceResolver.resolveDimenOffsetRes(resId));
   }
 
@@ -794,19 +673,12 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   public InternalNode borderWidthDip(
       YogaEdge edge,
       @Dimension(unit = DP) int borderWidth) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return borderWidthPx(edge, mResourceResolver.dipsToPixels(borderWidth));
   }
 
   @Override
   public Builder borderColor(@ColorInt int borderColor) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_BORDER_COLOR_IS_SET;
     mBorderColor = borderColor;
     return this;
@@ -814,10 +686,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode positionPx(YogaEdge edge, @Px int position) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_POSITION_IS_SET;
     mYogaNode.setPosition(edge, position);
     return this;
@@ -825,10 +694,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode positionPercent(YogaEdge edge, float percent) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_POSITION_IS_SET;
     mYogaNode.setPositionPercent(edge, percent);
     return this;
@@ -839,28 +705,16 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
       YogaEdge edge,
       @AttrRes int resId,
       @DimenRes int defaultResId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return positionPx(edge, mResourceResolver.resolveDimenOffsetAttr(resId, defaultResId));
   }
 
   @Override
   public InternalNode positionAttr(YogaEdge edge, @AttrRes int resId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return positionAttr(edge, resId, 0);
   }
 
   @Override
   public InternalNode positionRes(YogaEdge edge, @DimenRes int resId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return positionPx(edge, mResourceResolver.resolveDimenOffsetRes(resId));
   }
 
@@ -868,19 +722,12 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   public InternalNode positionDip(
       YogaEdge edge,
       @Dimension(unit = DP) int position) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return positionPx(edge, mResourceResolver.dipsToPixels(position));
   }
 
   @Override
   public InternalNode widthPx(@Px int width) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_WIDTH_IS_SET;
     mYogaNode.setWidth(width);
     return this;
@@ -894,10 +741,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode widthPercent(float percent) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_WIDTH_IS_SET;
     mYogaNode.setWidthPercent(percent);
     return this;
@@ -905,46 +749,27 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode widthRes(@DimenRes int resId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return widthPx(mResourceResolver.resolveDimenSizeRes(resId));
   }
 
   @Override
   public InternalNode widthAttr(@AttrRes int resId, @DimenRes int defaultResId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return widthPx(mResourceResolver.resolveDimenSizeAttr(resId, defaultResId));
   }
 
   @Override
   public InternalNode widthAttr(@AttrRes int resId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return widthAttr(resId, 0);
   }
 
   @Override
   public InternalNode widthDip(@Dimension(unit = DP) int width) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return widthPx(mResourceResolver.dipsToPixels(width));
   }
 
   @Override
   public InternalNode minWidthPx(@Px int minWidth) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_MIN_WIDTH_IS_SET;
     mYogaNode.setMinWidth(minWidth);
     return this;
@@ -952,10 +777,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode minWidthPercent(float percent) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_MIN_WIDTH_IS_SET;
     mYogaNode.setMinWidthPercent(percent);
     return this;
@@ -963,46 +785,27 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode minWidthAttr(@AttrRes int resId, @DimenRes int defaultResId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return minWidthPx(mResourceResolver.resolveDimenSizeAttr(resId, defaultResId));
   }
 
   @Override
   public InternalNode minWidthAttr(@AttrRes int resId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return minWidthAttr(resId, 0);
   }
 
   @Override
   public InternalNode minWidthRes(@DimenRes int resId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return minWidthPx(mResourceResolver.resolveDimenSizeRes(resId));
   }
 
   @Override
   public InternalNode minWidthDip(@Dimension(unit = DP) int minWidth) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return minWidthPx(mResourceResolver.dipsToPixels(minWidth));
   }
 
   @Override
   public InternalNode maxWidthPx(@Px int maxWidth) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_MAX_WIDTH_IS_SET;
     mYogaNode.setMaxWidth(maxWidth);
     return this;
@@ -1010,10 +813,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode maxWidthPercent(float percent) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_MAX_WIDTH_IS_SET;
     mYogaNode.setMaxWidthPercent(percent);
     return this;
@@ -1021,46 +821,27 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode maxWidthAttr(@AttrRes int resId, @DimenRes int defaultResId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return maxWidthPx(mResourceResolver.resolveDimenSizeAttr(resId, defaultResId));
   }
 
   @Override
   public InternalNode maxWidthAttr(@AttrRes int resId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return maxWidthAttr(resId, 0);
   }
 
   @Override
   public InternalNode maxWidthRes(@DimenRes int resId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return maxWidthPx(mResourceResolver.resolveDimenSizeRes(resId));
   }
 
   @Override
   public InternalNode maxWidthDip(@Dimension(unit = DP) int maxWidth) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return maxWidthPx(mResourceResolver.dipsToPixels(maxWidth));
   }
 
   @Override
   public InternalNode heightPx(@Px int height) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_HEIGHT_IS_SET;
     mYogaNode.setHeight(height);
     return this;
@@ -1068,20 +849,13 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   // Used by stetho to re-set auto value
   InternalNode heightAuto() {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     mYogaNode.setHeightAuto();
     return this;
   }
 
   @Override
   public InternalNode heightPercent(float percent) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_HEIGHT_IS_SET;
     mYogaNode.setHeightPercent(percent);
     return this;
@@ -1089,46 +863,27 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode heightRes(@DimenRes int resId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return heightPx(mResourceResolver.resolveDimenSizeRes(resId));
   }
 
   @Override
   public InternalNode heightAttr(@AttrRes int resId, @DimenRes int defaultResId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return heightPx(mResourceResolver.resolveDimenSizeAttr(resId, defaultResId));
   }
 
   @Override
   public InternalNode heightAttr(@AttrRes int resId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return heightAttr(resId, 0);
   }
 
   @Override
   public InternalNode heightDip(@Dimension(unit = DP) int height) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return heightPx(mResourceResolver.dipsToPixels(height));
   }
 
   @Override
   public InternalNode minHeightPx(@Px int minHeight) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_MIN_HEIGHT_IS_SET;
     mYogaNode.setMinHeight(minHeight);
     return this;
@@ -1136,10 +891,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode minHeightPercent(float percent) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_MIN_HEIGHT_IS_SET;
     mYogaNode.setMinHeightPercent(percent);
     return this;
@@ -1147,46 +899,27 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode minHeightAttr(@AttrRes int resId, @DimenRes int defaultResId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return minHeightPx(mResourceResolver.resolveDimenSizeAttr(resId, defaultResId));
   }
 
   @Override
   public InternalNode minHeightAttr(@AttrRes int resId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return minHeightAttr(resId, 0);
   }
 
   @Override
   public InternalNode minHeightRes(@DimenRes int resId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return minHeightPx(mResourceResolver.resolveDimenSizeRes(resId));
   }
 
   @Override
   public InternalNode minHeightDip(@Dimension(unit = DP) int minHeight) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return minHeightPx(mResourceResolver.dipsToPixels(minHeight));
   }
 
   @Override
   public InternalNode maxHeightPx(@Px int maxHeight) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_MAX_HEIGHT_IS_SET;
     mYogaNode.setMaxHeight(maxHeight);
     return this;
@@ -1194,10 +927,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode maxHeightPercent(float percent) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_MAX_HEIGHT_IS_SET;
     mYogaNode.setMaxHeightPercent(percent);
     return this;
@@ -1205,46 +935,27 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode maxHeightAttr(@AttrRes int resId, @DimenRes int defaultResId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return maxHeightPx(mResourceResolver.resolveDimenSizeAttr(resId, defaultResId));
   }
 
   @Override
   public InternalNode maxHeightAttr(@AttrRes int resId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return maxHeightAttr(resId, 0);
   }
 
   @Override
   public InternalNode maxHeightRes(@DimenRes int resId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return maxHeightPx(mResourceResolver.resolveDimenSizeRes(resId));
   }
 
   @Override
   public InternalNode maxHeightDip(@Dimension(unit = DP) int maxHeight) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return maxHeightPx(mResourceResolver.dipsToPixels(maxHeight));
   }
 
   @Override
   public InternalNode aspectRatio(float aspectRatio) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_ASPECT_RATIO_IS_SET;
     if (mYogaNode instanceof YogaNode) {
       mYogaNode.setAspectRatio(aspectRatio);
@@ -1308,10 +1019,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode touchExpansionPx(YogaEdge edge, @Px int touchExpansion) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     if (mTouchExpansion == null) {
       mTouchExpansion = ComponentsPools.acquireEdges();
     }
@@ -1327,10 +1035,6 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
       YogaEdge edge,
       @AttrRes int resId,
       @DimenRes int defaultResId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return touchExpansionPx(
         edge,
         mResourceResolver.resolveDimenOffsetAttr(resId, defaultResId));
@@ -1340,19 +1044,11 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   public InternalNode touchExpansionAttr(
       YogaEdge edge,
       @AttrRes int resId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return touchExpansionAttr(edge, resId, 0);
   }
 
   @Override
   public InternalNode touchExpansionRes(YogaEdge edge, @DimenRes int resId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return touchExpansionPx(edge, mResourceResolver.resolveDimenOffsetRes(resId));
   }
 
@@ -1360,19 +1056,12 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   public InternalNode touchExpansionDip(
       YogaEdge edge,
       @Dimension(unit = DP) int touchExpansion) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return touchExpansionPx(edge, mResourceResolver.dipsToPixels(touchExpansion));
   }
 
   @Override
   public InternalNode child(ComponentLayout child) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     if (child != null && child != NULL_LAYOUT) {
       addChildAt((InternalNode) child, mYogaNode.getChildCount());
     }
@@ -1381,10 +1070,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode child(ComponentLayout.Builder child) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     if (child != null && child != NULL_LAYOUT) {
       child(child.build());
     }
@@ -1393,10 +1079,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode child(Component<?> child) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     if (child != null) {
       child(Layout.create(mComponentContext, child).flexShrink(0));
     }
@@ -1405,10 +1088,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode child(Component.Builder<?> child) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     if (child != null) {
       child(child.build());
     }
@@ -1417,10 +1097,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode background(Reference<? extends Drawable> background) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_BACKGROUND_IS_SET;
     mBackground = background;
     setPaddingFromDrawableReference(background);
@@ -1429,45 +1106,27 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode background(Reference.Builder<? extends Drawable> builder) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return background(builder.build());
   }
 
   @Override
   public InternalNode background(Drawable background) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return background(DrawableReference.create().drawable(background));
   }
 
   @Override
   public InternalNode backgroundAttr(@AttrRes int resId, @DrawableRes int defaultResId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return backgroundRes(mResourceResolver.resolveResIdAttr(resId, defaultResId));
   }
 
   @Override
   public InternalNode backgroundAttr(@AttrRes int resId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return backgroundAttr(resId, 0);
   }
 
   @Override
   public InternalNode backgroundRes(@DrawableRes int resId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
+    checkIfBuilt();
 
     if (resId == 0) {
       return background((Reference<Drawable>) null);
@@ -1481,10 +1140,6 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode backgroundColor(@ColorInt int backgroundColor) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return background(
         ColorDrawableReference.create(mComponentContext)
             .color(backgroundColor)
@@ -1493,9 +1148,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode foreground(Drawable foreground) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
+    checkIfBuilt();
 
     mPrivateFlags |= PFLAG_FOREGROUND_IS_SET;
     mForeground = foreground;
@@ -1504,27 +1157,17 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode foregroundAttr(@AttrRes int resId, @DrawableRes int defaultResId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return foregroundRes(mResourceResolver.resolveResIdAttr(resId, defaultResId));
   }
 
   @Override
   public InternalNode foregroundAttr(@AttrRes int resId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return foregroundAttr(resId, 0);
   }
 
   @Override
   public InternalNode foregroundRes(@DrawableRes int resId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
+    checkIfBuilt();
 
     if (resId == 0) {
       return foreground(null);
@@ -1535,19 +1178,12 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode foregroundColor(@ColorInt int foregroundColor) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return foreground(new ColorDrawable(foregroundColor));
   }
 
   @Override
   public InternalNode wrapInView() {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mForceViewWrapping = true;
     return this;
   }
@@ -1558,50 +1194,35 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode clickHandler(EventHandler clickHandler) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     getOrCreateNodeInfo().setClickHandler(clickHandler);
     return this;
   }
 
   @Override
   public InternalNode longClickHandler(EventHandler longClickHandler) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     getOrCreateNodeInfo().setLongClickHandler(longClickHandler);
     return this;
   }
 
   @Override
   public InternalNode touchHandler(EventHandler touchHandler) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     getOrCreateNodeInfo().setTouchHandler(touchHandler);
     return this;
   }
 
   @Override
   public ContainerBuilder focusable(boolean isFocusable) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     getOrCreateNodeInfo().setFocusable(isFocusable);
     return this;
   }
 
   @Override
   public InternalNode visibleHandler(EventHandler visibleHandler) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_VISIBLE_HANDLER_IS_SET;
     mVisibleHandler = visibleHandler;
     return this;
@@ -1613,10 +1234,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode focusedHandler(EventHandler focusedHandler) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_FOCUSED_HANDLER_IS_SET;
     mFocusedHandler = focusedHandler;
     return this;
@@ -1628,10 +1246,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode unfocusedHandler(EventHandler unfocusedHandler) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_UNFOCUSED_HANDLER_IS_SET;
     mUnfocusedHandler = unfocusedHandler;
     return this;
@@ -1643,10 +1258,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode fullImpressionHandler(EventHandler fullImpressionHandler) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_FULL_IMPRESSION_HANDLER_IS_SET;
     mFullImpressionHandler = fullImpressionHandler;
     return this;
@@ -1658,10 +1270,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode invisibleHandler(EventHandler invisibleHandler) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mPrivateFlags |= PFLAG_INVISIBLE_HANDLER_IS_SET;
     mInvisibleHandler = invisibleHandler;
     return this;
@@ -1673,38 +1282,24 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode contentDescription(CharSequence contentDescription) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     getOrCreateNodeInfo().setContentDescription(contentDescription);
     return this;
   }
 
   @Override
   public InternalNode contentDescription(@StringRes int stringId) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return contentDescription(mResources.getString(stringId));
   }
 
   @Override
   public InternalNode contentDescription(@StringRes int stringId, Object... formatArgs) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return contentDescription(mResources.getString(stringId, formatArgs));
   }
 
   @Override
   public InternalNode viewTag(Object viewTag) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     getOrCreateNodeInfo().setViewTag(viewTag);
     return this;
   }
@@ -1717,10 +1312,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode testKey(String testKey) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     mTestKey = testKey;
     return this;
   }
@@ -1729,24 +1321,19 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   public InternalNode dispatchPopulateAccessibilityEventHandler(
       EventHandler<DispatchPopulateAccessibilityEventEvent>
           dispatchPopulateAccessibilityEventHandler) {
+    checkIfBuilt();
     getOrCreateNodeInfo().setDispatchPopulateAccessibilityEventHandler(
         dispatchPopulateAccessibilityEventHandler);
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     return this;
   }
 
   @Override
   public InternalNode onInitializeAccessibilityEventHandler(
       EventHandler<OnInitializeAccessibilityEventEvent> onInitializeAccessibilityEventHandler) {
+    checkIfBuilt();
     getOrCreateNodeInfo().setOnInitializeAccessibilityEventHandler(
         onInitializeAccessibilityEventHandler);
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
     return this;
   }
 
@@ -1754,10 +1341,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   public InternalNode onInitializeAccessibilityNodeInfoHandler(
       EventHandler<OnInitializeAccessibilityNodeInfoEvent>
           onInitializeAccessibilityNodeInfoHandler) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     getOrCreateNodeInfo().setOnInitializeAccessibilityNodeInfoHandler(
         onInitializeAccessibilityNodeInfoHandler);
     return this;
@@ -1766,10 +1350,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   @Override
   public InternalNode onPopulateAccessibilityEventHandler(
       EventHandler<OnPopulateAccessibilityEventEvent> onPopulateAccessibilityEventHandler) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     getOrCreateNodeInfo().setOnPopulateAccessibilityEventHandler(
         onPopulateAccessibilityEventHandler);
     return this;
@@ -1778,10 +1359,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   @Override
   public InternalNode onRequestSendAccessibilityEventHandler(
       EventHandler<OnRequestSendAccessibilityEventEvent> onRequestSendAccessibilityEventHandler) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     getOrCreateNodeInfo().setOnRequestSendAccessibilityEventHandler(
         onRequestSendAccessibilityEventHandler);
     return this;
@@ -1790,10 +1368,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   @Override
   public InternalNode performAccessibilityActionHandler(
       EventHandler<PerformAccessibilityActionEvent> performAccessibilityActionHandler) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     getOrCreateNodeInfo().setPerformAccessibilityActionHandler(performAccessibilityActionHandler);
     return this;
   }
@@ -1801,10 +1376,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   @Override
   public InternalNode sendAccessibilityEventHandler(
       EventHandler<SendAccessibilityEventEvent> sendAccessibilityEventHandler) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     getOrCreateNodeInfo().setSendAccessibilityEventHandler(sendAccessibilityEventHandler);
     return this;
   }
@@ -1812,10 +1384,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   @Override
   public InternalNode sendAccessibilityEventUncheckedHandler(
       EventHandler<SendAccessibilityEventUncheckedEvent> sendAccessibilityEventUncheckedHandler) {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+    checkIfBuilt();
     getOrCreateNodeInfo().setSendAccessibilityEventUncheckedHandler(
         sendAccessibilityEventUncheckedHandler);
     return this;
@@ -1953,12 +1522,16 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     return (InternalNode) mYogaNode.removeChildAt(index).getData();
   }
 
+
+  private void checkIfBuilt() {
+    if (mIsBuilt) {
+      throw new UnsupportedOperationException("Attempt to mutate object after creation.");
+    }
+  }
+
   @Override
   public ComponentLayout build() {
-    if (mIsBuilt) {
-      throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
-    }
-
+   checkIfBuilt();
     mIsBuilt = true;
     return this;
   }

--- a/litho-core/src/main/java/com/facebook/litho/InternalNode.java
+++ b/litho-core/src/main/java/com/facebook/litho/InternalNode.java
@@ -247,6 +247,70 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     return (int) mResolvedHeight;
   }
 
+  private class InternalLayoutFrozen implements ComponentLayout {
+
+    private int x, y, width, height;
+    private int paddingTop, paddingRight, paddingBottom, paddingLeft;
+    private YogaDirection resolvedLayoutDirection;
+
+    InternalLayoutFrozen(InternalNode node) {
+      this.x = node.getX();
+      this.y = node.getY();
+      this.height = node.getHeight();
+      this.width = node.getWidth();
+      this.paddingBottom = node.getPaddingBottom();
+      this.paddingTop = node.getPaddingTop();
+      this.paddingLeft = node.getPaddingLeft();
+      this.paddingRight = node.getPaddingRight();
+      this.resolvedLayoutDirection = node.getResolvedLayoutDirection();
+    }
+
+    @Override
+    public int getX() {
+      return x;
+    }
+
+    @Override
+    public int getY() {
+      return y;
+    }
+
+    @Override
+    public int getWidth() {
+      return width;
+    }
+
+    @Override
+    public int getHeight() {
+      return height;
+    }
+
+    @Override
+    public int getPaddingTop() {
+      return paddingTop;
+    }
+
+    @Override
+    public int getPaddingRight() {
+      return paddingRight;
+    }
+
+    @Override
+    public int getPaddingBottom() {
+      return paddingBottom;
+    }
+
+    @Override
+    public int getPaddingLeft() {
+      return paddingLeft;
+    }
+
+    @Override
+    public YogaDirection getResolvedLayoutDirection() {
+      return resolvedLayoutDirection;
+    }
+  }
+
   @Px
   @Override
   public int getPaddingLeft() {
@@ -1448,7 +1512,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public ComponentLayout build() {
-    return this;
+    return new InternalLayoutFrozen(this);
   }
 
   private float resolveHorizontalEdges(Edges spacing, YogaEdge edge) {

--- a/litho-core/src/main/java/com/facebook/litho/InternalNode.java
+++ b/litho-core/src/main/java/com/facebook/litho/InternalNode.java
@@ -188,7 +188,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   private boolean mCachedMeasuresValid;
   private TreeProps mPendingTreeProps;
 
-  private boolean mIsBuilt;
+  private boolean mIsMutable;
 
   void init(YogaNode yogaNode, ComponentContext componentContext, Resources resources) {
     yogaNode.setData(this);
@@ -208,7 +208,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
         mComponentContext,
         componentContext.getResourceCache());
 
-    mIsBuilt = false;
+    mIsMutable = false;
   }
 
   @Px
@@ -380,7 +380,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode layoutDirection(YogaDirection direction) {
-	checkIfBuilt();
+	  checkIfMutable();
+
     mPrivateFlags |= PFLAG_LAYOUT_DIRECTION_IS_SET;
     mYogaNode.setDirection(direction);
     return this;
@@ -393,35 +394,40 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode wrap(YogaWrap wrap) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mYogaNode.setWrap(wrap);
     return this;
   }
 
   @Override
   public InternalNode justifyContent(YogaJustify justifyContent) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mYogaNode.setJustifyContent(justifyContent);
     return this;
   }
 
   @Override
   public InternalNode alignItems(YogaAlign alignItems) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mYogaNode.setAlignItems(alignItems);
     return this;
   }
 
   @Override
   public InternalNode alignContent(YogaAlign alignContent) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mYogaNode.setAlignContent(alignContent);
     return this;
   }
 
   @Override
   public InternalNode alignSelf(YogaAlign alignSelf) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_ALIGN_SELF_IS_SET;
     mYogaNode.setAlignSelf(alignSelf);
     return this;
@@ -429,7 +435,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode positionType(YogaPositionType positionType) {
-	checkIfBuilt();
+	  checkIfMutable();
+
     mPrivateFlags |= PFLAG_POSITION_TYPE_IS_SET;
     mYogaNode.setPositionType(positionType);
     return this;
@@ -437,7 +444,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode flex(float flex) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_FLEX_IS_SET;
     mYogaNode.setFlex(flex);
     return this;
@@ -445,7 +453,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode flexGrow(float flexGrow) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_FLEX_GROW_IS_SET;
     mYogaNode.setFlexGrow(flexGrow);
     return this;
@@ -453,7 +462,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode flexShrink(float flexShrink) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_FLEX_SHRINK_IS_SET;
     mYogaNode.setFlexShrink(flexShrink);
     return this;
@@ -461,7 +471,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode flexBasisPx(@Px int flexBasis) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_FLEX_BASIS_IS_SET;
     mYogaNode.setFlexBasis(flexBasis);
     return this;
@@ -475,7 +486,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode flexBasisPercent(float percent) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_FLEX_BASIS_IS_SET;
     mYogaNode.setFlexBasisPercent(percent);
     return this;
@@ -503,7 +515,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode importantForAccessibility(int importantForAccessibility) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_IMPORTANT_FOR_ACCESSIBILITY_IS_SET;
     mImportantForAccessibility = importantForAccessibility;
     return this;
@@ -511,7 +524,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode duplicateParentState(boolean duplicateParentState) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_DUPLICATE_PARENT_STATE_IS_SET;
     mDuplicateParentState = duplicateParentState;
     return this;
@@ -519,7 +533,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode marginPx(YogaEdge edge, @Px int margin) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_MARGIN_IS_SET;
     mYogaNode.setMargin(edge, margin);
     return this;
@@ -527,7 +542,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode marginPercent(YogaEdge edge, float percent) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_MARGIN_IS_SET;
     mYogaNode.setMarginPercent(edge, percent);
     return this;
@@ -535,7 +551,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode marginAuto(YogaEdge edge) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_MARGIN_IS_SET;
     mYogaNode.setMarginAuto(edge);
     return this;
@@ -577,7 +594,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode paddingPx(YogaEdge edge, @Px int padding) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_PADDING_IS_SET;
 
     if (mIsNestedTreeHolder) {
@@ -592,7 +610,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode paddingPercent(YogaEdge edge, float percent) {
-    checkIfBuilt();
+    checkIfMutable();
 
     mPrivateFlags |= PFLAG_PADDING_IS_SET;
 
@@ -633,7 +651,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode borderWidthPx(YogaEdge edge, @Px int borderWidth) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_BORDER_WIDTH_IS_SET;
 
     if (mIsNestedTreeHolder) {
@@ -678,7 +697,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public Builder borderColor(@ColorInt int borderColor) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_BORDER_COLOR_IS_SET;
     mBorderColor = borderColor;
     return this;
@@ -686,7 +706,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode positionPx(YogaEdge edge, @Px int position) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_POSITION_IS_SET;
     mYogaNode.setPosition(edge, position);
     return this;
@@ -694,7 +715,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode positionPercent(YogaEdge edge, float percent) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_POSITION_IS_SET;
     mYogaNode.setPositionPercent(edge, percent);
     return this;
@@ -727,7 +749,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode widthPx(@Px int width) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_WIDTH_IS_SET;
     mYogaNode.setWidth(width);
     return this;
@@ -741,7 +764,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode widthPercent(float percent) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_WIDTH_IS_SET;
     mYogaNode.setWidthPercent(percent);
     return this;
@@ -769,7 +793,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode minWidthPx(@Px int minWidth) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_MIN_WIDTH_IS_SET;
     mYogaNode.setMinWidth(minWidth);
     return this;
@@ -777,7 +802,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode minWidthPercent(float percent) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_MIN_WIDTH_IS_SET;
     mYogaNode.setMinWidthPercent(percent);
     return this;
@@ -805,7 +831,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode maxWidthPx(@Px int maxWidth) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_MAX_WIDTH_IS_SET;
     mYogaNode.setMaxWidth(maxWidth);
     return this;
@@ -813,7 +840,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode maxWidthPercent(float percent) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_MAX_WIDTH_IS_SET;
     mYogaNode.setMaxWidthPercent(percent);
     return this;
@@ -841,7 +869,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode heightPx(@Px int height) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_HEIGHT_IS_SET;
     mYogaNode.setHeight(height);
     return this;
@@ -855,7 +884,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode heightPercent(float percent) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_HEIGHT_IS_SET;
     mYogaNode.setHeightPercent(percent);
     return this;
@@ -883,7 +913,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode minHeightPx(@Px int minHeight) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_MIN_HEIGHT_IS_SET;
     mYogaNode.setMinHeight(minHeight);
     return this;
@@ -891,7 +922,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode minHeightPercent(float percent) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_MIN_HEIGHT_IS_SET;
     mYogaNode.setMinHeightPercent(percent);
     return this;
@@ -919,7 +951,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode maxHeightPx(@Px int maxHeight) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_MAX_HEIGHT_IS_SET;
     mYogaNode.setMaxHeight(maxHeight);
     return this;
@@ -927,7 +960,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode maxHeightPercent(float percent) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_MAX_HEIGHT_IS_SET;
     mYogaNode.setMaxHeightPercent(percent);
     return this;
@@ -955,7 +989,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode aspectRatio(float aspectRatio) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_ASPECT_RATIO_IS_SET;
     if (mYogaNode instanceof YogaNode) {
       mYogaNode.setAspectRatio(aspectRatio);
@@ -1019,7 +1054,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode touchExpansionPx(YogaEdge edge, @Px int touchExpansion) {
-    checkIfBuilt();
+    checkIfMutable();
+
     if (mTouchExpansion == null) {
       mTouchExpansion = ComponentsPools.acquireEdges();
     }
@@ -1061,7 +1097,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode child(ComponentLayout child) {
-    checkIfBuilt();
+    checkIfMutable();
+
     if (child != null && child != NULL_LAYOUT) {
       addChildAt((InternalNode) child, mYogaNode.getChildCount());
     }
@@ -1070,7 +1107,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode child(ComponentLayout.Builder child) {
-    checkIfBuilt();
+    checkIfMutable();
+
     if (child != null && child != NULL_LAYOUT) {
       child(child.build());
     }
@@ -1079,7 +1117,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode child(Component<?> child) {
-    checkIfBuilt();
+    checkIfMutable();
+
     if (child != null) {
       child(Layout.create(mComponentContext, child).flexShrink(0));
     }
@@ -1088,7 +1127,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode child(Component.Builder<?> child) {
-    checkIfBuilt();
+    checkIfMutable();
+
     if (child != null) {
       child(child.build());
     }
@@ -1097,7 +1137,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode background(Reference<? extends Drawable> background) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_BACKGROUND_IS_SET;
     mBackground = background;
     setPaddingFromDrawableReference(background);
@@ -1126,7 +1167,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode backgroundRes(@DrawableRes int resId) {
-    checkIfBuilt();
+    checkIfMutable();
 
     if (resId == 0) {
       return background((Reference<Drawable>) null);
@@ -1148,7 +1189,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode foreground(Drawable foreground) {
-    checkIfBuilt();
+    checkIfMutable();
 
     mPrivateFlags |= PFLAG_FOREGROUND_IS_SET;
     mForeground = foreground;
@@ -1167,7 +1208,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode foregroundRes(@DrawableRes int resId) {
-    checkIfBuilt();
+    checkIfMutable();
 
     if (resId == 0) {
       return foreground(null);
@@ -1183,7 +1224,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode wrapInView() {
-    checkIfBuilt();
+    checkIfMutable();
+
     mForceViewWrapping = true;
     return this;
   }
@@ -1194,35 +1236,40 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode clickHandler(EventHandler clickHandler) {
-    checkIfBuilt();
+    checkIfMutable();
+
     getOrCreateNodeInfo().setClickHandler(clickHandler);
     return this;
   }
 
   @Override
   public InternalNode longClickHandler(EventHandler longClickHandler) {
-    checkIfBuilt();
+    checkIfMutable();
+
     getOrCreateNodeInfo().setLongClickHandler(longClickHandler);
     return this;
   }
 
   @Override
   public InternalNode touchHandler(EventHandler touchHandler) {
-    checkIfBuilt();
+    checkIfMutable();
+
     getOrCreateNodeInfo().setTouchHandler(touchHandler);
     return this;
   }
 
   @Override
   public ContainerBuilder focusable(boolean isFocusable) {
-    checkIfBuilt();
+    checkIfMutable();
+
     getOrCreateNodeInfo().setFocusable(isFocusable);
     return this;
   }
 
   @Override
   public InternalNode visibleHandler(EventHandler visibleHandler) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_VISIBLE_HANDLER_IS_SET;
     mVisibleHandler = visibleHandler;
     return this;
@@ -1234,7 +1281,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode focusedHandler(EventHandler focusedHandler) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_FOCUSED_HANDLER_IS_SET;
     mFocusedHandler = focusedHandler;
     return this;
@@ -1246,7 +1294,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode unfocusedHandler(EventHandler unfocusedHandler) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_UNFOCUSED_HANDLER_IS_SET;
     mUnfocusedHandler = unfocusedHandler;
     return this;
@@ -1258,7 +1307,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode fullImpressionHandler(EventHandler fullImpressionHandler) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_FULL_IMPRESSION_HANDLER_IS_SET;
     mFullImpressionHandler = fullImpressionHandler;
     return this;
@@ -1270,7 +1320,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode invisibleHandler(EventHandler invisibleHandler) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mPrivateFlags |= PFLAG_INVISIBLE_HANDLER_IS_SET;
     mInvisibleHandler = invisibleHandler;
     return this;
@@ -1282,7 +1333,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode contentDescription(CharSequence contentDescription) {
-    checkIfBuilt();
+    checkIfMutable();
+
     getOrCreateNodeInfo().setContentDescription(contentDescription);
     return this;
   }
@@ -1299,7 +1351,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode viewTag(Object viewTag) {
-    checkIfBuilt();
+    checkIfMutable();
+
     getOrCreateNodeInfo().setViewTag(viewTag);
     return this;
   }
@@ -1312,7 +1365,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
 
   @Override
   public InternalNode testKey(String testKey) {
-    checkIfBuilt();
+    checkIfMutable();
+
     mTestKey = testKey;
     return this;
   }
@@ -1321,17 +1375,18 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   public InternalNode dispatchPopulateAccessibilityEventHandler(
       EventHandler<DispatchPopulateAccessibilityEventEvent>
           dispatchPopulateAccessibilityEventHandler) {
-    checkIfBuilt();
+    checkIfMutable();
+
     getOrCreateNodeInfo().setDispatchPopulateAccessibilityEventHandler(
         dispatchPopulateAccessibilityEventHandler);
-    checkIfBuilt();
     return this;
   }
 
   @Override
   public InternalNode onInitializeAccessibilityEventHandler(
       EventHandler<OnInitializeAccessibilityEventEvent> onInitializeAccessibilityEventHandler) {
-    checkIfBuilt();
+    checkIfMutable();
+
     getOrCreateNodeInfo().setOnInitializeAccessibilityEventHandler(
         onInitializeAccessibilityEventHandler);
     return this;
@@ -1341,7 +1396,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   public InternalNode onInitializeAccessibilityNodeInfoHandler(
       EventHandler<OnInitializeAccessibilityNodeInfoEvent>
           onInitializeAccessibilityNodeInfoHandler) {
-    checkIfBuilt();
+    checkIfMutable();
+
     getOrCreateNodeInfo().setOnInitializeAccessibilityNodeInfoHandler(
         onInitializeAccessibilityNodeInfoHandler);
     return this;
@@ -1350,7 +1406,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   @Override
   public InternalNode onPopulateAccessibilityEventHandler(
       EventHandler<OnPopulateAccessibilityEventEvent> onPopulateAccessibilityEventHandler) {
-    checkIfBuilt();
+    checkIfMutable();
+
     getOrCreateNodeInfo().setOnPopulateAccessibilityEventHandler(
         onPopulateAccessibilityEventHandler);
     return this;
@@ -1359,7 +1416,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   @Override
   public InternalNode onRequestSendAccessibilityEventHandler(
       EventHandler<OnRequestSendAccessibilityEventEvent> onRequestSendAccessibilityEventHandler) {
-    checkIfBuilt();
+    checkIfMutable();
+
     getOrCreateNodeInfo().setOnRequestSendAccessibilityEventHandler(
         onRequestSendAccessibilityEventHandler);
     return this;
@@ -1368,7 +1426,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   @Override
   public InternalNode performAccessibilityActionHandler(
       EventHandler<PerformAccessibilityActionEvent> performAccessibilityActionHandler) {
-    checkIfBuilt();
+    checkIfMutable();
+
     getOrCreateNodeInfo().setPerformAccessibilityActionHandler(performAccessibilityActionHandler);
     return this;
   }
@@ -1376,7 +1435,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   @Override
   public InternalNode sendAccessibilityEventHandler(
       EventHandler<SendAccessibilityEventEvent> sendAccessibilityEventHandler) {
-    checkIfBuilt();
+    checkIfMutable();
+
     getOrCreateNodeInfo().setSendAccessibilityEventHandler(sendAccessibilityEventHandler);
     return this;
   }
@@ -1384,7 +1444,8 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
   @Override
   public InternalNode sendAccessibilityEventUncheckedHandler(
       EventHandler<SendAccessibilityEventUncheckedEvent> sendAccessibilityEventUncheckedHandler) {
-    checkIfBuilt();
+    checkIfMutable();
+
     getOrCreateNodeInfo().setSendAccessibilityEventUncheckedHandler(
         sendAccessibilityEventUncheckedHandler);
     return this;
@@ -1522,17 +1583,17 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     return (InternalNode) mYogaNode.removeChildAt(index).getData();
   }
 
-
-  private void checkIfBuilt() {
-    if (mIsBuilt) {
+  private void checkIfMutable() {
+    if (mIsMutable) {
       throw new UnsupportedOperationException("Attempt to mutate object after creation.");
     }
   }
 
   @Override
   public ComponentLayout build() {
-   checkIfBuilt();
-    mIsBuilt = true;
+    checkIfMutable();
+
+    mIsMutable = true;
     return this;
   }
 

--- a/litho-core/src/main/java/com/facebook/litho/InternalNode.java
+++ b/litho-core/src/main/java/com/facebook/litho/InternalNode.java
@@ -385,6 +385,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     mPrivateFlags |= PFLAG_LAYOUT_DIRECTION_IS_SET;
     mYogaNode.setDirection(direction);
     return this;
@@ -400,6 +401,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     mYogaNode.setWrap(wrap);
     return this;
   }
@@ -409,6 +411,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     mYogaNode.setJustifyContent(justifyContent);
     return this;
   }
@@ -418,6 +421,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     mYogaNode.setAlignItems(alignItems);
     return this;
   }
@@ -427,6 +431,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     mYogaNode.setAlignContent(alignContent);
     return this;
   }
@@ -436,6 +441,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     mPrivateFlags |= PFLAG_ALIGN_SELF_IS_SET;
     mYogaNode.setAlignSelf(alignSelf);
     return this;
@@ -446,6 +452,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     mPrivateFlags |= PFLAG_POSITION_TYPE_IS_SET;
     mYogaNode.setPositionType(positionType);
     return this;
@@ -456,6 +463,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     mPrivateFlags |= PFLAG_FLEX_IS_SET;
     mYogaNode.setFlex(flex);
     return this;
@@ -466,6 +474,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     mPrivateFlags |= PFLAG_FLEX_GROW_IS_SET;
     mYogaNode.setFlexGrow(flexGrow);
     return this;
@@ -476,6 +485,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     mPrivateFlags |= PFLAG_FLEX_SHRINK_IS_SET;
     mYogaNode.setFlexShrink(flexShrink);
     return this;
@@ -486,6 +496,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     mPrivateFlags |= PFLAG_FLEX_BASIS_IS_SET;
     mYogaNode.setFlexBasis(flexBasis);
     return this;
@@ -502,6 +513,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     mPrivateFlags |= PFLAG_FLEX_BASIS_IS_SET;
     mYogaNode.setFlexBasisPercent(percent);
     return this;
@@ -512,6 +524,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     return flexBasisPx(mResourceResolver.resolveDimenOffsetAttr(resId, defaultResId));
   }
 
@@ -520,6 +533,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     return flexBasisAttr(resId, 0);
   }
 
@@ -528,6 +542,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     return flexBasisPx(mResourceResolver.resolveDimenOffsetRes(resId));
   }
 
@@ -536,6 +551,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     return flexBasisPx(mResourceResolver.dipsToPixels(flexBasis));
   }
 
@@ -544,6 +560,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     mPrivateFlags |= PFLAG_IMPORTANT_FOR_ACCESSIBILITY_IS_SET;
     mImportantForAccessibility = importantForAccessibility;
     return this;
@@ -554,6 +571,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     mPrivateFlags |= PFLAG_DUPLICATE_PARENT_STATE_IS_SET;
     mDuplicateParentState = duplicateParentState;
     return this;
@@ -564,6 +582,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     mPrivateFlags |= PFLAG_MARGIN_IS_SET;
     mYogaNode.setMargin(edge, margin);
     return this;
@@ -574,6 +593,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     mPrivateFlags |= PFLAG_MARGIN_IS_SET;
     mYogaNode.setMarginPercent(edge, percent);
     return this;
@@ -584,6 +604,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     mPrivateFlags |= PFLAG_MARGIN_IS_SET;
     mYogaNode.setMarginAuto(edge);
     return this;
@@ -597,6 +618,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     return marginPx(edge, mResourceResolver.resolveDimenOffsetAttr(resId, defaultResId));
   }
 
@@ -607,6 +629,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     return marginAttr(edge, resId, 0);
   }
 
@@ -615,6 +638,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     return marginPx(edge, mResourceResolver.resolveDimenOffsetRes(resId));
   }
 
@@ -623,6 +647,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     return marginPx(edge, mResourceResolver.dipsToPixels(margin));
   }
 
@@ -631,6 +656,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mNestedTreePadding == null) {
       mNestedTreePadding = ComponentsPools.acquireEdges();
     }
+
     return mNestedTreePadding;
   }
 
@@ -639,6 +665,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     mPrivateFlags |= PFLAG_PADDING_IS_SET;
 
     if (mIsNestedTreeHolder) {
@@ -656,6 +683,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     mPrivateFlags |= PFLAG_PADDING_IS_SET;
 
     if (mIsNestedTreeHolder) {
@@ -676,6 +704,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     return paddingPx(edge, mResourceResolver.resolveDimenOffsetAttr(resId, defaultResId));
   }
 
@@ -686,6 +715,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     return paddingAttr(edge, resId, 0);
   }
 
@@ -694,6 +724,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     return paddingPx(edge, mResourceResolver.resolveDimenOffsetRes(resId));
   }
 
@@ -702,6 +733,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     return paddingPx(edge, mResourceResolver.dipsToPixels(padding));
   }
 
@@ -710,6 +742,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     mPrivateFlags |= PFLAG_BORDER_WIDTH_IS_SET;
 
     if (mIsNestedTreeHolder) {
@@ -733,6 +766,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     return borderWidthPx(edge, mResourceResolver.resolveDimenOffsetAttr(resId, defaultResId));
   }
 
@@ -743,6 +777,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     return borderWidthAttr(edge, resId, 0);
   }
 
@@ -751,6 +786,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     return borderWidthPx(edge, mResourceResolver.resolveDimenOffsetRes(resId));
   }
 
@@ -761,6 +797,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     return borderWidthPx(edge, mResourceResolver.dipsToPixels(borderWidth));
   }
 
@@ -769,6 +806,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     mPrivateFlags |= PFLAG_BORDER_COLOR_IS_SET;
     mBorderColor = borderColor;
     return this;
@@ -779,6 +817,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     mPrivateFlags |= PFLAG_POSITION_IS_SET;
     mYogaNode.setPosition(edge, position);
     return this;
@@ -789,6 +828,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     mPrivateFlags |= PFLAG_POSITION_IS_SET;
     mYogaNode.setPositionPercent(edge, percent);
     return this;
@@ -802,6 +842,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     return positionPx(edge, mResourceResolver.resolveDimenOffsetAttr(resId, defaultResId));
   }
 
@@ -810,6 +851,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     return positionAttr(edge, resId, 0);
   }
 
@@ -818,6 +860,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     return positionPx(edge, mResourceResolver.resolveDimenOffsetRes(resId));
   }
 
@@ -828,6 +871,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     return positionPx(edge, mResourceResolver.dipsToPixels(position));
   }
 
@@ -836,6 +880,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     mPrivateFlags |= PFLAG_WIDTH_IS_SET;
     mYogaNode.setWidth(width);
     return this;
@@ -852,6 +897,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     mPrivateFlags |= PFLAG_WIDTH_IS_SET;
     mYogaNode.setWidthPercent(percent);
     return this;
@@ -862,6 +908,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     return widthPx(mResourceResolver.resolveDimenSizeRes(resId));
   }
 
@@ -870,6 +917,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     return widthPx(mResourceResolver.resolveDimenSizeAttr(resId, defaultResId));
   }
 
@@ -878,6 +926,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     return widthAttr(resId, 0);
   }
 
@@ -886,6 +935,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     return widthPx(mResourceResolver.dipsToPixels(width));
   }
 
@@ -894,6 +944,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     mPrivateFlags |= PFLAG_MIN_WIDTH_IS_SET;
     mYogaNode.setMinWidth(minWidth);
     return this;
@@ -904,6 +955,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     mPrivateFlags |= PFLAG_MIN_WIDTH_IS_SET;
     mYogaNode.setMinWidthPercent(percent);
     return this;
@@ -914,6 +966,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     return minWidthPx(mResourceResolver.resolveDimenSizeAttr(resId, defaultResId));
   }
 
@@ -922,6 +975,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     return minWidthAttr(resId, 0);
   }
 
@@ -930,6 +984,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     return minWidthPx(mResourceResolver.resolveDimenSizeRes(resId));
   }
 
@@ -938,6 +993,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     return minWidthPx(mResourceResolver.dipsToPixels(minWidth));
   }
 
@@ -1902,6 +1958,7 @@ class InternalNode implements ComponentLayout, ComponentLayout.ContainerBuilder 
     if (mIsBuilt) {
       throw new IllegalStateException(ILLEGAL_MODIFY_OPERATION);
     }
+
     mIsBuilt = true;
     return this;
   }


### PR DESCRIPTION
Pull Request for   #64 

The current flow seems to be modifying ComponentLayout.Builder after build() has been called. Here is the stack trace on running the sample app. 

```
java.lang.IllegalStateException: Should not modify ComponentLayout properties on a built object
 at com.facebook.litho.InternalNode.flexShrink(InternalNode.java:486)
 at com.facebook.litho.InternalNode.flexShrink(InternalNode.java:75)
 at com.facebook.litho.InternalNode.child(InternalNode.java:1401)
 at com.facebook.litho.InternalNode.child(InternalNode.java:1413)
 at com.facebook.litho.InternalNode.child(InternalNode.java:75)
 at com.facebook.samples.lithobarebones.ListItemSpec.onCreateLayout(ListItemSpec.java:33)
 at com.facebook.samples.lithobarebones.ListItem.onCreateLayout(ListItem.java:39)
 at com.facebook.litho.ComponentLifecycle.createLayout(ComponentLifecycle.java:229)
 at com.facebook.litho.LayoutState.createTree(LayoutState.java:1154)
 at com.facebook.litho.LayoutState.createAndMeasureTreeForComponent(LayoutState.java:1325)
 at com.facebook.litho.LayoutState.calculate(LayoutState.java:908)
 at com.facebook.litho.ComponentTree.calculateLayoutState(ComponentTree.java:1254)
 at com.facebook.litho.ComponentTree.calculateLayout(ComponentTree.java:992)
 at com.facebook.litho.ComponentTree.setRootAndSizeSpecInternal(ComponentTree.java:945)
 at com.facebook.litho.ComponentTree.setRootAndSizeSpec(ComponentTree.java:831)
 at com.facebook.litho.widget.ComponentTreeHolder.computeLayoutSync(ComponentTreeHolder.java:83)
 at com.facebook.litho.widget.RecyclerBinder.initRange(RecyclerBinder.java:611)
 at com.facebook.litho.widget.RecyclerBinder.measure(RecyclerBinder.java:537)
 at com.facebook.litho.widget.RecyclerBinder.setSize(RecyclerBinder.java:637)
 at com.facebook.litho.widget.RecyclerSpec.onBoundsDefined(RecyclerSpec.java:67)
 at com.facebook.litho.widget.Recycler.onBoundsDefined(Recycler.java:78)
 at com.facebook.litho.LayoutState.collectResults(LayoutState.java:569)
 at com.facebook.litho.LayoutState.calculate(LayoutState.java:958)
 at com.facebook.litho.ComponentTree.calculateLayoutState(ComponentTree.java:1254)
 at com.facebook.litho.ComponentTree.measure(ComponentTree.java:539)
 at com.facebook.litho.LithoView.onMeasure(LithoView.java:211)
 at android.view.View.measure(View.java:17547)
 at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:5535)
 at android.widget.FrameLayout.onMeasure(FrameLayout.java:436)
 at android.view.View.measure(View.java:17547)
 at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:5535)
 at com.android.internal.widget.ActionBarOverlayLayout.onMeasure(ActionBarOverlayLayout.java:447)
 at android.view.View.measure(View.java:17547)
 at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:5535)
 at android.widget.FrameLayout.onMeasure(FrameLayout.java:436)
 at com.android.internal.policy.impl.PhoneWindow$DecorView.onMeasure(PhoneWindow.java:2615)
 at android.view.View.measure(View.java:17547)
 at android.view.ViewRootImpl.performMeasure(ViewRootImpl.java:2015)
 at android.view.ViewRootImpl.measureHierarchy(ViewRootImpl.java:1173)
 at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:1379)
 at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1061)
 at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:5885)
 at android.view.Choreographer$CallbackRecord.run(Choreographer.java:767)
 at android.view.Choreographer.doCallbacks(Choreographer.java:580)
 at android.view.Choreographer.doFrame(Choreographer.java:550)
 at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:753)
 at android.os.Handler.handleCallback(Handler.java:739)
 at android.os.Handler.dispatchMessage(Handler.java:95)
 at android.os.Looper.loop(Looper.java:135)
 at android.app.ActivityThread.main(ActivityThread.java:5254)
 at java.lang.reflect.Method.invoke(Native Method)
 at java.lang.reflect.Method.invoke(Method.java:372)
 at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:903)
 at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:698)
```
