### PR TITLE
litho-annotation should be a provided_deps

### DIFF
--- a/docs/_docs/getting-started/buck.md
+++ b/docs/_docs/getting-started/buck.md
@@ -53,7 +53,7 @@ remote_file(
     url = "mvn:com.facebook.litho:litho-widget:aar:{{site.litho-version}}",
 )
 
-litho_android_library(
+android_library(
     ...
     # Your target here
     ...
@@ -63,6 +63,9 @@ litho_android_library(
     ],
     annotation_processors = [
         "com.facebook.litho.specmodels.processor.ComponentsProcessor",
+    ],
+    provided_deps = [
+        "litho-annotation",
     ],
     deps = [
         ":litho",


### PR DESCRIPTION
Java files with litho annotations needs to be compiled with a "provided_deps" of litho-annotation. Putting litho-annotation in "deps" will cause duplicate jar inclusion when building the APK.

Note "provided_deps" is not documented in android_library's APIs.

@passy PTAL :)