### PR TITLE
Add parent param to ViewCreator

### DIFF
--- a/litho-core/src/main/java/com/facebook/litho/ViewCompatComponent.java
+++ b/litho-core/src/main/java/com/facebook/litho/ViewCompatComponent.java
@@ -108,7 +108,7 @@ public class ViewCompatComponent<V extends View> extends Component {
 
   @Override
   public V createMountContent(ComponentContext c) {
-    return (V) mViewCreator.createView(c);
+    return (V) mViewCreator.createView(c, null);
   }
 
   public static final class Builder<V extends View> extends Component.Builder<Builder<V>> {

--- a/litho-core/src/main/java/com/facebook/litho/viewcompat/ViewCreator.java
+++ b/litho-core/src/main/java/com/facebook/litho/viewcompat/ViewCreator.java
@@ -11,6 +11,7 @@ package com.facebook.litho.viewcompat;
 
 import android.content.Context;
 import android.view.View;
+import android.view.ViewGroup;
 
 /**
  * Creates a View of the specified type. Used as the mount content for ViewCompatComponent.
@@ -22,7 +23,8 @@ public interface ViewCreator<V extends View> {
 
   /**
    * @param c android Context.
+   * @param parent the parent {@link ViewGroup}, or {@code null} if there isn't one.
    * @return a new view of type V.
    */
-  V createView(Context c);
+  V createView(Context c, ViewGroup parent);
 }

--- a/litho-it/src/test/java/com/facebook/litho/ViewCompatComponentTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/ViewCompatComponentTest.java
@@ -15,6 +15,7 @@ import static com.facebook.litho.testing.helper.ComponentTestHelper.unbindCompon
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 import android.content.Context;
+import android.view.ViewGroup;
 import android.widget.TextView;
 import com.facebook.litho.testing.testrunner.ComponentsTestRunner;
 import com.facebook.litho.viewcompat.ViewBinder;
@@ -33,7 +34,7 @@ public class ViewCompatComponentTest {
   private static final ViewCreator<TextView> TEXT_VIEW_CREATOR =
       new ViewCreator<TextView>() {
         @Override
-        public TextView createView(Context c) {
+        public TextView createView(Context c, ViewGroup parent) {
           return new TextView(c);
         }
       };
@@ -41,7 +42,7 @@ public class ViewCompatComponentTest {
   private static final ViewCreator<TextView> TEXT_VIEW_CREATOR_2 =
       new ViewCreator<TextView>() {
         @Override
-        public TextView createView(Context c) {
+        public TextView createView(Context c, ViewGroup parent) {
           return new TextView(c);
         }
       };

--- a/litho-it/src/test/java/com/facebook/litho/widget/RecyclerBinderTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/widget/RecyclerBinderTest.java
@@ -30,6 +30,7 @@ import android.support.v7.widget.RecyclerView.OnScrollListener;
 import android.support.v7.widget.RecyclerView.ViewHolder;
 import android.view.View;
 import android.widget.FrameLayout;
+import android.view.ViewGroup;
 import com.facebook.litho.Component;
 import com.facebook.litho.ComponentContext;
 import com.facebook.litho.ComponentTree;
@@ -72,7 +73,7 @@ public class RecyclerBinderTest {
   private static final ViewCreator VIEW_CREATOR_1 =
       new ViewCreator() {
         @Override
-        public View createView(Context c) {
+        public View createView(Context c, ViewGroup parent) {
           return mock(View.class);
         }
       };
@@ -80,7 +81,7 @@ public class RecyclerBinderTest {
   private static final ViewCreator VIEW_CREATOR_2 =
       new ViewCreator() {
         @Override
-        public View createView(Context c) {
+        public View createView(Context c, ViewGroup parent) {
           return mock(View.class);
         }
       };
@@ -88,7 +89,7 @@ public class RecyclerBinderTest {
   private static final ViewCreator VIEW_CREATOR_3 =
       new ViewCreator() {
         @Override
-        public View createView(Context c) {
+        public View createView(Context c, ViewGroup parent) {
           return mock(View.class);
         }
       };
@@ -1079,7 +1080,7 @@ public class RecyclerBinderTest {
             // Different ViewCreator instances for each view item.
             return new ViewCreator() {
               @Override
-              public View createView(Context c) {
+              public View createView(Context c, ViewGroup parent) {
                 return mock(View.class);
               }
             };
@@ -1181,7 +1182,7 @@ public class RecyclerBinderTest {
     final ViewCreator<View> viewCreator =
         new ViewCreator<View>() {
           @Override
-          public View createView(Context c) {
+          public View createView(Context c, ViewGroup parent) {
             return view;
           }
         };

--- a/litho-widget/src/main/java/com/facebook/litho/widget/RecyclerBinder.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/RecyclerBinder.java
@@ -1443,7 +1443,7 @@ public class RecyclerBinder
       final ViewCreator viewCreator = mRenderInfoViewCreatorController.getViewCreator(viewType);
 
       if (viewCreator != null) {
-        final View view = viewCreator.createView(mComponentContext);
+        final View view = viewCreator.createView(mComponentContext, parent);
         final RecyclerView.LayoutParams layoutParams;
         if (mLayoutInfo.getScrollDirection() == OrientationHelper.VERTICAL) {
           layoutParams = new RecyclerView.LayoutParams(MATCH_PARENT, WRAP_CONTENT);


### PR DESCRIPTION
This adds a nullable `parent` parameter to the `ViewCreator.createView()` function, which helps with migrations from legacy code in adapters.

Fixes #306.