### PR TITLE
[easy] Fix small markdown error in tutorial

### DIFF
--- a/docs/_docs/tutorial.md
+++ b/docs/_docs/tutorial.md
@@ -50,7 +50,7 @@ public void onCreate(Bundle savedInstanceState) {
 }
 ```
 
-`LithoView` is an Android `ViewGroup` that can render components; it is the bridge between Litho components and Android `View`s. The example sets the content for the activity to a `LithoView` that displays a `Text` component.
+`LithoView` is an Android `ViewGroup` that can render components; it is the bridge between Litho components and Android `Views`. The example sets the content for the activity to a `LithoView` that displays a `Text` component.
 
 How do the components come into play? Let's zero in on this piece of code:
 


### PR DESCRIPTION
I was checking out Litho and I noticed a small error in the markdown on the tutorial page. 

<img width="318" alt="screen shot 2017-07-21 at 11 16 41 pm" src="https://user-images.githubusercontent.com/7844509/28488934-afc1e2ee-6e6a-11e7-9e1c-50d8a780ae26.png">
