### PR TITLE
Add google's maven repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ subprojects {
     repositories {
         jcenter()
         maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+        maven { url 'https://maven.google.com' }
     }
 }
 

--- a/litho-annotations/build.gradle
+++ b/litho-annotations/build.gradle
@@ -1,16 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'maven-publish'
 
-// Add Android SDK repositories to the lookup path for standard java library
-// projects.
-def logger = new com.android.build.gradle.internal.LoggerWrapper(project.logger)
-def sdkHandler = new com.android.build.gradle.internal.SdkHandler(project, logger)
-for (File file : sdkHandler.sdkLoader.repositories) {
-  repositories.maven {
-    url = file.toURI()
-  }
-}
-
 targetCompatibility = rootProject.targetCompatibilityVersion
 sourceCompatibility = rootProject.sourceCompatibilityVersion
 

--- a/litho-processor/build.gradle
+++ b/litho-processor/build.gradle
@@ -1,16 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'maven-publish'
 
-// Add Android SDK repositories to the lookup path for standard java library
-// projects.
-def logger = new com.android.build.gradle.internal.LoggerWrapper(project.logger)
-def sdkHandler = new com.android.build.gradle.internal.SdkHandler(project, logger)
-for (File file : sdkHandler.sdkLoader.repositories) {
-  repositories.maven {
-    url = file.toURI()
-  }
-}
-
 dependencies {
     compile project(':litho-annotations')
     compile deps.jsr305


### PR DESCRIPTION
This allows including android dependencies without calling internal
apis in build.gradle.