### PR TITLE
Enable support for change animations in ItemAnimator

### DIFF
--- a/litho-widget/src/main/java/com/facebook/litho/widget/RecyclerBinder.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/RecyclerBinder.java
@@ -480,7 +480,14 @@ public class RecyclerBinder
       if (previousRenderInfo.rendersView()) {
         updateViewCreatorMappingsOnItemRemove(previousRenderInfo);
       }
-      holder.setRenderInfo(renderInfo);
+      final ComponentTreeHolder newHolder = mComponentTreeHolderFactory.create(
+              renderInfo,
+              mLayoutHandlerFactory != null ?
+                      mLayoutHandlerFactory.createLayoutCalculationHandler(renderInfo) :
+                      null,
+              mCanPrefetchDisplayLists,
+              mCanCacheDrawingDisplayLists);
+      mComponentTreeHolders.set(position, newHolder);
       if (renderInfo.rendersView()) {
         updateViewCreatorMappingsOnItemInsert(renderInfo);
       }


### PR DESCRIPTION
What I wanted to achieve in an app in which I'm using Litho, is a crossfade animation between the old view and the new view after updating a component in the `Recycler`.

ItemAnimators have support for this, you can override the ``canReuseUpdatedViewHolder`` method inside an ``ItemAnimator`` and, when returning false, will enable both views (the old and the new one) to be alive at the same time when doing an update of a view on a certain position.

So for a demo I wrote inside the Playground a simple``Recycler`` which holds some components (rectangles with black color). I then update the items to a component with a cyan color with the ``updateItemAt`` method in the ``RecyclerBinder`` . I wrote the custom ItemAnimator and in the callback where you get both views, I set the correct alpha's and start the crossfade animation. This was the result:

![litho_itemanimator_change_wrong](https://user-images.githubusercontent.com/8387808/29488669-09dced3a-8510-11e7-911f-998ea66b3511.gif)

No animation is triggered. While debugging I noticed that both views where the same new view, and not the old one and the new. I digged around a little in the ``RecyclerBinder`` and noticed that when updating a component, it does not actually create a new one but modifies the existing one. When replacing that code with creating a new  ``ComponentTree`` it magically works.

![litho_itemanimator_change_correct](https://user-images.githubusercontent.com/8387808/29488679-4f0aa7d0-8510-11e7-8931-7651f97c4f9c.gif)

I did not dig that deep into the source code and I do not know if this would be the proper solution, but at least this fixes the issue for me. 
 


