### PR TITLE
Support  for var-arg properties

### DIFF
--- a/docs/_docs/props.md
+++ b/docs/_docs/props.md
@@ -167,15 +167,15 @@ MyComponent.create(c)
    .name("Three")
 ```
 
-If you specific `resType`:
+You can also combine `varArg` with `resType` props:
 
 ```java
 MyComponent.create(c)
-   .namePx(1f)
-   .nameRes(resId)
-   .nameAttr(attrResId)
-   .nameDip(1f)
-   .nameSp(1f)
+   .textSizePx(1f)
+   .textSizeRes(resId)
+   .textSizeAttr(attrResId)
+   .textSizeDip(1f)
+   .textSizeSp(1f)
 ```
 
 

--- a/docs/_docs/props.md
+++ b/docs/_docs/props.md
@@ -167,7 +167,18 @@ MyComponent.create(c)
    .name("Three")
 ```
 
-Note that, when using `varArg`, `resType`s are not supported.
+If you specific `resType`:
+
+```java
+MyComponent.create(c)
+   .namePx(1f)
+   .nameRes(resId)
+   .nameAttr(attrResId)
+   .nameDip(1f)
+   .nameSp(1f)
+```
+
+
 
 ## Immutability
 The props of a Component are read-only. The Component's parent passes down values for the props when it creates the Component and they cannot change throughout the lifecycle of the Component. If the props values must be updated, the parent has to create a new Component and pass down new values for the props.

--- a/litho-core/src/main/java/com/facebook/litho/ResourceResolver.java
+++ b/litho-core/src/main/java/com/facebook/litho/ResourceResolver.java
@@ -69,7 +69,7 @@ public class ResourceResolver {
     return resId != 0 ? mResources.getString(resId, formatArgs) : null;
   }
 
-  private final String[] resolveStringArrayRes(@ArrayRes int resId) {
+  protected final String[] resolveStringArrayRes(@ArrayRes int resId) {
     if (resId != 0) {
       String[] cached = mResourceCache.get(resId);
       if (cached != null) {
@@ -115,6 +115,16 @@ public class ResourceResolver {
     }
 
     return null;
+  }
+
+  protected final Integer[] resolveIntegerArrayRes(@ArrayRes int resId) {
+    int[] resIds = resolveIntArrayRes(resId);
+    if (resIds == null) return null;
+    Integer[] result = new Integer[resIds.length];
+    for (int i = 0; i < resIds.length; i++) {
+      result[i] = resIds[i];
+    }
+    return result;
   }
 
   protected final boolean resolveBoolRes(@BoolRes int resId) {
@@ -253,6 +263,16 @@ public class ResourceResolver {
     } finally {
       a.recycle();
     }
+  }
+
+  protected final Integer[] resolveIntegerArrayAttr(@AttrRes int attrResId, @ArrayRes int defResId) {
+    int[] resIds = resolveIntArrayAttr(attrResId, defResId);
+    if (resIds == null) return null;
+    Integer[] result = new Integer[resIds.length];
+    for (int i = 0; i < resIds.length; i++) {
+      result[i] = resIds[i];
+    }
+    return result;
   }
 
   protected final boolean resolveBoolAttr(@AttrRes int attrResId, @BoolRes int defResId) {

--- a/litho-it/src/test/java/com/facebook/litho/specmodels/generator/BuilderGeneratorTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/specmodels/generator/BuilderGeneratorTest.java
@@ -63,13 +63,23 @@ public class BuilderGeneratorTest {
     public void testUpdateStateMethod() {}
   }
 
+  @LayoutSpec
+  static class TestResTypeWithVarArgsSpec {
+    @OnCreateLayout
+    public void test(@Prop(varArg = "test", resType = ResType.DIMEN_TEXT) List<Float> arg0) {}
+  }
+
   private SpecModel mSpecModel;
+  private SpecModel mSpecModel1;
 
   @Before
   public void setUp() {
     Elements elements = mCompilationRule.getElements();
     TypeElement typeElement = elements.getTypeElement(TestSpec.class.getCanonicalName());
     mSpecModel = mLayoutSpecModelFactory.create(elements, typeElement, null);
+
+    TypeElement typeElement1 = elements.getTypeElement(TestResTypeWithVarArgsSpec.class.getCanonicalName());
+    mSpecModel1 = mLayoutSpecModelFactory.create(elements, typeElement1, null);
   }
 
   @Test
@@ -185,5 +195,217 @@ public class BuilderGeneratorTest {
                 + "    sBuilderPool.release(this);\n"
                 + "  }\n"
                 + "}\n");
+  }
+
+  @Test
+  public void testResTypeWithVarArgs() {
+    TypeSpecDataHolder dataHolder = BuilderGenerator.generate(mSpecModel1);
+    assertThat(dataHolder.getTypeSpecs()).hasSize(1);
+    assertThat(dataHolder.getTypeSpecs().get(0).toString())
+        .isEqualTo(
+            "public static class Builder extends com.facebook.litho.Component.Builder<com.facebook.litho.specmodels.generator.BuilderGeneratorTest.TestResTypeWithVarArgs, Builder> {\n" +
+            "  private static final java.lang.String[] REQUIRED_PROPS_NAMES = new String[] {\"arg0\"};\n" +
+            "\n" +
+            "  private static final int REQUIRED_PROPS_COUNT = 1;\n" +
+            "\n" +
+            "  TestResTypeWithVarArgsImpl mTestResTypeWithVarArgsImpl;\n" +
+            "\n" +
+            "  com.facebook.litho.ComponentContext mContext;\n" +
+            "\n" +
+            "  private java.util.BitSet mRequired = new java.util.BitSet(REQUIRED_PROPS_COUNT);\n" +
+            "\n" +
+            "  private void init(com.facebook.litho.ComponentContext context, int defStyleAttr, int defStyleRes,\n" +
+            "      TestResTypeWithVarArgsImpl testResTypeWithVarArgsImpl) {\n" +
+            "    super.init(context, defStyleAttr, defStyleRes, testResTypeWithVarArgsImpl);\n" +
+            "    mTestResTypeWithVarArgsImpl = testResTypeWithVarArgsImpl;\n" +
+            "    mContext = context;\n" +
+            "    mRequired.clear();\n" +
+            "  }\n" +
+            "\n" +
+            "  public Builder test(java.lang.Float test) {\n" +
+            "    if (test == null) {\n" +
+            "      return this;\n" +
+            "    }\n" +
+            "    if (this.mTestResTypeWithVarArgsImpl.arg0 == null) {\n" +
+            "      this.mTestResTypeWithVarArgsImpl.arg0 = new java.util.ArrayList<java.lang.Float>();\n" +
+            "    }\n" +
+            "    this.mTestResTypeWithVarArgsImpl.arg0.add(test);\n" +
+            "    mRequired.set(0);\n" +
+            "    return this;\n" +
+            "  }\n" +
+            "\n" +
+            "  public Builder testPx(@android.support.annotation.Px float test) {\n" +
+            "    if (this.mTestResTypeWithVarArgsImpl.arg0 == null) {\n" +
+            "      this.mTestResTypeWithVarArgsImpl.arg0 = new java.util.ArrayList<java.lang.Float>();\n" +
+            "    }\n" +
+            "    final float res = test;\n" +
+            "    this.mTestResTypeWithVarArgsImpl.arg0.add(res);\n" +
+            "    mRequired.set(0);\n" +
+            "    return this;\n" +
+            "  }\n" +
+            "\n" +
+            "  public Builder arg0Px(java.util.List<java.lang.Float> arg0) {\n" +
+            "    if (arg0 == null) {\n" +
+            "      return this;\n" +
+            "    }\n" +
+            "    if (this.mTestResTypeWithVarArgsImpl.arg0 == null) {\n" +
+            "      this.mTestResTypeWithVarArgsImpl.arg0 = new java.util.ArrayList<java.lang.Float>();\n" +
+            "    }\n" +
+            "    for (int i = 0; i < arg0.size(); i++) {\n" +
+            "      final float res = arg0.get(i);\n" +
+            "      this.mTestResTypeWithVarArgsImpl.arg0.add(res);\n" +
+            "    }\n" +
+            "    mRequired.set(0);\n" +
+            "    return this;\n" +
+            "  }\n" +
+            "\n" +
+            "  public Builder testRes(@android.support.annotation.DimenRes int resId) {\n" +
+            "    if (this.mTestResTypeWithVarArgsImpl.arg0 == null) {\n" +
+            "      this.mTestResTypeWithVarArgsImpl.arg0 = new java.util.ArrayList<java.lang.Float>();\n" +
+            "    }\n" +
+            "    final float res = resolveDimenSizeRes(resId);\n" +
+            "    this.mTestResTypeWithVarArgsImpl.arg0.add(res);\n" +
+            "    mRequired.set(0);\n" +
+            "    return this;\n" +
+            "  }\n" +
+            "\n" +
+            "  public Builder arg0Res(java.util.List<java.lang.Integer> resIds) {\n" +
+            "    if (resIds == null) {\n" +
+            "      return this;\n" +
+            "    }\n" +
+            "    if (this.mTestResTypeWithVarArgsImpl.arg0 == null) {\n" +
+            "      this.mTestResTypeWithVarArgsImpl.arg0 = new java.util.ArrayList<java.lang.Float>();\n" +
+            "    }\n" +
+            "    for (int i = 0; i < resIds.size(); i++) {\n" +
+            "      final float res = resolveDimenSizeRes(resIds.get(i));\n" +
+            "      this.mTestResTypeWithVarArgsImpl.arg0.add(res);\n" +
+            "    }\n" +
+            "    mRequired.set(0);\n" +
+            "    return this;\n" +
+            "  }\n" +
+            "\n" +
+            "  public Builder testAttr(@android.support.annotation.AttrRes int attrResId,\n" +
+            "      @android.support.annotation.DimenRes int defResId) {\n" +
+            "    if (this.mTestResTypeWithVarArgsImpl.arg0 == null) {\n" +
+            "      this.mTestResTypeWithVarArgsImpl.arg0 = new java.util.ArrayList<java.lang.Float>();\n" +
+            "    }\n" +
+            "    final float res = resolveDimenSizeAttr(attrResId, defResId);\n" +
+            "    this.mTestResTypeWithVarArgsImpl.arg0.add(res);\n" +
+            "    mRequired.set(0);\n" +
+            "    return this;\n" +
+            "  }\n" +
+            "\n" +
+            "  public Builder testAttr(@android.support.annotation.AttrRes int attrResId) {\n" +
+            "    if (this.mTestResTypeWithVarArgsImpl.arg0 == null) {\n" +
+            "      this.mTestResTypeWithVarArgsImpl.arg0 = new java.util.ArrayList<java.lang.Float>();\n" +
+            "    }\n" +
+            "    final float res = resolveDimenSizeAttr(attrResId, 0);\n" +
+            "    this.mTestResTypeWithVarArgsImpl.arg0.add(res);\n" +
+            "    mRequired.set(0);\n" +
+            "    return this;\n" +
+            "  }\n" +
+            "\n" +
+            "  public Builder arg0Attr(java.util.List<java.lang.Integer> attrResIds,\n" +
+            "      @android.support.annotation.DimenRes int defResId) {\n" +
+            "    if (attrResIds == null) {\n" +
+            "      return this;\n" +
+            "    }\n" +
+            "    if (this.mTestResTypeWithVarArgsImpl.arg0 == null) {\n" +
+            "      this.mTestResTypeWithVarArgsImpl.arg0 = new java.util.ArrayList<java.lang.Float>();\n" +
+            "    }\n" +
+            "    for (int i = 0; i < attrResIds.size(); i++) {\n" +
+            "      final float res = resolveDimenSizeAttr(attrResIds.get(i), defResId);\n" +
+            "      this.mTestResTypeWithVarArgsImpl.arg0.add(res);\n" +
+            "    }\n" +
+            "    mRequired.set(0);\n" +
+            "    return this;\n" +
+            "  }\n" +
+            "\n" +
+            "  public Builder arg0Attr(java.util.List<java.lang.Integer> attrResIds) {\n" +
+            "    if (attrResIds == null) {\n" +
+            "      return this;\n" +
+            "    }\n" +
+            "    if (this.mTestResTypeWithVarArgsImpl.arg0 == null) {\n" +
+            "      this.mTestResTypeWithVarArgsImpl.arg0 = new java.util.ArrayList<java.lang.Float>();\n" +
+            "    }\n" +
+            "    for (int i = 0; i < attrResIds.size(); i++) {\n" +
+            "      final float res = resolveDimenSizeAttr(attrResIds.get(i), 0);\n" +
+            "      this.mTestResTypeWithVarArgsImpl.arg0.add(res);\n" +
+            "    }\n" +
+            "    mRequired.set(0);\n" +
+            "    return this;\n" +
+            "  }\n" +
+            "\n" +
+            "  public Builder testDip(@android.support.annotation.Dimension(unit = android.support.annotation.Dimension.DP) float dip) {\n" +
+            "    if (this.mTestResTypeWithVarArgsImpl.arg0 == null) {\n" +
+            "      this.mTestResTypeWithVarArgsImpl.arg0 = new java.util.ArrayList<java.lang.Float>();\n" +
+            "    }\n" +
+            "    final float res = dipsToPixels(dip);\n" +
+            "    this.mTestResTypeWithVarArgsImpl.arg0.add(res);\n" +
+            "    mRequired.set(0);\n" +
+            "    return this;\n" +
+            "  }\n" +
+            "\n" +
+            "  public Builder arg0Dip(java.util.List<java.lang.Float> dips) {\n" +
+            "    if (dips == null) {\n" +
+            "      return this;\n" +
+            "    }\n" +
+            "    if (this.mTestResTypeWithVarArgsImpl.arg0 == null) {\n" +
+            "      this.mTestResTypeWithVarArgsImpl.arg0 = new java.util.ArrayList<java.lang.Float>();\n" +
+            "    }\n" +
+            "    for (int i = 0; i < dips.size(); i++) {\n" +
+            "      final float res = dipsToPixels(dips.get(i));\n" +
+            "      this.mTestResTypeWithVarArgsImpl.arg0.add(res);\n" +
+            "    }\n" +
+            "    mRequired.set(0);\n" +
+            "    return this;\n" +
+            "  }\n" +
+            "\n" +
+            "  public Builder testSp(@android.support.annotation.Dimension(unit = android.support.annotation.Dimension.SP) float sip) {\n" +
+            "    if (this.mTestResTypeWithVarArgsImpl.arg0 == null) {\n" +
+            "      this.mTestResTypeWithVarArgsImpl.arg0 = new java.util.ArrayList<java.lang.Float>();\n" +
+            "    }\n" +
+            "    final float res = sipsToPixels(sip);\n" +
+            "    this.mTestResTypeWithVarArgsImpl.arg0.add(res);\n" +
+            "    mRequired.set(0);\n" +
+            "    return this;\n" +
+            "  }\n" +
+            "\n" +
+            "  public Builder arg0Sp(java.util.List<java.lang.Float> sips) {\n" +
+            "    if (sips == null) {\n" +
+            "      return this;\n" +
+            "    }\n" +
+            "    if (this.mTestResTypeWithVarArgsImpl.arg0 == null) {\n" +
+            "      this.mTestResTypeWithVarArgsImpl.arg0 = new java.util.ArrayList<java.lang.Float>();\n" +
+            "    }\n" +
+            "    for (int i = 0; i < sips.size(); i++) {\n" +
+            "      final float res = sipsToPixels(sips.get(i));\n" +
+            "      this.mTestResTypeWithVarArgsImpl.arg0.add(res);\n" +
+            "    }\n" +
+            "    mRequired.set(0);\n" +
+            "    return this;\n" +
+            "  }\n" +
+            "\n" +
+            "  @java.lang.Override\n" +
+            "  public Builder getThis() {\n" +
+            "    return this;\n" +
+            "  }\n" +
+            "\n" +
+            "  @java.lang.Override\n" +
+            "  public com.facebook.litho.Component<com.facebook.litho.specmodels.generator.BuilderGeneratorTest.TestResTypeWithVarArgs> build() {\n" +
+            "    checkArgs(REQUIRED_PROPS_COUNT, mRequired, REQUIRED_PROPS_NAMES);\n" +
+            "    TestResTypeWithVarArgsImpl testResTypeWithVarArgsImpl = mTestResTypeWithVarArgsImpl;\n" +
+            "    release();\n" +
+            "    return testResTypeWithVarArgsImpl;\n" +
+            "  }\n" +
+            "\n" +
+            "  @java.lang.Override\n" +
+            "  protected void release() {\n" +
+            "    super.release();\n" +
+            "    mTestResTypeWithVarArgsImpl = null;\n" +
+            "    mContext = null;\n" +
+            "    sBuilderPool.release(this);\n" +
+            "  }\n" +
+            "}\n");
   }
 }

--- a/litho-it/src/test/java/com/facebook/litho/specmodels/generator/BuilderGeneratorTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/specmodels/generator/BuilderGeneratorTest.java
@@ -233,18 +233,6 @@ public class BuilderGeneratorTest {
             "    mRequired.clear();\n" +
             "  }\n" +
             "\n" +
-            "  public Builder size(java.lang.Float size) {\n" +
-            "    if (size == null) {\n" +
-            "      return this;\n" +
-            "    }\n" +
-            "    if (this.mTestResTypeWithVarArgsImpl.sizes == null) {\n" +
-            "      this.mTestResTypeWithVarArgsImpl.sizes = new java.util.ArrayList<java.lang.Float>();\n" +
-            "    }\n" +
-            "    this.mTestResTypeWithVarArgsImpl.sizes.add(size);\n" +
-            "    mRequired.set(0);\n" +
-            "    return this;\n" +
-            "  }\n" +
-            "\n" +
             "  public Builder sizePx(@android.support.annotation.Px float size) {\n" +
             "    if (this.mTestResTypeWithVarArgsImpl.sizes == null) {\n" +
             "      this.mTestResTypeWithVarArgsImpl.sizes = new java.util.ArrayList<java.lang.Float>();\n" +

--- a/litho-it/src/test/java/com/facebook/litho/specmodels/generator/BuilderGeneratorTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/specmodels/generator/BuilderGeneratorTest.java
@@ -69,17 +69,28 @@ public class BuilderGeneratorTest {
     public void resTypeWithVarArgs(@Prop(varArg = "size", resType = ResType.DIMEN_TEXT) List<Float> sizes) {}
   }
 
+  @LayoutSpec
+  static class TestDimenResTypeWithBoxFloatArgSpec {
+    @OnCreateLayout
+    public void dimenResTypeWithBoxFloatArg(@Prop(resType = ResType.DIMEN_TEXT) Float size) {}
+  }
+
   private SpecModel mSpecModel;
   private SpecModel mResTypeVarArgsSpecModel;
+  private SpecModel mDimenResTypeWithBoxFloatArgSpecModel;
 
   @Before
   public void setUp() {
     Elements elements = mCompilationRule.getElements();
+
     TypeElement typeElement = elements.getTypeElement(TestSpec.class.getCanonicalName());
     mSpecModel = mLayoutSpecModelFactory.create(elements, typeElement, null);
 
     TypeElement resWithVarArgsElement = elements.getTypeElement(TestResTypeWithVarArgsSpec.class.getCanonicalName());
     mResTypeVarArgsSpecModel = mLayoutSpecModelFactory.create(elements, resWithVarArgsElement, null);
+
+    TypeElement dimenResTypeWithBoxFloatArgElement = elements.getTypeElement(TestDimenResTypeWithBoxFloatArgSpec.class.getCanonicalName());
+    mDimenResTypeWithBoxFloatArgSpecModel = mLayoutSpecModelFactory.create(elements, dimenResTypeWithBoxFloatArgElement, null);
   }
 
   @Test
@@ -403,6 +414,91 @@ public class BuilderGeneratorTest {
             "  protected void release() {\n" +
             "    super.release();\n" +
             "    mTestResTypeWithVarArgsImpl = null;\n" +
+            "    mContext = null;\n" +
+            "    sBuilderPool.release(this);\n" +
+            "  }\n" +
+            "}\n");
+  }
+
+  @Test
+  public void testDimenResTypeWithBoxFloatArgSpecModel() {
+    TypeSpecDataHolder dataHolder = BuilderGenerator.generate(mDimenResTypeWithBoxFloatArgSpecModel);
+    assertThat(dataHolder.getTypeSpecs()).hasSize(1);
+    assertThat(dataHolder.getTypeSpecs().get(0).toString())
+        .isEqualTo(
+            "public static class Builder extends com.facebook.litho.Component.Builder<com.facebook.litho.specmodels.generator.BuilderGeneratorTest.TestDimenResTypeWithBoxFloatArg, Builder> {\n" +
+            "  private static final java.lang.String[] REQUIRED_PROPS_NAMES = new String[] {\"size\"};\n" +
+            "\n" +
+            "  private static final int REQUIRED_PROPS_COUNT = 1;\n" +
+            "\n" +
+            "  TestDimenResTypeWithBoxFloatArgImpl mTestDimenResTypeWithBoxFloatArgImpl;\n" +
+            "\n" +
+            "  com.facebook.litho.ComponentContext mContext;\n" +
+            "\n" +
+            "  private java.util.BitSet mRequired = new java.util.BitSet(REQUIRED_PROPS_COUNT);\n" +
+            "\n" +
+            "  private void init(com.facebook.litho.ComponentContext context, int defStyleAttr, int defStyleRes,\n" +
+            "      TestDimenResTypeWithBoxFloatArgImpl testDimenResTypeWithBoxFloatArgImpl) {\n" +
+            "    super.init(context, defStyleAttr, defStyleRes, testDimenResTypeWithBoxFloatArgImpl);\n" +
+            "    mTestDimenResTypeWithBoxFloatArgImpl = testDimenResTypeWithBoxFloatArgImpl;\n" +
+            "    mContext = context;\n" +
+            "    mRequired.clear();\n" +
+            "  }\n" +
+            "\n" +
+            "  public Builder sizePx(@android.support.annotation.Px float size) {\n" +
+            "    this.mTestDimenResTypeWithBoxFloatArgImpl.size = size;\n" +
+            "    mRequired.set(0);\n" +
+            "    return this;\n" +
+            "  }\n" +
+            "\n" +
+            "  public Builder sizeRes(@android.support.annotation.DimenRes int resId) {\n" +
+            "    this.mTestDimenResTypeWithBoxFloatArgImpl.size = (float) resolveDimenSizeRes(resId);\n" +
+            "    mRequired.set(0);\n" +
+            "    return this;\n" +
+            "  }\n" +
+            "\n" +
+            "  public Builder sizeAttr(@android.support.annotation.AttrRes int attrResId,\n" +
+            "      @android.support.annotation.DimenRes int defResId) {\n" +
+            "    this.mTestDimenResTypeWithBoxFloatArgImpl.size = (float) resolveDimenSizeAttr(attrResId, defResId);\n" +
+            "    mRequired.set(0);\n" +
+            "    return this;\n" +
+            "  }\n" +
+            "\n" +
+            "  public Builder sizeAttr(@android.support.annotation.AttrRes int attrResId) {\n" +
+            "    this.mTestDimenResTypeWithBoxFloatArgImpl.size = (float) resolveDimenSizeAttr(attrResId, 0);\n" +
+            "    mRequired.set(0);\n" +
+            "    return this;\n" +
+            "  }\n" +
+            "\n" +
+            "  public Builder sizeDip(@android.support.annotation.Dimension(unit = android.support.annotation.Dimension.DP) float dip) {\n" +
+            "    this.mTestDimenResTypeWithBoxFloatArgImpl.size = (float) dipsToPixels(dip);\n" +
+            "    mRequired.set(0);\n" +
+            "    return this;\n" +
+            "  }\n" +
+            "\n" +
+            "  public Builder sizeSp(@android.support.annotation.Dimension(unit = android.support.annotation.Dimension.SP) float sip) {\n" +
+            "    this.mTestDimenResTypeWithBoxFloatArgImpl.size = (float) sipsToPixels(sip);\n" +
+            "    mRequired.set(0);\n" +
+            "    return this;\n" +
+            "  }\n" +
+            "\n" +
+            "  @java.lang.Override\n" +
+            "  public Builder getThis() {\n" +
+            "    return this;\n" +
+            "  }\n" +
+            "\n" +
+            "  @java.lang.Override\n" +
+            "  public com.facebook.litho.Component<com.facebook.litho.specmodels.generator.BuilderGeneratorTest.TestDimenResTypeWithBoxFloatArg> build() {\n" +
+            "    checkArgs(REQUIRED_PROPS_COUNT, mRequired, REQUIRED_PROPS_NAMES);\n" +
+            "    TestDimenResTypeWithBoxFloatArgImpl testDimenResTypeWithBoxFloatArgImpl = mTestDimenResTypeWithBoxFloatArgImpl;\n" +
+            "    release();\n" +
+            "    return testDimenResTypeWithBoxFloatArgImpl;\n" +
+            "  }\n" +
+            "\n" +
+            "  @java.lang.Override\n" +
+            "  protected void release() {\n" +
+            "    super.release();\n" +
+            "    mTestDimenResTypeWithBoxFloatArgImpl = null;\n" +
             "    mContext = null;\n" +
             "    sBuilderPool.release(this);\n" +
             "  }\n" +

--- a/litho-it/src/test/java/com/facebook/litho/specmodels/generator/BuilderGeneratorTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/specmodels/generator/BuilderGeneratorTest.java
@@ -66,11 +66,11 @@ public class BuilderGeneratorTest {
   @LayoutSpec
   static class TestResTypeWithVarArgsSpec {
     @OnCreateLayout
-    public void test(@Prop(varArg = "test", resType = ResType.DIMEN_TEXT) List<Float> arg0) {}
+    public void resTypeWithVarArgs(@Prop(varArg = "size", resType = ResType.DIMEN_TEXT) List<Float> sizes) {}
   }
 
   private SpecModel mSpecModel;
-  private SpecModel mSpecModel1;
+  private SpecModel mResTypeVarArgsSpecModel;
 
   @Before
   public void setUp() {
@@ -78,8 +78,8 @@ public class BuilderGeneratorTest {
     TypeElement typeElement = elements.getTypeElement(TestSpec.class.getCanonicalName());
     mSpecModel = mLayoutSpecModelFactory.create(elements, typeElement, null);
 
-    TypeElement typeElement1 = elements.getTypeElement(TestResTypeWithVarArgsSpec.class.getCanonicalName());
-    mSpecModel1 = mLayoutSpecModelFactory.create(elements, typeElement1, null);
+    TypeElement resWithVarArgsElement = elements.getTypeElement(TestResTypeWithVarArgsSpec.class.getCanonicalName());
+    mResTypeVarArgsSpecModel = mLayoutSpecModelFactory.create(elements, resWithVarArgsElement, null);
   }
 
   @Test
@@ -199,12 +199,12 @@ public class BuilderGeneratorTest {
 
   @Test
   public void testResTypeWithVarArgs() {
-    TypeSpecDataHolder dataHolder = BuilderGenerator.generate(mSpecModel1);
+    TypeSpecDataHolder dataHolder = BuilderGenerator.generate(mResTypeVarArgsSpecModel);
     assertThat(dataHolder.getTypeSpecs()).hasSize(1);
     assertThat(dataHolder.getTypeSpecs().get(0).toString())
         .isEqualTo(
             "public static class Builder extends com.facebook.litho.Component.Builder<com.facebook.litho.specmodels.generator.BuilderGeneratorTest.TestResTypeWithVarArgs, Builder> {\n" +
-            "  private static final java.lang.String[] REQUIRED_PROPS_NAMES = new String[] {\"arg0\"};\n" +
+            "  private static final java.lang.String[] REQUIRED_PROPS_NAMES = new String[] {\"sizes\"};\n" +
             "\n" +
             "  private static final int REQUIRED_PROPS_COUNT = 1;\n" +
             "\n" +
@@ -222,165 +222,165 @@ public class BuilderGeneratorTest {
             "    mRequired.clear();\n" +
             "  }\n" +
             "\n" +
-            "  public Builder test(java.lang.Float test) {\n" +
-            "    if (test == null) {\n" +
+            "  public Builder size(java.lang.Float size) {\n" +
+            "    if (size == null) {\n" +
             "      return this;\n" +
             "    }\n" +
-            "    if (this.mTestResTypeWithVarArgsImpl.arg0 == null) {\n" +
-            "      this.mTestResTypeWithVarArgsImpl.arg0 = new java.util.ArrayList<java.lang.Float>();\n" +
+            "    if (this.mTestResTypeWithVarArgsImpl.sizes == null) {\n" +
+            "      this.mTestResTypeWithVarArgsImpl.sizes = new java.util.ArrayList<java.lang.Float>();\n" +
             "    }\n" +
-            "    this.mTestResTypeWithVarArgsImpl.arg0.add(test);\n" +
+            "    this.mTestResTypeWithVarArgsImpl.sizes.add(size);\n" +
             "    mRequired.set(0);\n" +
             "    return this;\n" +
             "  }\n" +
             "\n" +
-            "  public Builder testPx(@android.support.annotation.Px float test) {\n" +
-            "    if (this.mTestResTypeWithVarArgsImpl.arg0 == null) {\n" +
-            "      this.mTestResTypeWithVarArgsImpl.arg0 = new java.util.ArrayList<java.lang.Float>();\n" +
+            "  public Builder sizePx(@android.support.annotation.Px float size) {\n" +
+            "    if (this.mTestResTypeWithVarArgsImpl.sizes == null) {\n" +
+            "      this.mTestResTypeWithVarArgsImpl.sizes = new java.util.ArrayList<java.lang.Float>();\n" +
             "    }\n" +
-            "    final float res = test;\n" +
-            "    this.mTestResTypeWithVarArgsImpl.arg0.add(res);\n" +
+            "    final float res = size;\n" +
+            "    this.mTestResTypeWithVarArgsImpl.sizes.add(res);\n" +
             "    mRequired.set(0);\n" +
             "    return this;\n" +
             "  }\n" +
             "\n" +
-            "  public Builder arg0Px(java.util.List<java.lang.Float> arg0) {\n" +
-            "    if (arg0 == null) {\n" +
+            "  public Builder sizesPx(java.util.List<java.lang.Float> sizes) {\n" +
+            "    if (sizes == null) {\n" +
             "      return this;\n" +
             "    }\n" +
-            "    if (this.mTestResTypeWithVarArgsImpl.arg0 == null) {\n" +
-            "      this.mTestResTypeWithVarArgsImpl.arg0 = new java.util.ArrayList<java.lang.Float>();\n" +
+            "    if (this.mTestResTypeWithVarArgsImpl.sizes == null) {\n" +
+            "      this.mTestResTypeWithVarArgsImpl.sizes = new java.util.ArrayList<java.lang.Float>();\n" +
             "    }\n" +
-            "    for (int i = 0; i < arg0.size(); i++) {\n" +
-            "      final float res = arg0.get(i);\n" +
-            "      this.mTestResTypeWithVarArgsImpl.arg0.add(res);\n" +
+            "    for (int i = 0; i < sizes.size(); i++) {\n" +
+            "      final float res = sizes.get(i);\n" +
+            "      this.mTestResTypeWithVarArgsImpl.sizes.add(res);\n" +
             "    }\n" +
             "    mRequired.set(0);\n" +
             "    return this;\n" +
             "  }\n" +
             "\n" +
-            "  public Builder testRes(@android.support.annotation.DimenRes int resId) {\n" +
-            "    if (this.mTestResTypeWithVarArgsImpl.arg0 == null) {\n" +
-            "      this.mTestResTypeWithVarArgsImpl.arg0 = new java.util.ArrayList<java.lang.Float>();\n" +
+            "  public Builder sizeRes(@android.support.annotation.DimenRes int resId) {\n" +
+            "    if (this.mTestResTypeWithVarArgsImpl.sizes == null) {\n" +
+            "      this.mTestResTypeWithVarArgsImpl.sizes = new java.util.ArrayList<java.lang.Float>();\n" +
             "    }\n" +
             "    final float res = resolveDimenSizeRes(resId);\n" +
-            "    this.mTestResTypeWithVarArgsImpl.arg0.add(res);\n" +
+            "    this.mTestResTypeWithVarArgsImpl.sizes.add(res);\n" +
             "    mRequired.set(0);\n" +
             "    return this;\n" +
             "  }\n" +
             "\n" +
-            "  public Builder arg0Res(java.util.List<java.lang.Integer> resIds) {\n" +
+            "  public Builder sizesRes(java.util.List<java.lang.Integer> resIds) {\n" +
             "    if (resIds == null) {\n" +
             "      return this;\n" +
             "    }\n" +
-            "    if (this.mTestResTypeWithVarArgsImpl.arg0 == null) {\n" +
-            "      this.mTestResTypeWithVarArgsImpl.arg0 = new java.util.ArrayList<java.lang.Float>();\n" +
+            "    if (this.mTestResTypeWithVarArgsImpl.sizes == null) {\n" +
+            "      this.mTestResTypeWithVarArgsImpl.sizes = new java.util.ArrayList<java.lang.Float>();\n" +
             "    }\n" +
             "    for (int i = 0; i < resIds.size(); i++) {\n" +
             "      final float res = resolveDimenSizeRes(resIds.get(i));\n" +
-            "      this.mTestResTypeWithVarArgsImpl.arg0.add(res);\n" +
+            "      this.mTestResTypeWithVarArgsImpl.sizes.add(res);\n" +
             "    }\n" +
             "    mRequired.set(0);\n" +
             "    return this;\n" +
             "  }\n" +
             "\n" +
-            "  public Builder testAttr(@android.support.annotation.AttrRes int attrResId,\n" +
+            "  public Builder sizeAttr(@android.support.annotation.AttrRes int attrResId,\n" +
             "      @android.support.annotation.DimenRes int defResId) {\n" +
-            "    if (this.mTestResTypeWithVarArgsImpl.arg0 == null) {\n" +
-            "      this.mTestResTypeWithVarArgsImpl.arg0 = new java.util.ArrayList<java.lang.Float>();\n" +
+            "    if (this.mTestResTypeWithVarArgsImpl.sizes == null) {\n" +
+            "      this.mTestResTypeWithVarArgsImpl.sizes = new java.util.ArrayList<java.lang.Float>();\n" +
             "    }\n" +
             "    final float res = resolveDimenSizeAttr(attrResId, defResId);\n" +
-            "    this.mTestResTypeWithVarArgsImpl.arg0.add(res);\n" +
+            "    this.mTestResTypeWithVarArgsImpl.sizes.add(res);\n" +
             "    mRequired.set(0);\n" +
             "    return this;\n" +
             "  }\n" +
             "\n" +
-            "  public Builder testAttr(@android.support.annotation.AttrRes int attrResId) {\n" +
-            "    if (this.mTestResTypeWithVarArgsImpl.arg0 == null) {\n" +
-            "      this.mTestResTypeWithVarArgsImpl.arg0 = new java.util.ArrayList<java.lang.Float>();\n" +
+            "  public Builder sizeAttr(@android.support.annotation.AttrRes int attrResId) {\n" +
+            "    if (this.mTestResTypeWithVarArgsImpl.sizes == null) {\n" +
+            "      this.mTestResTypeWithVarArgsImpl.sizes = new java.util.ArrayList<java.lang.Float>();\n" +
             "    }\n" +
             "    final float res = resolveDimenSizeAttr(attrResId, 0);\n" +
-            "    this.mTestResTypeWithVarArgsImpl.arg0.add(res);\n" +
+            "    this.mTestResTypeWithVarArgsImpl.sizes.add(res);\n" +
             "    mRequired.set(0);\n" +
             "    return this;\n" +
             "  }\n" +
             "\n" +
-            "  public Builder arg0Attr(java.util.List<java.lang.Integer> attrResIds,\n" +
+            "  public Builder sizesAttr(java.util.List<java.lang.Integer> attrResIds,\n" +
             "      @android.support.annotation.DimenRes int defResId) {\n" +
             "    if (attrResIds == null) {\n" +
             "      return this;\n" +
             "    }\n" +
-            "    if (this.mTestResTypeWithVarArgsImpl.arg0 == null) {\n" +
-            "      this.mTestResTypeWithVarArgsImpl.arg0 = new java.util.ArrayList<java.lang.Float>();\n" +
+            "    if (this.mTestResTypeWithVarArgsImpl.sizes == null) {\n" +
+            "      this.mTestResTypeWithVarArgsImpl.sizes = new java.util.ArrayList<java.lang.Float>();\n" +
             "    }\n" +
             "    for (int i = 0; i < attrResIds.size(); i++) {\n" +
             "      final float res = resolveDimenSizeAttr(attrResIds.get(i), defResId);\n" +
-            "      this.mTestResTypeWithVarArgsImpl.arg0.add(res);\n" +
+            "      this.mTestResTypeWithVarArgsImpl.sizes.add(res);\n" +
             "    }\n" +
             "    mRequired.set(0);\n" +
             "    return this;\n" +
             "  }\n" +
             "\n" +
-            "  public Builder arg0Attr(java.util.List<java.lang.Integer> attrResIds) {\n" +
+            "  public Builder sizesAttr(java.util.List<java.lang.Integer> attrResIds) {\n" +
             "    if (attrResIds == null) {\n" +
             "      return this;\n" +
             "    }\n" +
-            "    if (this.mTestResTypeWithVarArgsImpl.arg0 == null) {\n" +
-            "      this.mTestResTypeWithVarArgsImpl.arg0 = new java.util.ArrayList<java.lang.Float>();\n" +
+            "    if (this.mTestResTypeWithVarArgsImpl.sizes == null) {\n" +
+            "      this.mTestResTypeWithVarArgsImpl.sizes = new java.util.ArrayList<java.lang.Float>();\n" +
             "    }\n" +
             "    for (int i = 0; i < attrResIds.size(); i++) {\n" +
             "      final float res = resolveDimenSizeAttr(attrResIds.get(i), 0);\n" +
-            "      this.mTestResTypeWithVarArgsImpl.arg0.add(res);\n" +
+            "      this.mTestResTypeWithVarArgsImpl.sizes.add(res);\n" +
             "    }\n" +
             "    mRequired.set(0);\n" +
             "    return this;\n" +
             "  }\n" +
             "\n" +
-            "  public Builder testDip(@android.support.annotation.Dimension(unit = android.support.annotation.Dimension.DP) float dip) {\n" +
-            "    if (this.mTestResTypeWithVarArgsImpl.arg0 == null) {\n" +
-            "      this.mTestResTypeWithVarArgsImpl.arg0 = new java.util.ArrayList<java.lang.Float>();\n" +
+            "  public Builder sizeDip(@android.support.annotation.Dimension(unit = android.support.annotation.Dimension.DP) float dip) {\n" +
+            "    if (this.mTestResTypeWithVarArgsImpl.sizes == null) {\n" +
+            "      this.mTestResTypeWithVarArgsImpl.sizes = new java.util.ArrayList<java.lang.Float>();\n" +
             "    }\n" +
             "    final float res = dipsToPixels(dip);\n" +
-            "    this.mTestResTypeWithVarArgsImpl.arg0.add(res);\n" +
+            "    this.mTestResTypeWithVarArgsImpl.sizes.add(res);\n" +
             "    mRequired.set(0);\n" +
             "    return this;\n" +
             "  }\n" +
             "\n" +
-            "  public Builder arg0Dip(java.util.List<java.lang.Float> dips) {\n" +
+            "  public Builder sizesDip(java.util.List<java.lang.Float> dips) {\n" +
             "    if (dips == null) {\n" +
             "      return this;\n" +
             "    }\n" +
-            "    if (this.mTestResTypeWithVarArgsImpl.arg0 == null) {\n" +
-            "      this.mTestResTypeWithVarArgsImpl.arg0 = new java.util.ArrayList<java.lang.Float>();\n" +
+            "    if (this.mTestResTypeWithVarArgsImpl.sizes == null) {\n" +
+            "      this.mTestResTypeWithVarArgsImpl.sizes = new java.util.ArrayList<java.lang.Float>();\n" +
             "    }\n" +
             "    for (int i = 0; i < dips.size(); i++) {\n" +
             "      final float res = dipsToPixels(dips.get(i));\n" +
-            "      this.mTestResTypeWithVarArgsImpl.arg0.add(res);\n" +
+            "      this.mTestResTypeWithVarArgsImpl.sizes.add(res);\n" +
             "    }\n" +
             "    mRequired.set(0);\n" +
             "    return this;\n" +
             "  }\n" +
             "\n" +
-            "  public Builder testSp(@android.support.annotation.Dimension(unit = android.support.annotation.Dimension.SP) float sip) {\n" +
-            "    if (this.mTestResTypeWithVarArgsImpl.arg0 == null) {\n" +
-            "      this.mTestResTypeWithVarArgsImpl.arg0 = new java.util.ArrayList<java.lang.Float>();\n" +
+            "  public Builder sizeSp(@android.support.annotation.Dimension(unit = android.support.annotation.Dimension.SP) float sip) {\n" +
+            "    if (this.mTestResTypeWithVarArgsImpl.sizes == null) {\n" +
+            "      this.mTestResTypeWithVarArgsImpl.sizes = new java.util.ArrayList<java.lang.Float>();\n" +
             "    }\n" +
             "    final float res = sipsToPixels(sip);\n" +
-            "    this.mTestResTypeWithVarArgsImpl.arg0.add(res);\n" +
+            "    this.mTestResTypeWithVarArgsImpl.sizes.add(res);\n" +
             "    mRequired.set(0);\n" +
             "    return this;\n" +
             "  }\n" +
             "\n" +
-            "  public Builder arg0Sp(java.util.List<java.lang.Float> sips) {\n" +
+            "  public Builder sizesSp(java.util.List<java.lang.Float> sips) {\n" +
             "    if (sips == null) {\n" +
             "      return this;\n" +
             "    }\n" +
-            "    if (this.mTestResTypeWithVarArgsImpl.arg0 == null) {\n" +
-            "      this.mTestResTypeWithVarArgsImpl.arg0 = new java.util.ArrayList<java.lang.Float>();\n" +
+            "    if (this.mTestResTypeWithVarArgsImpl.sizes == null) {\n" +
+            "      this.mTestResTypeWithVarArgsImpl.sizes = new java.util.ArrayList<java.lang.Float>();\n" +
             "    }\n" +
             "    for (int i = 0; i < sips.size(); i++) {\n" +
             "      final float res = sipsToPixels(sips.get(i));\n" +
-            "      this.mTestResTypeWithVarArgsImpl.arg0.add(res);\n" +
+            "      this.mTestResTypeWithVarArgsImpl.sizes.add(res);\n" +
             "    }\n" +
             "    mRequired.set(0);\n" +
             "    return this;\n" +

--- a/litho-it/src/test/java/com/facebook/litho/specmodels/model/PropValidationTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/specmodels/model/PropValidationTest.java
@@ -219,7 +219,7 @@ public class PropValidationTest {
     assertThat(validationErrors).hasSize(1);
     assertThat(validationErrors.get(0).element).isEqualTo(mRepresentedObject1);
     assertThat(validationErrors.get(0).message).isEqualTo(
-        "A prop declared with resType BOOL must be one of the following types: " +
+        "A variable argument declared with resType BOOL must be one of the following types: " +
             "[java.util.List<java.lang.Boolean>].");
   }
 

--- a/litho-it/src/test/java/com/facebook/litho/specmodels/model/PropValidationTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/specmodels/model/PropValidationTest.java
@@ -210,6 +210,20 @@ public class PropValidationTest {
   }
 
   @Test
+  public void testIncorrectTypeForResTypeWithVarArg() {
+    when(mPropModel1.getResType()).thenReturn(ResType.BOOL);
+    when(mPropModel1.hasVarArgs()).thenReturn(true);
+    when(mPropModel1.getType()).thenReturn(ParameterizedTypeName.get(ClassNames.LIST, TypeName.INT.box()));
+
+    List<SpecModelValidationError> validationErrors = PropValidation.validate(mSpecModel, PropValidation.RESERVED_PROP_NAMES);
+    assertThat(validationErrors).hasSize(1);
+    assertThat(validationErrors.get(0).element).isEqualTo(mRepresentedObject1);
+    assertThat(validationErrors.get(0).message).isEqualTo(
+        "A prop declared with resType BOOL must be one of the following types: " +
+            "[java.util.List<java.lang.Boolean>].");
+  }
+
+  @Test
   public void testResTypeDimenMustNotHavePxOrDimensionAnnotations() {
     when(mPropModel1.getResType()).thenReturn(ResType.DIMEN_OFFSET);
     when(mPropModel1.getType()).thenReturn(TypeName.INT);

--- a/litho-it/src/test/resources/processor/TestMount.java
+++ b/litho-it/src/test/resources/processor/TestMount.java
@@ -634,25 +634,29 @@ public final class TestMount<S extends View> extends ComponentLifecycle {
     }
 
     public Builder prop7Res(@StringRes int resId) {
-      this.mTestMountImpl.prop7 = resolveStringRes(resId);
+      final CharSequence res = resolveStringRes(resId);
+      this.mTestMountImpl.prop7 = res;
       mRequired.set(5);
       return this;
     }
 
     public Builder prop7Res(@StringRes int resId, Object... formatArgs) {
-      this.mTestMountImpl.prop7 = resolveStringRes(resId, formatArgs);
+      final CharSequence res = resolveStringRes(resId, formatArgs);
+      this.mTestMountImpl.prop7 = res;
       mRequired.set(5);
       return this;
     }
 
     public Builder prop7Attr(@AttrRes int attrResId, @StringRes int defResId) {
-      this.mTestMountImpl.prop7 = resolveStringAttr(attrResId, defResId);
+      final CharSequence res = resolveStringAttr(attrResId, defResId);
+      this.mTestMountImpl.prop7 = res;
       mRequired.set(5);
       return this;
     }
 
     public Builder prop7Attr(@AttrRes int attrResId) {
-      this.mTestMountImpl.prop7 = resolveStringAttr(attrResId, 0);
+      final CharSequence res = resolveStringAttr(attrResId, 0);
+      this.mTestMountImpl.prop7 = res;
       mRequired.set(5);
       return this;
     }

--- a/litho-it/src/test/resources/processor/TestMount.java
+++ b/litho-it/src/test/resources/processor/TestMount.java
@@ -634,29 +634,25 @@ public final class TestMount<S extends View> extends ComponentLifecycle {
     }
 
     public Builder prop7Res(@StringRes int resId) {
-      final CharSequence res = resolveStringRes(resId);
-      this.mTestMountImpl.prop7 = res;
+      this.mTestMountImpl.prop7 = resolveStringRes(resId);
       mRequired.set(5);
       return this;
     }
 
     public Builder prop7Res(@StringRes int resId, Object... formatArgs) {
-      final CharSequence res = resolveStringRes(resId, formatArgs);
-      this.mTestMountImpl.prop7 = res;
+      this.mTestMountImpl.prop7 = resolveStringRes(resId, formatArgs);
       mRequired.set(5);
       return this;
     }
 
     public Builder prop7Attr(@AttrRes int attrResId, @StringRes int defResId) {
-      final CharSequence res = resolveStringAttr(attrResId, defResId);
-      this.mTestMountImpl.prop7 = res;
+      this.mTestMountImpl.prop7 = resolveStringAttr(attrResId, defResId);
       mRequired.set(5);
       return this;
     }
 
     public Builder prop7Attr(@AttrRes int attrResId) {
-      final CharSequence res = resolveStringAttr(attrResId, 0);
-      this.mTestMountImpl.prop7 = res;
+      this.mTestMountImpl.prop7 = resolveStringAttr(attrResId, 0);
       mRequired.set(5);
       return this;
     }

--- a/litho-processor/src/main/java/com/facebook/litho/specmodels/generator/BuilderGenerator.java
+++ b/litho-processor/src/main/java/com/facebook/litho/specmodels/generator/BuilderGenerator.java
@@ -313,7 +313,8 @@ public class BuilderGenerator {
       PropModel prop,
       int requiredIndex) {
     final TypeSpecDataHolder.Builder dataHolder = TypeSpecDataHolder.newBuilder();
-    if (prop.hasVarArgs()) {
+    final boolean hasVarArgs = prop.hasVarArgs();
+    if (hasVarArgs) {
       dataHolder.addMethod(varArgBuilder(specModel, prop, requiredIndex));
       ParameterizedTypeName type = (ParameterizedTypeName) prop.getType();
       if (getRawType(type.typeArguments.get(0)).equals(ClassNames.COMPONENT)) {
@@ -325,9 +326,9 @@ public class BuilderGenerator {
     switch (prop.getResType()) {
       case STRING:
         dataHolder.addMethod(regularBuilder(specModel, prop, requiredIndex));
-        dataHolder.addMethod(
-            resBuilder(specModel, prop, requiredIndex, ClassNames.STRING_RES, "resolveString"));
-        dataHolder.addMethod(resWithVarargsBuilder(
+        dataHolder.addTypeSpecDataHolder(
+            resBuilders(specModel, prop, requiredIndex, ClassNames.STRING_RES, "resolveString"));
+        dataHolder.addTypeSpecDataHolder(resWithVarargsBuilders(
             specModel,
             prop,
             requiredIndex,
@@ -340,62 +341,64 @@ public class BuilderGenerator {
         break;
       case STRING_ARRAY:
         dataHolder.addMethod(regularBuilder(specModel, prop, requiredIndex));
-        dataHolder.addMethod(
-            resBuilder(specModel, prop, requiredIndex, ClassNames.ARRAY_RES, "resolveStringArray"));
+        dataHolder.addTypeSpecDataHolder(
+            resBuilders(specModel, prop, requiredIndex, ClassNames.ARRAY_RES, "resolveStringArray"));
         dataHolder.addTypeSpecDataHolder(
             attrBuilders(
                 specModel, prop, requiredIndex, ClassNames.ARRAY_RES, "resolveStringArray"));
         break;
       case INT:
         dataHolder.addMethod(regularBuilder(specModel, prop, requiredIndex));
-        dataHolder.addMethod(
-            resBuilder(specModel, prop, requiredIndex, ClassNames.INT_RES, "resolveInt"));
+        dataHolder.addTypeSpecDataHolder(
+            resBuilders(specModel, prop, requiredIndex, ClassNames.INT_RES, "resolveInt"));
         dataHolder.addTypeSpecDataHolder(
             attrBuilders(specModel, prop, requiredIndex, ClassNames.INT_RES, "resolveInt"));
         break;
       case INT_ARRAY:
         dataHolder.addMethod(regularBuilder(specModel, prop, requiredIndex));
-        dataHolder.addMethod(
-            resBuilder(specModel, prop, requiredIndex, ClassNames.ARRAY_RES, "resolveIntArray"));
         dataHolder.addTypeSpecDataHolder(
-            attrBuilders(specModel, prop, requiredIndex, ClassNames.ARRAY_RES, "resolveIntArray"));
+            resBuilders(specModel, prop, requiredIndex, ClassNames.ARRAY_RES,
+                hasVarArgs ? "resolveIntegerArray" : "resolveIntArray"));
+        dataHolder.addTypeSpecDataHolder(
+            attrBuilders(specModel, prop, requiredIndex, ClassNames.ARRAY_RES,
+                hasVarArgs ? "resolveIntegerArray" : "resolveIntArray"));
         break;
       case BOOL:
         dataHolder.addMethod(regularBuilder(specModel, prop, requiredIndex));
-        dataHolder.addMethod(
-            resBuilder(specModel, prop, requiredIndex, ClassNames.BOOL_RES, "resolveBool"));
+        dataHolder.addTypeSpecDataHolder(
+            resBuilders(specModel, prop, requiredIndex, ClassNames.BOOL_RES, "resolveBool"));
         dataHolder.addTypeSpecDataHolder(
             attrBuilders(specModel, prop, requiredIndex, ClassNames.BOOL_RES, "resolveBool"));
         break;
       case COLOR:
         dataHolder.addMethod(
             regularBuilder(specModel, prop, requiredIndex, annotation(ClassNames.COLOR_INT)));
-        dataHolder.addMethod(
-            resBuilder(specModel, prop, requiredIndex, ClassNames.COLOR_RES, "resolveColor"));
+        dataHolder.addTypeSpecDataHolder(
+            resBuilders(specModel, prop, requiredIndex, ClassNames.COLOR_RES, "resolveColor"));
         dataHolder.addTypeSpecDataHolder(
             attrBuilders(specModel, prop, requiredIndex, ClassNames.COLOR_RES, "resolveColor"));
         break;
       case DIMEN_SIZE:
-        dataHolder.addMethod(pxBuilder(specModel, prop, requiredIndex));
-        dataHolder.addMethod(
-            resBuilder(specModel, prop, requiredIndex, ClassNames.DIMEN_RES, "resolveDimenSize"));
+        dataHolder.addTypeSpecDataHolder(pxBuilders(specModel, prop, requiredIndex));
+        dataHolder.addTypeSpecDataHolder(
+            resBuilders(specModel, prop, requiredIndex, ClassNames.DIMEN_RES, "resolveDimenSize"));
         dataHolder.addTypeSpecDataHolder(
             attrBuilders(specModel, prop, requiredIndex, ClassNames.DIMEN_RES, "resolveDimenSize"));
-        dataHolder.addMethod(dipBuilder(specModel, prop, requiredIndex));
+        dataHolder.addTypeSpecDataHolder(dipBuilders(specModel, prop, requiredIndex));
         break;
       case DIMEN_TEXT:
-        dataHolder.addMethod(pxBuilder(specModel, prop, requiredIndex));
-        dataHolder.addMethod(
-            resBuilder(specModel, prop, requiredIndex, ClassNames.DIMEN_RES, "resolveDimenSize"));
+        dataHolder.addTypeSpecDataHolder(pxBuilders(specModel, prop, requiredIndex));
+        dataHolder.addTypeSpecDataHolder(
+            resBuilders(specModel, prop, requiredIndex, ClassNames.DIMEN_RES, "resolveDimenSize"));
         dataHolder.addTypeSpecDataHolder(
             attrBuilders(specModel, prop, requiredIndex, ClassNames.DIMEN_RES, "resolveDimenSize"));
-        dataHolder.addMethod(dipBuilder(specModel, prop, requiredIndex));
-        dataHolder.addMethod(sipBuilder(specModel, prop, requiredIndex));
+        dataHolder.addTypeSpecDataHolder(dipBuilders(specModel, prop, requiredIndex));
+        dataHolder.addTypeSpecDataHolder(sipBuilders(specModel, prop, requiredIndex));
         break;
       case DIMEN_OFFSET:
-        dataHolder.addMethod(pxBuilder(specModel, prop, requiredIndex));
-        dataHolder.addMethod(
-            resBuilder(specModel, prop, requiredIndex, ClassNames.DIMEN_RES, "resolveDimenOffset"));
+        dataHolder.addTypeSpecDataHolder(pxBuilders(specModel, prop, requiredIndex));
+        dataHolder.addTypeSpecDataHolder(
+            resBuilders(specModel, prop, requiredIndex, ClassNames.DIMEN_RES, "resolveDimenOffset"));
         dataHolder.addTypeSpecDataHolder(
             attrBuilders(
                 specModel,
@@ -403,19 +406,19 @@ public class BuilderGenerator {
                 requiredIndex,
                 ClassNames.DIMEN_RES,
                 "resolveDimenOffset"));
-        dataHolder.addMethod(dipBuilder(specModel, prop, requiredIndex));
+        dataHolder.addTypeSpecDataHolder(dipBuilders(specModel, prop, requiredIndex));
         break;
       case FLOAT:
         dataHolder.addMethod(regularBuilder(specModel, prop, requiredIndex));
-        dataHolder.addMethod(
-            resBuilder(specModel, prop, requiredIndex, ClassNames.DIMEN_RES, "resolveFloat"));
+        dataHolder.addTypeSpecDataHolder(
+            resBuilders(specModel, prop, requiredIndex, ClassNames.DIMEN_RES, "resolveFloat"));
         dataHolder.addTypeSpecDataHolder(
             attrBuilders(specModel, prop, requiredIndex, ClassNames.DIMEN_RES, "resolveFloat"));
         break;
       case DRAWABLE:
         dataHolder.addMethod(regularBuilder(specModel, prop, requiredIndex));
-        dataHolder.addMethod(
-            resBuilder(
+        dataHolder.addTypeSpecDataHolder(
+            resBuilders(
                 specModel,
                 prop,
                 requiredIndex,
@@ -491,7 +494,7 @@ public class BuilderGenerator {
       SpecModel specModel,
       PropModel prop,
       int requiredIndex) {
-    return builder(
+    return getMethodSpecBuilder(
         specModel,
         prop,
         requiredIndex,
@@ -499,7 +502,7 @@ public class BuilderGenerator {
         Arrays.asList(parameter(prop, prop.getType(), prop.getName())),
         "$L == null ? null : $L.makeShallowCopy()",
         prop.getName(),
-        prop.getName());
+        prop.getName()).build();
   }
 
   private static MethodSpec regularBuilder(
@@ -507,13 +510,14 @@ public class BuilderGenerator {
       PropModel prop,
       int requiredIndex,
       AnnotationSpec... extraAnnotations) {
-    return builder(
+    return getMethodSpecBuilder(
         specModel,
         prop,
         requiredIndex,
         prop.getName(),
         Arrays.asList(parameter(prop, prop.getType(), prop.getName(), extraAnnotations)),
-        prop.getName());
+        prop.getName())
+        .build();
   }
 
   private static MethodSpec varArgBuilder(
@@ -574,23 +578,43 @@ public class BuilderGenerator {
         codeBlock).build();
   }
 
-  private static MethodSpec resBuilder(
+  private static TypeSpecDataHolder resBuilders(
       SpecModel specModel,
       PropModel prop,
       int requiredIndex,
       ClassName annotationClassName,
       String resolver) {
-    return builder(
+    final TypeSpecDataHolder.Builder dataHolder = TypeSpecDataHolder.newBuilder();
+    final boolean hasVarArgs = prop.hasVarArgs();
+    final String name = hasVarArgs ? prop.getVarArgsSingleName() : prop.getName();
+
+    dataHolder.addMethod(resTypeRegularBuilder(
         specModel,
         prop,
         requiredIndex,
-        prop.getName() + "Res",
+        name + "Res",
         Arrays.asList(parameter(prop, TypeName.INT, "resId", annotation(annotationClassName))),
         "$L(resId)",
-        resolver + "Res");
+        resolver + "Res").build());
+
+    if (hasVarArgs) {
+      dataHolder.addMethod(resTypeListBuilder(
+          specModel,
+          prop,
+          requiredIndex,
+          prop.getName() + "Res",
+          Arrays.asList(
+              parameter(
+                  prop,
+                  ParameterizedTypeName.get(ClassNames.LIST, TypeName.INT.box()),
+                  "resIds")),
+          "$L(resIds.get(i))",
+          resolver + "Res").build());
+    }
+    return dataHolder.build();
   }
 
-  private static MethodSpec resWithVarargsBuilder(
+  private static TypeSpecDataHolder resWithVarargsBuilders(
       SpecModel specModel,
       PropModel prop,
       int requiredIndex,
@@ -598,18 +622,43 @@ public class BuilderGenerator {
       String resolver,
       TypeName varargsType,
       String varargsName) {
-    return getMethodSpecBuilder(
+    final TypeSpecDataHolder.Builder dataHolder = TypeSpecDataHolder.newBuilder();
+    final boolean hasVarArgs = prop.hasVarArgs();
+    final String name = hasVarArgs ? prop.getVarArgsSingleName() : prop.getName();
+
+    dataHolder.addMethod(resTypeRegularBuilder(
         specModel,
         prop,
         requiredIndex,
-        prop.getName() + "Res",
+        name + "Res",
         Arrays.asList(
             parameter(prop, TypeName.INT, "resId", annotation(annotationClassName)),
             ParameterSpec.builder(ArrayTypeName.of(varargsType), varargsName).build()),
         "$L(resId, " + varargsName + ")",
         resolver + "Res")
         .varargs(true)
-        .build();
+        .build());
+
+    if (hasVarArgs) {
+      dataHolder.addMethod(resTypeListBuilder(
+          specModel,
+          prop,
+          requiredIndex,
+          prop.getName() + "Res",
+          Arrays.asList(
+              parameter(
+                  prop,
+                  ParameterizedTypeName.get(ClassNames.LIST, TypeName.INT.box()),
+                  "resIds",
+                  annotation(annotationClassName)),
+              ParameterSpec.builder(ArrayTypeName.of(varargsType), varargsName).build()),
+          "$L(resIds.get(i), " + varargsName + ")",
+          resolver + "Res")
+          .varargs(true)
+          .build());
+    }
+
+    return dataHolder.build();
   }
 
   private static TypeSpecDataHolder attrBuilders(
@@ -619,75 +668,168 @@ public class BuilderGenerator {
       ClassName annotationClassName,
       String resolver) {
     final TypeSpecDataHolder.Builder dataHolder = TypeSpecDataHolder.newBuilder();
+    final boolean hasVarArgs = prop.hasVarArgs();
+    final String name = hasVarArgs ? prop.getVarArgsSingleName() : prop.getName();
 
-    dataHolder.addMethod(builder(
+    dataHolder.addMethod(resTypeRegularBuilder(
         specModel,
         prop,
         requiredIndex,
-        prop.getName() + "Attr",
+        name + "Attr",
         Arrays.asList(
             parameter(prop, TypeName.INT, "attrResId", annotation(ClassNames.ATTR_RES)),
             parameter(prop, TypeName.INT, "defResId", annotation(annotationClassName))),
         "$L(attrResId, defResId)",
-        resolver + "Attr"));
+        resolver + "Attr").build());
 
-    dataHolder.addMethod(builder(
+    dataHolder.addMethod(resTypeRegularBuilder(
         specModel,
         prop,
         requiredIndex,
-        prop.getName() + "Attr",
+        name + "Attr",
         Arrays.asList(parameter(prop, TypeName.INT, "attrResId", annotation(ClassNames.ATTR_RES))),
         "$L(attrResId, 0)",
-        resolver + "Attr"));
+        resolver + "Attr").build());
+
+    if (hasVarArgs) {
+      dataHolder.addMethod(resTypeListBuilder(
+          specModel,
+          prop,
+          requiredIndex,
+          prop.getName() + "Attr",
+          Arrays.asList(
+              parameter(
+                  prop,
+                  ParameterizedTypeName.get(ClassNames.LIST, TypeName.INT.box()),
+                  "attrResIds"),
+              parameter(prop, TypeName.INT, "defResId", annotation(annotationClassName))),
+          "$L(attrResIds.get(i), defResId)",
+          resolver + "Attr").build());
+
+      dataHolder.addMethod(resTypeListBuilder(
+          specModel,
+          prop,
+          requiredIndex,
+          prop.getName() + "Attr",
+          Arrays.asList(
+              parameter(
+                  prop,
+                  ParameterizedTypeName.get(ClassNames.LIST, TypeName.INT.box()),
+                  "attrResIds")),
+          "$L(attrResIds.get(i), 0)",
+          resolver + "Attr").build());
+    }
 
     return dataHolder.build();
   }
 
-  private static MethodSpec pxBuilder(
+  private static TypeSpecDataHolder pxBuilders(
       SpecModel specModel,
       PropModel prop,
       int requiredIndex) {
-    return builder(
+    final TypeSpecDataHolder.Builder dataHolder = TypeSpecDataHolder.newBuilder();
+    final boolean hasVarArgs = prop.hasVarArgs();
+    final String name = hasVarArgs ? prop.getVarArgsSingleName() : prop.getName();
+
+    dataHolder.addMethod(resTypeRegularBuilder(
         specModel,
         prop,
         requiredIndex,
-        prop.getName() + "Px",
-        Arrays.asList(parameter(prop, prop.getType(), prop.getName(), annotation(ClassNames.PX))),
-        prop.getName());
+        name + "Px",
+        Arrays.asList(parameter(
+            prop,
+            hasVarArgs ?
+                ((ParameterizedTypeName) prop.getType()).typeArguments.get(0).unbox() :
+                prop.getType().unbox(),
+            name,
+            annotation(ClassNames.PX))),
+        name).build());
+
+    if (hasVarArgs) {
+      dataHolder.addMethod(resTypeListBuilder(
+          specModel,
+          prop,
+          requiredIndex,
+          prop.getName() + "Px",
+          Arrays.asList(parameter(
+              prop,
+              prop.getType(),
+              prop.getName())),
+          prop.getName() + ".get(i)").build());
+    }
+
+    return dataHolder.build();
   }
 
-  private static MethodSpec dipBuilder(
+  private static TypeSpecDataHolder dipBuilders(
       SpecModel specModel,
       PropModel prop,
       int requiredIndex) {
+    final TypeSpecDataHolder.Builder dataHolder = TypeSpecDataHolder.newBuilder();
+    final boolean hasVarArgs = prop.hasVarArgs();
+    final String name = hasVarArgs ? prop.getVarArgsSingleName() : prop.getName();
+
     AnnotationSpec dipAnnotation = AnnotationSpec.builder(ClassNames.DIMENSION)
         .addMember("unit", "$T.DP", ClassNames.DIMENSION)
         .build();
 
-    return builder(
+    dataHolder.addMethod(resTypeRegularBuilder(
         specModel,
         prop,
         requiredIndex,
-        prop.getName() + "Dip",
-        Arrays.asList(parameter(prop, TypeName.FLOAT, "dips", dipAnnotation)),
-        "dipsToPixels(dips)");
+        name + "Dip",
+        Arrays.asList(parameter(prop, TypeName.FLOAT, "dip", dipAnnotation)),
+        "dipsToPixels(dip)").build());
+
+    if (hasVarArgs) {
+      dataHolder.addMethod(resTypeListBuilder(
+          specModel,
+          prop,
+          requiredIndex,
+          prop.getName() + "Dip",
+          Arrays.asList(parameter(
+              prop,
+              ParameterizedTypeName.get(ClassNames.LIST, TypeName.FLOAT.box()),
+              "dips")),
+          "dipsToPixels(dips.get(i))").build());
+    }
+
+    return dataHolder.build();
   }
 
-  private static MethodSpec sipBuilder(
+  private static TypeSpecDataHolder sipBuilders(
       SpecModel specModel,
       PropModel prop,
       int requiredIndex) {
+    final TypeSpecDataHolder.Builder dataHolder = TypeSpecDataHolder.newBuilder();
+    final boolean hasVarArgs = prop.hasVarArgs();
+    final String name = hasVarArgs ? prop.getVarArgsSingleName() : prop.getName();
+
     AnnotationSpec spAnnotation = AnnotationSpec.builder(ClassNames.DIMENSION)
         .addMember("unit", "$T.SP", ClassNames.DIMENSION)
         .build();
 
-    return builder(
+    dataHolder.addMethod(resTypeRegularBuilder(
         specModel,
         prop,
         requiredIndex,
-        prop.getName() + "Sp",
-        Arrays.asList(parameter(prop, TypeName.FLOAT, "sips", spAnnotation)),
-        "sipsToPixels(sips)");
+        name + "Sp",
+        Arrays.asList(parameter(prop, TypeName.FLOAT, "sip", spAnnotation)),
+        "sipsToPixels(sip)").build());
+
+    if (hasVarArgs) {
+      dataHolder.addMethod(resTypeListBuilder(
+          specModel,
+          prop,
+          requiredIndex,
+          prop.getName() + "Sp",
+          Arrays.asList(parameter(
+              prop,
+              ParameterizedTypeName.get(ClassNames.LIST, TypeName.FLOAT.box()),
+              "sips")),
+          "sipsToPixels(sips.get(i))").build());
+    }
+    return dataHolder.build();
   }
 
   private static MethodSpec builderBuilder(
@@ -695,7 +837,7 @@ public class BuilderGenerator {
       PropModel prop,
       int requiredIndex,
       ClassName builderClass) {
-    return builder(
+    return getMethodSpecBuilder(
         specModel,
         prop,
         requiredIndex,
@@ -705,7 +847,7 @@ public class BuilderGenerator {
             ParameterizedTypeName.get(builderClass, getBuilderGenericTypes(prop, builderClass)),
             prop.getName() + "Builder")),
         "$L.build()",
-        prop.getName() + "Builder");
+        prop.getName() + "Builder").build();
   }
 
   private static TypeName[] getBuilderGenericTypes(PropModel prop, ClassName builderClass) {
@@ -746,7 +888,7 @@ public class BuilderGenerator {
     return AnnotationSpec.builder(className).build();
   }
 
-  private static MethodSpec builder(
+  private static MethodSpec.Builder resTypeListBuilder(
       SpecModel specModel,
       PropModel prop,
       int requiredIndex,
@@ -754,14 +896,69 @@ public class BuilderGenerator {
       List<ParameterSpec> parameters,
       String statement,
       Object... formatObjects) {
-    return getMethodSpecBuilder(
-        specModel,
-        prop,
-        requiredIndex,
-        name,
-        parameters,
-        statement,
-        formatObjects).build();
+    final String propName = prop.getName();
+    final String parameterName = parameters.get(0).name;
+    final String implMemberInstanceName = getImplMemberInstanceName(specModel);
+    final ParameterizedTypeName varArgType = (ParameterizedTypeName) prop.getType();
+    final TypeName resType = varArgType.typeArguments.get(0);
+    final ParameterizedTypeName listType = ParameterizedTypeName.get(
+        ClassName.get(ArrayList.class), resType);
+
+    CodeBlock codeBlock = CodeBlock.builder()
+        .beginControlFlow("if ($L == null)", parameterName)
+        .addStatement("return this")
+        .endControlFlow()
+        .beginControlFlow("if (this.$L.$L == null)", implMemberInstanceName, propName)
+        .addStatement("this.$L.$L = new $T()", implMemberInstanceName, propName, listType)
+        .endControlFlow()
+        .beginControlFlow("for (int i = 0; i < $L.size(); i++)", parameterName)
+        .add("final $T res = ", resType.isBoxedPrimitive() ? resType.unbox() : resType)
+        .addStatement(statement, formatObjects)
+        .addStatement("this.$L.$L.add(res)", implMemberInstanceName, propName)
+        .endControlFlow()
+        .build();
+
+    return getMethodSpecBuilder(prop, requiredIndex, name, parameters, codeBlock);
+  }
+
+  private static MethodSpec.Builder resTypeRegularBuilder(
+      SpecModel specModel,
+      PropModel prop,
+      int requiredIndex,
+      String name,
+      List<ParameterSpec> parameters,
+      String statement,
+      Object... formatObjects) {
+
+    if (prop.hasVarArgs()) {
+      final String propName = prop.getName();
+      final String implMemberInstanceName = getImplMemberInstanceName(specModel);
+      final ParameterizedTypeName varArgType = (ParameterizedTypeName) prop.getType();
+      final TypeName singleParameterType = varArgType.typeArguments.get(0);
+      final ParameterizedTypeName listType = ParameterizedTypeName.get(
+          ClassName.get(ArrayList.class), singleParameterType);
+
+      CodeBlock.Builder codeBlockBuilder = CodeBlock.builder()
+              .beginControlFlow(
+                  "if (this.$L.$L == null)", implMemberInstanceName, propName)
+              .addStatement("this.$L.$L = new $T()", implMemberInstanceName, propName, listType)
+              .endControlFlow()
+              .add("final $T res = ", singleParameterType.isBoxedPrimitive() ?
+                  singleParameterType.unbox() : singleParameterType)
+              .addStatement(statement, formatObjects)
+              .addStatement("this.$L.$L.add(res)", implMemberInstanceName, propName);
+
+      return getMethodSpecBuilder(prop, requiredIndex, name, parameters, codeBlockBuilder.build());
+    }
+
+    final TypeName typeName = prop.getType();
+    CodeBlock codeBlock = CodeBlock.builder()
+        .add("final $T res = ", typeName.isBoxedPrimitive() ? typeName.unbox() : typeName)
+        .addStatement(statement, formatObjects)
+        .addStatement("this.$L.$L = res", getImplMemberInstanceName(specModel), prop.getName())
+        .build();
+
+    return getMethodSpecBuilder(prop, requiredIndex, name, parameters, codeBlock);
   }
 
   private static MethodSpec.Builder getMethodSpecBuilder(
@@ -861,7 +1058,7 @@ public class BuilderGenerator {
             "return super.$L($L)", builderMethodModel.paramName, builderMethodModel.paramName)
         .returns(BUILDER_CLASS_NAME)
         .build();
-    }
+  }
 
   private static MethodSpec generateBuildMethod(SpecModel specModel, int numRequiredProps) {
     final MethodSpec.Builder buildMethodBuilder = MethodSpec.methodBuilder("build")

--- a/litho-processor/src/main/java/com/facebook/litho/specmodels/generator/BuilderGenerator.java
+++ b/litho-processor/src/main/java/com/facebook/litho/specmodels/generator/BuilderGenerator.java
@@ -379,33 +379,34 @@ public class BuilderGenerator {
             attrBuilders(specModel, prop, requiredIndex, ClassNames.COLOR_RES, "resolveColor"));
         break;
       case DIMEN_SIZE:
+        final String sizeResolverName = !prop.hasVarArgs() && prop.getType().equals(ClassName.FLOAT.box())
+            ? "(float) resolveDimenSize" : "resolveDimenSize";
         dataHolder.addTypeSpecDataHolder(pxBuilders(specModel, prop, requiredIndex));
         dataHolder.addTypeSpecDataHolder(
-            resBuilders(specModel, prop, requiredIndex, ClassNames.DIMEN_RES, "resolveDimenSize"));
+            resBuilders(specModel, prop, requiredIndex, ClassNames.DIMEN_RES, sizeResolverName));
         dataHolder.addTypeSpecDataHolder(
-            attrBuilders(specModel, prop, requiredIndex, ClassNames.DIMEN_RES, "resolveDimenSize"));
+            attrBuilders(specModel, prop, requiredIndex, ClassNames.DIMEN_RES, sizeResolverName));
         dataHolder.addTypeSpecDataHolder(dipBuilders(specModel, prop, requiredIndex));
         break;
       case DIMEN_TEXT:
+        final String textResolverName = !prop.hasVarArgs() && prop.getType().equals(ClassName.FLOAT.box())
+            ? "(float) resolveDimenSize" : "resolveDimenSize";
         dataHolder.addTypeSpecDataHolder(pxBuilders(specModel, prop, requiredIndex));
         dataHolder.addTypeSpecDataHolder(
-            resBuilders(specModel, prop, requiredIndex, ClassNames.DIMEN_RES, "resolveDimenSize"));
+            resBuilders(specModel, prop, requiredIndex, ClassNames.DIMEN_RES,textResolverName));
         dataHolder.addTypeSpecDataHolder(
-            attrBuilders(specModel, prop, requiredIndex, ClassNames.DIMEN_RES, "resolveDimenSize"));
+            attrBuilders(specModel, prop, requiredIndex, ClassNames.DIMEN_RES, textResolverName));
         dataHolder.addTypeSpecDataHolder(dipBuilders(specModel, prop, requiredIndex));
         dataHolder.addTypeSpecDataHolder(sipBuilders(specModel, prop, requiredIndex));
         break;
       case DIMEN_OFFSET:
+        final String offsetResolverName = !prop.hasVarArgs() && prop.getType().equals(ClassName.FLOAT.box())
+            ? "(float) resolveDimenSize" : "resolveDimenSize";
         dataHolder.addTypeSpecDataHolder(pxBuilders(specModel, prop, requiredIndex));
         dataHolder.addTypeSpecDataHolder(
-            resBuilders(specModel, prop, requiredIndex, ClassNames.DIMEN_RES, "resolveDimenOffset"));
+            resBuilders(specModel, prop, requiredIndex, ClassNames.DIMEN_RES, offsetResolverName));
         dataHolder.addTypeSpecDataHolder(
-            attrBuilders(
-                specModel,
-                prop,
-                requiredIndex,
-                ClassNames.DIMEN_RES,
-                "resolveDimenOffset"));
+            attrBuilders(specModel, prop, requiredIndex, ClassNames.DIMEN_RES, offsetResolverName));
         dataHolder.addTypeSpecDataHolder(dipBuilders(specModel, prop, requiredIndex));
         break;
       case FLOAT:
@@ -768,6 +769,8 @@ public class BuilderGenerator {
     final TypeSpecDataHolder.Builder dataHolder = TypeSpecDataHolder.newBuilder();
     final boolean hasVarArgs = prop.hasVarArgs();
     final String name = hasVarArgs ? prop.getVarArgsSingleName() : prop.getName();
+    final String statement = !prop.hasVarArgs() && prop.getType().equals(ClassName.FLOAT.box())
+        ? "(float) dipsToPixels(dip)" : "dipsToPixels(dip)";
 
     AnnotationSpec dipAnnotation = AnnotationSpec.builder(ClassNames.DIMENSION)
         .addMember("unit", "$T.DP", ClassNames.DIMENSION)
@@ -779,7 +782,7 @@ public class BuilderGenerator {
         requiredIndex,
         name + "Dip",
         Arrays.asList(parameter(prop, TypeName.FLOAT, "dip", dipAnnotation)),
-        "dipsToPixels(dip)").build());
+        statement).build());
 
     if (hasVarArgs) {
       dataHolder.addMethod(resTypeListBuilder(
@@ -804,6 +807,8 @@ public class BuilderGenerator {
     final TypeSpecDataHolder.Builder dataHolder = TypeSpecDataHolder.newBuilder();
     final boolean hasVarArgs = prop.hasVarArgs();
     final String name = hasVarArgs ? prop.getVarArgsSingleName() : prop.getName();
+    final String statement = !prop.hasVarArgs() && prop.getType().equals(ClassName.FLOAT.box())
+        ? "(float) sipsToPixels(sip)" : "sipsToPixels(sip)";
 
     AnnotationSpec spAnnotation = AnnotationSpec.builder(ClassNames.DIMENSION)
         .addMember("unit", "$T.SP", ClassNames.DIMENSION)
@@ -815,7 +820,7 @@ public class BuilderGenerator {
         requiredIndex,
         name + "Sp",
         Arrays.asList(parameter(prop, TypeName.FLOAT, "sip", spAnnotation)),
-        "sipsToPixels(sip)").build());
+        statement).build());
 
     if (hasVarArgs) {
       dataHolder.addMethod(resTypeListBuilder(
@@ -951,11 +956,9 @@ public class BuilderGenerator {
       return getMethodSpecBuilder(prop, requiredIndex, name, parameters, codeBlockBuilder.build());
     }
 
-    final TypeName typeName = prop.getType();
     CodeBlock codeBlock = CodeBlock.builder()
-        .add("final $T res = ", typeName.isBoxedPrimitive() ? typeName.unbox() : typeName)
+        .add("this.$L.$L = ", getImplMemberInstanceName(specModel), prop.getName())
         .addStatement(statement, formatObjects)
-        .addStatement("this.$L.$L = res", getImplMemberInstanceName(specModel), prop.getName())
         .build();
 
     return getMethodSpecBuilder(prop, requiredIndex, name, parameters, codeBlock);

--- a/litho-processor/src/main/java/com/facebook/litho/specmodels/model/PropValidation.java
+++ b/litho-processor/src/main/java/com/facebook/litho/specmodels/model/PropValidation.java
@@ -122,13 +122,6 @@ public class PropValidation {
                     + "generated code."));
       }
 
-      if (prop.hasVarArgs() && prop.getResType() != ResType.NONE) {
-        validationErrors.add(
-            new SpecModelValidationError(
-                prop.getRepresentedObject(),
-                prop.getName() + " is a variable argument, and thus should not set a resType."));
-      }
-
       if (prop.hasVarArgs()) {
         TypeName typeName = prop.getType();
         if (typeName instanceof ParameterizedTypeName) {
@@ -179,41 +172,64 @@ public class PropValidation {
       return validationErrors;
     }
 
+    final boolean hasVarArgs = prop.hasVarArgs();
     final List<TypeName> validResTypes = new ArrayList<>();
     switch (resType) {
       case STRING:
-        validResTypes.add(TypeName.get(String.class));
-        validResTypes.add(TypeName.get(CharSequence.class));
+        validResTypes.add(hasVarArgs ?
+            ParameterizedTypeName.get(List.class, String.class) : TypeName.get(String.class));
+        validResTypes.add(hasVarArgs ?
+            ParameterizedTypeName.get(List.class, CharSequence.class) : TypeName.get(CharSequence.class));
         break;
       case STRING_ARRAY:
-        validResTypes.add(TypeName.get(String[].class));
+        validResTypes.add(hasVarArgs ?
+            ParameterizedTypeName.get(List.class, String[].class) : TypeName.get(String[].class));
         break;
       case INT:
       case COLOR:
-        validResTypes.add(TypeName.get(int.class));
-        validResTypes.add(TypeName.get(Integer.class));
+        if (hasVarArgs) {
+          validResTypes.add(ParameterizedTypeName.get(List.class, Integer.class));
+        } else {
+          validResTypes.add(TypeName.get(int.class));
+          validResTypes.add(TypeName.get(Integer.class));
+        }
         break;
       case INT_ARRAY:
-        validResTypes.add(TypeName.get(int[].class));
+        validResTypes.add(hasVarArgs ?
+            ParameterizedTypeName.get(List.class, Integer[].class) : TypeName.get(int[].class));
         break;
       case BOOL:
-        validResTypes.add(TypeName.get(boolean.class));
-        validResTypes.add(TypeName.get(Boolean.class));
+        if (hasVarArgs) {
+          validResTypes.add(ParameterizedTypeName.get(List.class, Boolean.class));
+        } else {
+          validResTypes.add(TypeName.get(boolean.class));
+          validResTypes.add(TypeName.get(Boolean.class));
+        }
         break;
       case DIMEN_SIZE:
       case DIMEN_TEXT:
       case DIMEN_OFFSET:
-        validResTypes.add(TypeName.get(int.class));
-        validResTypes.add(TypeName.get(Integer.class));
-        validResTypes.add(TypeName.get(float.class));
-        validResTypes.add(TypeName.get(Float.class));
+        if (hasVarArgs) {
+          validResTypes.add(ParameterizedTypeName.get(List.class, Integer.class));
+          validResTypes.add(ParameterizedTypeName.get(List.class, Float.class));
+        } else {
+          validResTypes.add(TypeName.get(int.class));
+          validResTypes.add(TypeName.get(Integer.class));
+          validResTypes.add(TypeName.get(float.class));
+          validResTypes.add(TypeName.get(Float.class));
+        }
         break;
       case FLOAT:
-        validResTypes.add(TypeName.get(float.class));
-        validResTypes.add(TypeName.get(Float.class));
+        if (hasVarArgs) {
+          validResTypes.add(ParameterizedTypeName.get(List.class, Float.class));
+        } else {
+          validResTypes.add(TypeName.get(float.class));
+          validResTypes.add(TypeName.get(Float.class));
+        }
         break;
       case DRAWABLE:
-        validResTypes.add(ClassNames.DRAWABLE);
+        validResTypes.add(hasVarArgs ?
+            ParameterizedTypeName.get(ClassNames.LIST, ClassNames.DRAWABLE) : ClassNames.DRAWABLE);
         break;
     }
 

--- a/litho-processor/src/main/java/com/facebook/litho/specmodels/model/PropValidation.java
+++ b/litho-processor/src/main/java/com/facebook/litho/specmodels/model/PropValidation.java
@@ -237,8 +237,9 @@ public class PropValidation {
       validationErrors.add(
           new SpecModelValidationError(
               prop.getRepresentedObject(),
-              "A prop declared with resType " + prop.getResType() + " must be one of the " +
-                  "following types: " + Arrays.toString(validResTypes.toArray()) + "."));
+              (prop.hasVarArgs() ? "A variable argument" : "A prop") + " declared with resType "
+                  + prop.getResType() + " must be one of the following types: "
+                  + Arrays.toString(validResTypes.toArray()) + "."));
     }
 
     return validationErrors;


### PR DESCRIPTION
PR for #206 
Cause `varArgBuilder` and `regularBuilder` handle the default generating properly. 
So I reconstruct `attrBuilders` `resBuilder` `pxBuilder` `dipBuilder` and `sipBuilder` for supporting this feature. 

There are two builders, `resTypeListBuilder` for generating method with `List` parameter, `resTypeRegularBuilder` for generating method with normal parameter. 
The code generated looks like below:
```java
public Builder sRes(@DimenRes int resId) {
  if (this.mPlaygroundComponentImpl.s == null) {
    this.mPlaygroundComponentImpl.s = new ArrayList<Float>();
  }
  final float res = resolveFloatRes(resId);
  this.mPlaygroundComponentImpl.s.add(res);
  mRequired.set(0);
  return this;
}

public Builder sRes(List<Integer> resIds) {
  if (resIds == null) {
    return this;
  }
  if (this.mPlaygroundComponentImpl.s == null) {
    this.mPlaygroundComponentImpl.s = new ArrayList<Float>();
  }
  for (int i = 0; i < resIds.size(); i++) {
    final float res = resolveFloatRes(resIds.get(i));
    this.mPlaygroundComponentImpl.s.add(res);
  }
  mRequired.set(0);
  return this;
}
```
Also, If the parameter type is something like `List<Float>` I will unbox the Float,
 or `final Float res = resolveFloatRes(resIds.get(i))` will emit an error.

For `ResType.INT_ARRAY`, `int[]` can't be auto-box into `Integer[]` , so I add two methods to return `Integer[]` in `ResourceResolver.java`. And change the modifier of `resolveStringArrayRes` from `private` to `protected` or it will emit an error when resType is `ResType.STRING` 

And I find that if `resType` is `DIMEN` and parameter is `Float`. `this.mPlaygroundComponentImpl.f = resolveDimenSizeRes(resId);` will emit an error. I fix that by changing generated code of `resType.non-null` like this:
```java
public Builder fRes(@DimenRes int resId) {
  this.mPlaygroundComponentImpl.f = (float) resolveDimenSizeRes(resId);
  mRequired.set(0);
  return this;
}
```
I also handle the `xPx(@Px float f)` method properly, since it is a little bit different from others.
Finally, I remove the warning in `PropValidation.java` of using both `varArgs` and `resType`, and add some new validations. 