### PR TITLE
Fix crash caused by SnapHelper

### DIFF
--- a/litho-it/src/test/java/com/facebook/litho/widget/RecyclerSpecTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/widget/RecyclerSpecTest.java
@@ -19,6 +19,8 @@ import android.support.v4.widget.SwipeRefreshLayout.OnRefreshListener;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.RecyclerView.ItemAnimator;
 import android.support.v7.widget.RecyclerView.OnScrollListener;
+import android.support.v7.widget.SnapHelper;
+
 import com.facebook.litho.ComponentContext;
 import com.facebook.litho.Output;
 import com.facebook.litho.testing.testrunner.ComponentsTestRunner;
@@ -59,6 +61,8 @@ public class RecyclerSpecTest {
 
     Output<ItemAnimator> oldAnimator = mock(Output.class);
 
+    SnapHelper snapHelper = mock(SnapHelper.class);
+
     final int size = 3;
     List<RecyclerView.OnScrollListener> scrollListeners = createListOfScrollListeners(size);
 
@@ -69,6 +73,7 @@ public class RecyclerSpecTest {
         binder,
         null,
         scrollListeners,
+        snapHelper,
         onRefreshListener,
         oldAnimator);
 
@@ -89,6 +94,8 @@ public class RecyclerSpecTest {
 
     Binder<RecyclerView> binder = mock(Binder.class);
 
+    SnapHelper snapHelper = mock(SnapHelper.class);
+
     final int size = 3;
     List<RecyclerView.OnScrollListener> scrollListeners = createListOfScrollListeners(size);
 
@@ -98,6 +105,7 @@ public class RecyclerSpecTest {
         binder,
         null,
         scrollListeners,
+        snapHelper,
         mAnimator);
 
     verify(mRecyclerView).setItemAnimator(mAnimator);

--- a/litho-widget/src/main/java/com/facebook/litho/widget/RecyclerSpec.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/RecyclerSpec.java
@@ -131,8 +131,7 @@ class RecyclerSpec {
       @Prop(optional = true) boolean horizontalFadingEdgeEnabled,
       @Prop(optional = true) boolean verticalFadingEdgeEnabled,
       @Prop(optional = true, resType = ResType.DIMEN_SIZE) int fadingEdgeLength,
-      @Prop(optional = true) @IdRes int recyclerViewId,
-      @Prop(optional = true) SnapHelper snapHelper) {
+      @Prop(optional = true) @IdRes int recyclerViewId) {
     final RecyclerView recyclerView = recyclerViewWrapper.getRecyclerView();
 
     if (recyclerView == null) {
@@ -159,10 +158,6 @@ class RecyclerSpec {
       recyclerView.addItemDecoration(itemDecoration);
     }
 
-    if (snapHelper != null) {
-      snapHelper.attachToRecyclerView(recyclerView);
-    }
-
     binder.mount(recyclerView);
   }
 
@@ -174,6 +169,7 @@ class RecyclerSpec {
       @Prop Binder<RecyclerView> binder,
       @Prop(optional = true) final RecyclerEventsController recyclerEventsController,
       @Prop(optional = true, varArg = "onScrollListener") List<OnScrollListener> onScrollListeners,
+      @Prop(optional = true) SnapHelper snapHelper,
       @FromPrepare OnRefreshListener onRefreshListener,
       Output<ItemAnimator> oldAnimator) {
 
@@ -201,6 +197,10 @@ class RecyclerSpec {
       }
     }
 
+    if (snapHelper != null) {
+      snapHelper.attachToRecyclerView(recyclerView);
+    }
+
     binder.bind(recyclerView);
 
     if (recyclerEventsController != null) {
@@ -220,6 +220,7 @@ class RecyclerSpec {
       @Prop Binder<RecyclerView> binder,
       @Prop(optional =  true) RecyclerEventsController recyclerEventsController,
       @Prop(optional = true, varArg = "onScrollListener") List<OnScrollListener> onScrollListeners,
+      @Prop(optional = true) SnapHelper snapHelper,
       @FromBind ItemAnimator oldAnimator) {
     final RecyclerView recyclerView = recyclerViewWrapper.getRecyclerView();
 
@@ -243,6 +244,10 @@ class RecyclerSpec {
       }
     }
 
+    if (snapHelper != null) {
+      snapHelper.attachToRecyclerView(null);
+    }
+
     recyclerViewWrapper.setOnRefreshListener(null);
   }
 
@@ -251,8 +256,7 @@ class RecyclerSpec {
       ComponentContext context,
       RecyclerViewWrapper recyclerViewWrapper,
       @Prop Binder<RecyclerView> binder,
-      @Prop(optional = true) RecyclerView.ItemDecoration itemDecoration,
-      @Prop(optional = true) SnapHelper snapHelper) {
+      @Prop(optional = true) RecyclerView.ItemDecoration itemDecoration) {
     final RecyclerView recyclerView = recyclerViewWrapper.getRecyclerView();
 
     if (recyclerView == null) {
@@ -265,10 +269,6 @@ class RecyclerSpec {
 
     if (itemDecoration != null) {
       recyclerView.removeItemDecoration(itemDecoration);
-    }
-
-    if (snapHelper != null) {
-      snapHelper.attachToRecyclerView(null);
     }
 
     binder.unmount(recyclerView);


### PR DESCRIPTION
A crash happened when I play the lithography sample
#### Here are the steps to reproduce:
* Click the favourite button of the item who has a SnapHelper
* Move the item off screen
* Move it back
#### Logcat
```java
 java.lang.IllegalStateException: An instance of OnFlingListener already set.
     at android.support.v7.widget.SnapHelper.setupCallbacks(SnapHelper.java:114)
     at android.support.v7.widget.SnapHelper.attachToRecyclerView(SnapHelper.java:102)
     at com.facebook.litho.widget.RecyclerSpec.onMount(RecyclerSpec.java:163)
     at com.facebook.litho.widget.Recycler.onMount(Recycler.java:121)
     at com.facebook.litho.ComponentLifecycle.mount(ComponentLifecycle.java:183)
     at com.facebook.litho.MountState.mountLayoutOutput(MountState.java:994)
     at com.facebook.litho.MountState.mount(MountState.java:217)
     at com.facebook.litho.LithoView.mount(LithoView.java:563)
     at com.facebook.litho.ComponentTree.mountComponent(ComponentTree.java:476)
     at com.facebook.litho.LithoView.performIncrementalMount(LithoView.java:508)
     at com.facebook.litho.LithoView.maybePerformIncrementalMountOnView(LithoView.java:478)
     at com.facebook.litho.LithoView.offsetTopAndBottom(LithoView.java:416)
     at android.support.v7.widget.RecyclerView.offsetChildrenVertical(RecyclerView.java:4489)
     at android.support.v7.widget.RecyclerView$LayoutManager.offsetChildrenVertical(RecyclerView.java:8389)
     at android.support.v7.widget.OrientationHelper$2.offsetChildren(OrientationHelper.java:362)
     at android.support.v7.widget.LinearLayoutManager.scrollBy(LinearLayoutManager.java:1333)
     at android.support.v7.widget.LinearLayoutManager.scrollVerticallyBy(LinearLayoutManager.java:1061)
     at android.support.v7.widget.RecyclerView$ViewFlinger.run(RecyclerView.java:4726)
     at android.view.Choreographer$CallbackRecord.run(Choreographer.java:874)
     at android.view.Choreographer.doCallbacks(Choreographer.java:686)
     at android.view.Choreographer.doFrame(Choreographer.java:618)
     at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:860)
     at android.os.Handler.handleCallback(Handler.java:751)
     at android.os.Handler.dispatchMessage(Handler.java:95)
     at android.os.Looper.loop(Looper.java:154)
     at android.app.ActivityThread.main(ActivityThread.java:6119)
     at java.lang.reflect.Method.invoke(Native Method)
     at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:886)
     at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:776)
```
I find out that after changing the state of favourited the mRecyclerView of SnapHelper become null, so when `snapHelper.attachToRecyclerView(null);` evaluate, it just skip `destroyCallbacks();`
Then I follow the code and find that in `FeedItemComponentSpec.java`. Every time the Recycler create, it pass a new PagerSnapHelper() and in `RecyclerSpec.java` the shouldUpdate method does not return true when snapHelper changed.

This PR just fix that crash