### PR TITLE
Set component key inside LithoView

### DIFF
--- a/litho-core/src/main/java/com/facebook/litho/LithoView.java
+++ b/litho-core/src/main/java/com/facebook/litho/LithoView.java
@@ -99,6 +99,10 @@ public class LithoView extends ComponentHost {
     mMountState = new MountState(this);
     mAccessibilityManager = (AccessibilityManager) context.getSystemService(ACCESSIBILITY_SERVICE);
   }
+  
+  public @Nullable String getComponentKey() {
+    return mComponentKey;
+  }
 
   private static void performLayoutOnChildrenIfNecessary(ComponentHost host) {
     for (int i = 0, count = host.getChildCount(); i < count; i++) {

--- a/litho-core/src/main/java/com/facebook/litho/LithoView.java
+++ b/litho-core/src/main/java/com/facebook/litho/LithoView.java
@@ -39,6 +39,7 @@ public class LithoView extends ComponentHost {
   private boolean mForceLayout;
   private boolean mSuppressMeasureComponentTree;
   private boolean mIsMeasuring = false;
+  private String mComponentKey = null;
 
   private final AccessibilityManager mAccessibilityManager;
 
@@ -303,6 +304,7 @@ public class LithoView extends ComponentHost {
     assertMainThread();
     assertNotInMeasure();
 
+    mComponentKey = componentTree.getRoot().getKey();
     mTemporaryDetachedComponent = null;
     if (mComponentTree == componentTree) {
       if (mIsAttached) {


### PR DESCRIPTION
When doing view animations inside an ``ItemAnimator`` you would typically check the ``ViewHolder`` or ``View`` instance to check what kind of view you are animating for. Since Litho uses the same classes (``BaseViewHolder`` and ``LithoView``) you cannot really do that. 

This PR adds a ``mComponentKey`` property to the ``LithoView`` so you can do your animations based on what type of ``Component`` you are dealing with.