### PR TITLE
Remove customViewType duplicate check

### DIFF
--- a/litho-widget/src/main/java/com/facebook/litho/widget/RenderInfoViewCreatorController.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/RenderInfoViewCreatorController.java
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
+
 package com.facebook.litho.widget;
 
 import android.support.annotation.UiThread;
@@ -67,10 +68,8 @@ public class RenderInfoViewCreatorController {
     } else if (!mCustomViewTypeEnabled && renderInfo.hasCustomViewType()) {
       throw new IllegalStateException(
           "You must enable custom viewTypes to provide customViewType in ViewRenderInfo.");
-    } else if (mCustomViewTypeEnabled
-        && (mViewTypeToViewCreator.indexOfKey(renderInfo.getViewType()) >= 0
-            || mComponentViewType == renderInfo.getViewType())) {
-      throw new IllegalStateException("Duplicate ViewType detected: " + renderInfo.getViewType());
+    } else if (mCustomViewTypeEnabled && mComponentViewType == renderInfo.getViewType()) {
+      throw new IllegalStateException("CustomViewType cannot be the same as ComponentViewType.");
     }
   }
 


### PR DESCRIPTION
This check is too aggressive for customViewTypes as it will always throw if a custom view type is set, since we require customViewType to bet set on all RenderInfos and they will be positively identified as duplicates with other RenderInfos of the same type.

For proper duplicate checking, we could check if there are Multiple ViewCreators bound to the same viewType, or if there are multiple viewTypes for the same ViewCreator. But in my case I would actually have different ViewCreator instances that may have the same behavior, and would have to implement a proper .equals() implementation. I think given the advanced API and the implied dangers of the API, we can simply leave these checks as-is without stricter checks.