### PR TITLE
Remove unnecessary inheritImplementationMethods = true from shadow class

### DIFF
--- a/litho-testing/src/main/java/com/facebook/litho/testing/shadows/ColorDrawableShadow.java
+++ b/litho-testing/src/main/java/com/facebook/litho/testing/shadows/ColorDrawableShadow.java
@@ -23,7 +23,7 @@ import org.robolectric.shadows.ShadowDrawable;
  * Shadows a {@link ColorDrawable} to support of drawing its description on a
  * {@link org.robolectric.shadows.ShadowCanvas}
  */
-@Implements(value = ColorDrawable.class, inheritImplementationMethods = true)
+@Implements(value = ColorDrawable.class)
 public class ColorDrawableShadow extends ShadowDrawable {
 
   @RealObject private ColorDrawable mRealColorDrawable;


### PR DESCRIPTION
This is being cleaned up inside Google as removing an uncessary param
that's being deprecated and removed in the future.