### PR TITLE
Docs: Fix broken link to debugHighlightMountBounds

### DIFF
--- a/docs/_docs/view-flattening.md
+++ b/docs/_docs/view-flattening.md
@@ -16,7 +16,7 @@ First, Litho can completely skip containers after layout calculation because the
 
 Second, Litho can mount either a view or a drawable. In fact, most of the core widgets in the framework, such as Text and Image, mount drawables, not views.
 
-As a result of these optimizations, the component for the UI in the example would actually be rendered as a single, completely flat, view. You can see this in the following screenshot with the [Show layout bounds developer option enabled](/docs/debugging#null__debughighlightmountbounds).
+As a result of these optimizations, the component for the UI in the example would actually be rendered as a single, completely flat, view. You can see this in the following screenshot with the [Show layout bounds developer option enabled](/docs/developer-options#debughighlightmountbounds).
 
 ![View Flattening](/static/images/viewflattening.png)
 


### PR DESCRIPTION
I have previously signed the Facebook CLA, but to be clear I have not tested this by actually generating the docs from this. Please let me know if you'd like me to do so.

This fixes a broken link from when Dev Options page was created: https://github.com/facebook/litho/commit/a1207a8ce7227ebd6107ea5e17a420edd3d58c67#diff-120012bbe26d93715d4f73fb9328e38c