### PR TITLE
Updating the Java Example for Solid Color.

### DIFF
--- a/docs/_docs/layout-specs.md
+++ b/docs/_docs/layout-specs.md
@@ -49,7 +49,7 @@ The first child is a [SolidColor](/javadoc/com/facebook/litho/widget/SolidColor)
 
 ```java
 SolidColor.create(c)
-    .uri(imageUri)
+    .colorRes(color)
     .withLayout()
     .width(40)
     .height(40)


### PR DESCRIPTION
The text above mentions that SolidColor component that takes a `colorRes` prop..
In the actual Java Sample a different property is mentioned.