### PR TITLE
Don't override child layout params

### DIFF
--- a/litho-widget/src/main/java/com/facebook/litho/widget/RecyclerBinder.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/RecyclerBinder.java
@@ -1465,13 +1465,6 @@ public class RecyclerBinder
 
       if (viewCreator != null) {
         final View view = viewCreator.createView(mComponentContext, parent);
-        final RecyclerView.LayoutParams layoutParams;
-        if (mLayoutInfo.getScrollDirection() == OrientationHelper.VERTICAL) {
-          layoutParams = new RecyclerView.LayoutParams(MATCH_PARENT, WRAP_CONTENT);
-        } else {
-          layoutParams = new RecyclerView.LayoutParams(WRAP_CONTENT, MATCH_PARENT);
-        }
-        view.setLayoutParams(layoutParams);
         return new BaseViewHolder(view, false);
       } else {
         final LithoView lithoView =


### PR DESCRIPTION
The existing behavior of explicitly overriding LayoutParams breaks the ability of children to set explicit heights and widths.

Instead, to override the default case where LinearLayoutManager uses `WRAP_CONTENT`/`WRAP_CONTENT` for its LayoutParams, we will provide a default internal LinearLayoutManager that defaults to MATCH_PARENT in the non-scrolling dimension.