### PR TITLE
Add support for specifying ViewType to ViewRenderInfo

### DIFF
--- a/litho-it/src/test/java/com/facebook/litho/widget/RecyclerBinderTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/widget/RecyclerBinderTest.java
@@ -1192,8 +1192,9 @@ public class RecyclerBinderTest {
 
     mRecyclerBinder.mount(recyclerView);
 
-    final ViewHolder vh =
-        recyclerView.getAdapter().onCreateViewHolder(new FrameLayout(mComponentContext), 1);
+    final ViewHolder vh = recyclerView.getAdapter()
+        .onCreateViewHolder(new FrameLayout(mComponentContext),
+            RenderInfoViewCreatorController.DEFAULT_COMPONENT_VIEW_TYPE + 1);
 
     recyclerView.getAdapter().onBindViewHolder(vh, 0);
     verify(viewBinder).bind(view);

--- a/litho-widget/src/main/java/com/facebook/litho/widget/RenderInfo.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/RenderInfo.java
@@ -120,6 +120,14 @@ public abstract class RenderInfo {
   }
 
   /**
+   * @return true, if a custom viewType was set for this {@link RenderInfo} and it was created
+   *     through {@link ViewRenderInfo#create()}, or false otherwise.
+   */
+  public boolean hasCustomViewType() {
+    return false;
+  }
+
+  /**
    * @return viewType of current {@link RenderInfo} if it was created through {@link
    *     ViewRenderInfo#create()} or otherwise it will throw {@link UnsupportedOperationException}.
    *     If this method is accessed from {@link RenderInfo} type, {@link #rendersView()} should be
@@ -147,7 +155,8 @@ public abstract class RenderInfo {
 
   /**
    * Set viewType of current {@link RenderInfo} if it was created through {@link
-   * ViewRenderInfo#create()}, or otherwise it will throw {@link UnsupportedOperationException}.
+   * ViewRenderInfo#create()} and a custom viewType was not set, or otherwise it will throw
+   * {@link UnsupportedOperationException}.
    */
   void setViewType(int viewType) {
     throw new UnsupportedOperationException();

--- a/litho-widget/src/main/java/com/facebook/litho/widget/ViewRenderInfo.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/ViewRenderInfo.java
@@ -21,6 +21,7 @@ public class ViewRenderInfo extends RenderInfo {
   private final ViewBinder mViewBinder;
   private final ViewCreator mViewCreator;
 
+  private final boolean mCustomViewType;
   private int mViewType;
 
   public static Builder create() {
@@ -36,6 +37,10 @@ public class ViewRenderInfo extends RenderInfo {
     super(builder);
     mViewBinder = builder.viewBinder;
     mViewCreator = builder.viewCreator;
+    mCustomViewType = builder.hasCustomViewType;
+    if (mCustomViewType) {
+      mViewType = builder.viewType;
+    }
   }
 
   @Override
@@ -54,7 +59,15 @@ public class ViewRenderInfo extends RenderInfo {
   }
 
   @Override
+  public boolean hasCustomViewType() {
+    return mCustomViewType;
+  }
+
+  @Override
   void setViewType(int viewType) {
+    if (mCustomViewType) {
+      throw new UnsupportedOperationException("Cannot override custom view type.");
+    }
     mViewType = viewType;
   }
 
@@ -71,6 +84,8 @@ public class ViewRenderInfo extends RenderInfo {
   public static class Builder extends RenderInfo.Builder<Builder> {
     private ViewBinder viewBinder;
     private ViewCreator viewCreator;
+    private boolean hasCustomViewType = false;
+    private int viewType = 0;
 
     /**
      * Specify {@link ViewCreator} implementation that can be used to create a new view if such view
@@ -91,6 +106,16 @@ public class ViewRenderInfo extends RenderInfo {
       return this;
     }
 
+    /**
+     * Specify a custom ViewType identifier for this View. This will be used instead of being
+     * generated from the {@link ViewCreator} instance.
+     */
+    public Builder customViewType(int viewType) {
+      hasCustomViewType = true;
+      this.viewType = viewType;
+      return this;
+    }
+
     public ViewRenderInfo build() {
       if (viewCreator == null || viewBinder == null) {
         throw new IllegalStateException("Both viewCreator and viewBinder must be provided.");
@@ -107,6 +132,8 @@ public class ViewRenderInfo extends RenderInfo {
       super.release();
       viewBinder = null;
       viewCreator = null;
+      hasCustomViewType = false;
+      viewType = 0;
       sBuilderPool.release(this);
     }
   }


### PR DESCRIPTION
This also allows us to set the componentViewType to start at a number that's not 0, avoiding conflicts with any other collections of views we may have in a ViewPool.