### PR TITLE
Tutorial: return ComponentLayout from ListItemSpec#onCreateLayout()

### DIFF
--- a/docs/_docs/tutorial.md
+++ b/docs/_docs/tutorial.md
@@ -84,8 +84,7 @@ Your custom component will be called `ListItem` and it will display a title with
 public class ListItemSpec {
 
   @OnCreateLayout
-  static Component onCreateLayout(ComponentContext c) {
-
+  static ComponentLayout onCreateLayout(ComponentContext c) {
     return Column.create(c)
         .paddingDip(ALL, 16)
         .backgroundColor(Color.WHITE)


### PR DESCRIPTION
onCreateLayout() had a return type of Component, which is incorrect.