### PR TITLE
[WIP] Upgrade to Gradle Plugin 3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,10 @@
 buildscript {
     repositories {
         jcenter()
+        maven { url 'https://maven.google.com/' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.0-alpha4'
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:${GRADLE_BINTRAY_PLUGIN_VERSION}"
         classpath "com.github.dcendents:android-maven-gradle-plugin:${ANDROID_MAVEN_GRADLE_PLUGIN_VERSION}"
 

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ machine:
 
 dependencies:
   pre:
-    - [ -n "$KEY" ] && openssl aes-256-cbc -d -in scripts/setup-keys.enc -k $KEY >> gradle.properties
+    - "[ -n \"$KEY\" ] && openssl aes-256-cbc -d -in scripts/setup-keys.enc -k $KEY >> gradle.properties || true"
     # Manually override key to limit exposure
     - export KEY="<unset>"
   override:

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,6 @@ POM_DEVELOPER_NAME=facebook
 # Deps for publishing
 GRADLE_BINTRAY_PLUGIN_VERSION=1.7.1
 ANDROID_MAVEN_GRADLE_PLUGIN_VERSION=1.4.1
+
+# Not compatible at this point
+android.enableAapt2=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Mar 27 17:00:11 BST 2017
+#Thu May 25 14:52:47 BST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-rc-1-all.zip

--- a/lib/yoga/build.gradle
+++ b/lib/yoga/build.gradle
@@ -11,11 +11,11 @@ android {
 }
 
 dependencies {
-    compile deps.soloader
-    compile deps.jsr305
-    compile deps.inferAnnotations
+    implementation deps.soloader
+    implementation deps.jsr305
+    implementation deps.inferAnnotations
 
-    provided project(':litho-annotations')
+    compileOnly project(':litho-annotations')
 }
 
 // Our current NDK setup only gets us half-way there to a way to run Yoga

--- a/lib/yogajni/build.gradle
+++ b/lib/yogajni/build.gradle
@@ -27,6 +27,6 @@ android {
 
     dependencies {
         // We want to export the Java APIs
-        compile project(':yoga')
+        api project(':yoga')
     }
 }

--- a/litho-annotations/build.gradle
+++ b/litho-annotations/build.gradle
@@ -6,7 +6,7 @@ sourceCompatibility = rootProject.sourceCompatibilityVersion
 
 dependencies {
     // Android Support Library
-    compile deps.supportAnnotations
+    compileOnly deps.supportAnnotations
 }
 
 apply from: rootProject.file('gradle/release.gradle')

--- a/litho-core/build.gradle
+++ b/litho-core/build.gradle
@@ -35,23 +35,23 @@ android {
 
 dependencies {
     // Project dependencies
-    provided project(':litho-annotations')
-    provided project(':litho-stubs')
+    compileOnly project(':litho-annotations')
+    compileOnly project(':litho-stubs')
 
-    // Provided dependencies
-    provided deps.jsr305
-    provided deps.inferAnnotations
+    // compileOnly dependencies
+    compileOnly deps.jsr305
+    compileOnly deps.inferAnnotations
 
     // Android Support Library
-    provided deps.supportAnnotations
-    compile deps.supportCoreUi
-    compile deps.supportRecyclerView
+    compileOnly deps.supportAnnotations
+    implementation deps.supportCoreUi
+    implementation deps.supportRecyclerView
 
     // First-party dependencies
     if (project.hasProperty('RELEASE_MODE')) {
-        compile deps.yoga
+        api deps.yoga
     } else {
-        compile project(':yogajni')
+        api project(':yogajni')
     }
 }
 

--- a/litho-espresso/build.gradle
+++ b/litho-espresso/build.gradle
@@ -12,12 +12,12 @@ android {
 }
 
 dependencies {
-    compile project(':litho-core')
+    implementation project(':litho-core')
 
-    compile deps.supportEspresso
-    compile deps.screenshot
-    androidTestProvided project(':litho-annotations')
-    androidTestCompile project(':litho-widget')
+    implementation deps.supportEspresso
+    implementation deps.screenshot
+    androidTestCompileOnly project(':litho-annotations')
+    androidTestImplementation project(':litho-widget')
     androidTestAnnotationProcessor project(':litho-processor')
 }
 

--- a/litho-fresco/build.gradle
+++ b/litho-fresco/build.gradle
@@ -16,19 +16,19 @@ android {
 }
 
 dependencies {
-    compile project(':litho-core')
-    provided project(':litho-annotations')
+    implementation project(':litho-core')
+    compileOnly project(':litho-annotations')
     annotationProcessor project(':litho-processor')
 
     // Annotations
-    provided deps.jsr305
-    provided deps.inferAnnotations
+    compileOnly deps.jsr305
+    compileOnly deps.inferAnnotations
 
     // First-party
-    compile deps.fresco
+    implementation deps.fresco
 
     // Android Support Library
-    compile deps.supportCoreUi
+    implementation deps.supportCoreUi
 }
 
 apply from: rootProject.file('gradle/release.gradle')

--- a/litho-it-powermock/build.gradle
+++ b/litho-it-powermock/build.gradle
@@ -26,17 +26,20 @@ android {
 }
 
 dependencies {
-    compile project(':litho-core')
+    implementation project(':litho-core')
     // We are reusing some of the testing resources
-    compile project(':litho-it')
-    testCompile project(':litho-stubs')
-    testCompile project(':litho-testing')
-    testCompile project(':litho-widget')
+    implementation project(':litho-it')
+    testImplementation project(':litho-stubs')
+    testImplementation project(':litho-testing')
+    testImplementation project(':litho-widget')
 
     // Testing
-    testCompile deps.robolectric
-    testCompile deps.soloader
-    testCompile deps.powermockMockito
-    testCompile deps.powermockJunit
-    testCompile deps.powermockXstream
+    testImplementation deps.guava
+    testImplementation deps.supportRecyclerView
+    testImplementation deps.robolectric
+    testImplementation deps.soloader
+    testImplementation deps.assertjCore
+    testImplementation deps.powermockMockito
+    testImplementation deps.powermockJunit
+    testImplementation deps.powermockXstream
 }

--- a/litho-it/build.gradle
+++ b/litho-it/build.gradle
@@ -8,6 +8,15 @@ android {
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
+
+        javaCompileOptions {
+            annotationProcessorOptions {
+                // We transitively depend on auto-value which we don't want to
+                // use as annotation processor at this time, so we can safely
+                // disable this warning.
+                includeCompileClasspath false
+            }
+        }
     }
 
     testOptions {
@@ -21,20 +30,29 @@ android {
 }
 
 dependencies {
-    compile project(':litho-core')
-    provided project(':litho-annotations')
-    testCompile project(':litho-stubs')
-    testCompile project(':litho-testing')
-    testCompile project(':litho-widget')
+    api project(':litho-core')
+    testCompileOnly project(':litho-annotations')
+    testImplementation project(':litho-stubs')
+    testImplementation project(':litho-testing')
+    testImplementation project(':litho-widget')
+    testImplementation project(':litho-processor')
 
     // Testing
-    testCompile deps.compileTesting
-    testCompile deps.junit
-    testCompile deps.assertjCore
-    testCompile deps.mockitoCore
-    testCompile deps.robolectric
-    testCompile deps.soloader
-    testCompile files(getRuntimeJar())
+    testCompileOnly deps.jsr305
+    testImplementation deps.assertjCore
+    testImplementation deps.compileTesting
+    testImplementation deps.junit
+    testImplementation deps.mockitoCore
+    testImplementation deps.javapoet
+    testImplementation deps.powermockJunit
+    testImplementation deps.powermockMockito
+    testImplementation deps.powermockXstream
+    testImplementation deps.robolectric
+    testImplementation deps.soloader
+    testImplementation deps.supportAppCompat
+    testImplementation deps.supportCoreUi
+    testImplementation deps.supportRecyclerView
+    testImplementation files(getRuntimeJar())
 }
 
 static def getRuntimeJar() {

--- a/litho-processor/build.gradle
+++ b/litho-processor/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'java'
 apply plugin: 'maven-publish'
 
 dependencies {
-    compile project(':litho-annotations')
-    compile deps.jsr305
+    implementation project(':litho-annotations')
+    compileOnly deps.jsr305
 
     // Processor
-    compile deps.javapoet
+    implementation deps.javapoet
 }
 
 apply from: rootProject.file('gradle/release.gradle')

--- a/litho-stetho/build.gradle
+++ b/litho-stetho/build.gradle
@@ -16,15 +16,18 @@ android {
 }
 
 dependencies {
-    compile project(':litho-core')
-    compile project(':litho-annotations')
+    implementation project(':litho-core')
+    implementation project(':litho-annotations')
 
     // Annotations
-    provided deps.jsr305
-    provided deps.inferAnnotations
+    compileOnly deps.jsr305
+    compileOnly deps.inferAnnotations
 
     // First-party
-    compile deps.stetho
+    implementation deps.stetho
+
+    // Support
+    implementation deps.supportAppCompat
 }
 
 apply from: rootProject.file('gradle/release.gradle')

--- a/litho-testing/build.gradle
+++ b/litho-testing/build.gradle
@@ -13,16 +13,20 @@ android {
 }
 
 dependencies {
-    compile project(':litho-core')
-    compile project(':litho-processor')
+    implementation project(':litho-core')
+    implementation project(':litho-processor')
+    annotationProcessor project(':litho-processor')
 
-    compile deps.assertjCore
-    compile deps.guava
-    compile deps.jsr305
-    compile deps.junit
-    compile deps.mockitoCore
-    compile deps.powermockReflect
-    compile deps.robolectric
+    implementation deps.javapoet
+    implementation deps.assertjCore
+    implementation deps.guava
+    implementation deps.jsr305
+    implementation deps.junit
+    implementation deps.mockitoCore
+    implementation deps.powermockReflect
+    implementation deps.robolectric
+    implementation deps.supportAppCompat
+    compileOnly deps.supportAnnotations
 }
 
 apply from: rootProject.file('gradle/release.gradle')

--- a/litho-testing/build.gradle
+++ b/litho-testing/build.gradle
@@ -27,6 +27,10 @@ dependencies {
     implementation deps.robolectric
     implementation deps.supportAppCompat
     compileOnly deps.supportAnnotations
+
+    // There are no tests in here but the plugin will complain
+    // if we don't list it.
+    testAnnotationProcessor project(':litho-processor')
 }
 
 apply from: rootProject.file('gradle/release.gradle')

--- a/litho-widget/build.gradle
+++ b/litho-widget/build.gradle
@@ -18,19 +18,28 @@ android {
 }
 
 dependencies {
-    compile project(':litho-core')
-    provided project(':litho-annotations')
+    implementation project(':litho-core')
+    implementation deps.supportRecyclerView
+    compileOnly project(':litho-annotations')
     annotationProcessor project(':litho-processor')
 
     // Annotations
-    provided deps.jsr305
-    provided deps.inferAnnotations
+    compileOnly deps.jsr305
+    compileOnly deps.inferAnnotations
 
     // First-party
-    compile deps.textlayoutbuilder
+    implementation deps.textlayoutbuilder
 
     // Android Support Library
-    compile deps.supportCoreUi
+    implementation deps.supportCoreUi
+
+    // Testing
+    testImplementation project(':litho-testing')
+    testImplementation deps.robolectric
+    testImplementation deps.soloader
+    testImplementation deps.powermockMockito
+    testImplementation deps.powermockJunit
+    testImplementation deps.powermockXstream
 }
 
 apply from: rootProject.file('gradle/release.gradle')

--- a/sample-barebones/build.gradle
+++ b/sample-barebones/build.gradle
@@ -18,11 +18,11 @@ android {
 }
 
 dependencies {
-    compile project(':litho-core')
-    compile project(':litho-widget')
-    provided project(':litho-annotations')
+    implementation project(':litho-core')
+    implementation project(':litho-widget')
+    compileOnly project(':litho-annotations')
     annotationProcessor project(':litho-processor')
 
-    compile deps.soloader
-    compile deps.supportRecyclerView
+    implementation deps.soloader
+    implementation deps.supportRecyclerView
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -28,26 +28,29 @@ android {
 }
 
 dependencies {
-    compile project(':litho-core')
-    compile project(':litho-stetho')
-    compile project(':litho-widget')
-    compile project(':litho-fresco')
-    provided project(':litho-annotations')
+    implementation project(':litho-core')
+    implementation project(':litho-stetho')
+    implementation project(':litho-widget')
+    implementation project(':litho-fresco')
+    compileOnly project(':litho-annotations')
     annotationProcessor project(':litho-processor')
 
     // First-party
-    compile deps.soloader
+    implementation deps.soloader
+    implementation deps.fresco
+    implementation deps.stetho
 
     // Annotations
-    provided deps.jsr305
-    provided deps.inferAnnotations
+    compileOnly deps.jsr305
+    compileOnly deps.inferAnnotations
 
     // Support Library
-    compile deps.supportAppCompat
-    compile deps.supportRecyclerView
+    implementation deps.supportAppCompat
+    implementation deps.supportRecyclerView
 
-    androidTestCompile project(':litho-espresso')
-    androidTestCompile deps.supportEspresso
-    androidTestCompile deps.supportEspressoIntents
-    androidTestCompile deps.junit
+    // Test only
+    androidTestImplementation project(':litho-espresso')
+    androidTestImplementation deps.supportEspresso
+    androidTestImplementation deps.supportEspressoIntents
+    androidTestImplementation deps.junit
 }


### PR DESCRIPTION
Replaces #192 

This is a work-in-progress for upgrading to the new gradle plugin. It
significantly improves build times as it no longer implicitly propagates
`compile` dependencies and doesn't run all annotation processors it can
find on the class path.

It should also allow us to get rid of the `RELEASE_MODE` hack as it
properly supports variant propagation.

Sadly, the tests are currently failing due to this error:

```
java.lang.IllegalArgumentException: The key must be an application-specific resource id.
	at android.view.View.setTag(View.java:14978)
	at com.facebook.litho.ComponentHost.setTag(ComponentHost.java:379)
```

I've raised this with the Google tools folks and they're working on something to address this. The short version is that the resource ID generation has changed and is now supposed to go through AAPT for the final assignment, while Robolectric tries to use them as-is. Since the IDs are very low, it will fail the test in `View.java` and bail.