### PR TITLE
Use fixed, strict implementation in SizeSpec.makeSizeSpec

### DIFF
--- a/litho-core/src/main/java/com/facebook/litho/BoundsHelper.java
+++ b/litho-core/src/main/java/com/facebook/litho/BoundsHelper.java
@@ -8,7 +8,7 @@
  */
 package com.facebook.litho;
 
-import static android.view.View.MeasureSpec.makeMeasureSpec;
+import static com.facebook.litho.SizeSpec.makeSizeSpec;
 
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
@@ -27,8 +27,8 @@ public class BoundsHelper {
 
     if (force || view.getMeasuredHeight() != height || view.getMeasuredWidth() != width) {
       view.measure(
-          makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
-          makeMeasureSpec(height, View.MeasureSpec.EXACTLY));
+          makeSizeSpec(width, SizeSpec.EXACTLY),
+          makeSizeSpec(height, SizeSpec.EXACTLY));
     }
 
     if (force

--- a/litho-core/src/main/java/com/facebook/litho/LithoView.java
+++ b/litho-core/src/main/java/com/facebook/litho/LithoView.java
@@ -122,8 +122,8 @@ public class LithoView extends ComponentHost {
         // The hosting view doesn't allow children to change sizes dynamically as
         // this would conflict with the component's own layout calculations.
         child.measure(
-            MeasureSpec.makeMeasureSpec(child.getWidth(), MeasureSpec.EXACTLY),
-            MeasureSpec.makeMeasureSpec(child.getHeight(), MeasureSpec.EXACTLY));
+            SizeSpec.makeSizeSpec(child.getWidth(), SizeSpec.EXACTLY),
+            SizeSpec.makeSizeSpec(child.getHeight(), SizeSpec.EXACTLY));
         child.layout(child.getLeft(), child.getTop(), child.getRight(), child.getBottom());
       }
 
@@ -306,8 +306,8 @@ public class LithoView extends ComponentHost {
           && mComponentTree.getMainThreadLayoutState() == null) {
         // Call measure so that we get a layout state that we can use for layout.
         mComponentTree.measure(
-            MeasureSpec.makeMeasureSpec(right - left, MeasureSpec.EXACTLY),
-            MeasureSpec.makeMeasureSpec(bottom - top, MeasureSpec.EXACTLY),
+            SizeSpec.makeSizeSpec(right - left, SizeSpec.EXACTLY),
+            SizeSpec.makeSizeSpec(bottom - top, SizeSpec.EXACTLY),
             new int[2],
             false);
       }

--- a/litho-core/src/main/java/com/facebook/litho/SizeSpec.java
+++ b/litho-core/src/main/java/com/facebook/litho/SizeSpec.java
@@ -40,6 +40,8 @@ import java.lang.annotation.RetentionPolicy;
  * is provided to pack and unpack the &lt;size, mode&gt; tuple into the int.
  */
 public class SizeSpec {
+  private static final int MODE_SHIFT = 30;
+  private static final int MODE_MASK  = 0x3 << MODE_SHIFT;
 
   /**
    * Size specification mode: The parent has not imposed any constraint
@@ -77,15 +79,15 @@ public class SizeSpec {
    * implementation was such that the order of arguments did not matter
    * and overflow in either value could impact the resulting MeasureSpec.
    * {@link android.widget.RelativeLayout} was affected by this bug.
-   * Apps targeting API levels greater than 17 will get the fixed, more strict
-   * behavior.</p>
+   * This implementation uses the fixed, more strict version of the function
+   * found in API level 18+.</p>
    *
    * @param size the size of the size specification
    * @param mode the mode of the size specification
    * @return the size specification based on size and mode
    */
   public static int makeSizeSpec(int size, @MeasureSpecMode int mode) {
-    return View.MeasureSpec.makeMeasureSpec(size, mode);
+    return (size & ~MODE_MASK) | (mode & MODE_MASK);
   }
 
   /**

--- a/litho-core/src/main/java/com/facebook/litho/utils/MeasureUtils.java
+++ b/litho-core/src/main/java/com/facebook/litho/utils/MeasureUtils.java
@@ -28,11 +28,11 @@ public final class MeasureUtils {
   public static int getViewMeasureSpec(int sizeSpec) {
     switch (getMode(sizeSpec)) {
       case SizeSpec.EXACTLY:
-        return MeasureSpec.makeMeasureSpec(getSize(sizeSpec), MeasureSpec.EXACTLY);
+        return SizeSpec.makeSizeSpec(getSize(sizeSpec), MeasureSpec.EXACTLY);
       case SizeSpec.AT_MOST:
-        return MeasureSpec.makeMeasureSpec(getSize(sizeSpec), MeasureSpec.AT_MOST);
+        return SizeSpec.makeSizeSpec(getSize(sizeSpec), MeasureSpec.AT_MOST);
       case SizeSpec.UNSPECIFIED:
-        return MeasureSpec.makeMeasureSpec(getSize(sizeSpec), MeasureSpec.UNSPECIFIED);
+        return SizeSpec.makeSizeSpec(getSize(sizeSpec), MeasureSpec.UNSPECIFIED);
       default:
         throw new IllegalStateException("Unexpected size spec mode");
     }

--- a/litho-it/src/test/java/com/facebook/litho/CollectTransitionsTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/CollectTransitionsTest.java
@@ -12,7 +12,6 @@ package com.facebook.litho;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.robolectric.RuntimeEnvironment.application;
 
-import android.view.View;
 import com.facebook.litho.animation.AnimatedProperties;
 import com.facebook.litho.testing.testrunner.ComponentsTestRunner;
 import com.facebook.litho.testing.util.InlineLayoutSpec;
@@ -65,8 +64,8 @@ public class CollectTransitionsTest {
             c,
             mWrappingContentWithTransition,
             ComponentTree.generateComponentTreeId(),
-            View.MeasureSpec.makeMeasureSpec(100, View.MeasureSpec.EXACTLY),
-            View.MeasureSpec.makeMeasureSpec(100, View.MeasureSpec.EXACTLY),
+            SizeSpec.makeSizeSpec(100, SizeSpec.EXACTLY),
+            SizeSpec.makeSizeSpec(100, SizeSpec.EXACTLY),
             LayoutState.CalculateLayoutSource.TEST);
     assertThat(layoutState.getTransitionContext()).isNotNull();
     assertThat(layoutState.getTransitionContext().getTransitions()).hasSize(2);

--- a/litho-it/src/test/java/com/facebook/litho/ComponentGlobalKeyTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/ComponentGlobalKeyTest.java
@@ -17,7 +17,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import android.view.View;
 import com.facebook.litho.annotations.OnCreateLayout;
 import com.facebook.litho.testing.TestDrawableComponent;
 import com.facebook.litho.testing.TestViewComponent;
@@ -347,8 +346,8 @@ public class ComponentGlobalKeyTest {
     LithoView lithoView = new LithoView(mContext);
     lithoView.setComponentTree(componentTree);
     lithoView.measure(
-        View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED),
-        View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED));
+        SizeSpec.makeSizeSpec(0, SizeSpec.UNSPECIFIED),
+        SizeSpec.makeSizeSpec(0, SizeSpec.UNSPECIFIED));
     lithoView.layout(
         0,
         0,

--- a/litho-it/src/test/java/com/facebook/litho/ComponentHostTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/ComponentHostTest.java
@@ -14,11 +14,11 @@ import static android.view.MotionEvent.obtain;
 import static android.view.View.GONE;
 import static android.view.View.IMPORTANT_FOR_ACCESSIBILITY_AUTO;
 import static android.view.View.INVISIBLE;
-import static android.view.View.MeasureSpec.EXACTLY;
-import static android.view.View.MeasureSpec.makeMeasureSpec;
 import static android.view.View.VISIBLE;
 import static com.facebook.litho.MountItem.FLAG_DUPLICATE_PARENT_STATE;
 import static com.facebook.litho.MountItem.FLAG_MATCH_HOST_BOUNDS;
+import static com.facebook.litho.SizeSpec.EXACTLY;
+import static com.facebook.litho.SizeSpec.makeSizeSpec;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
@@ -104,8 +104,8 @@ public class ComponentHostTest {
     View v1 = new View(mContext);
     Rect v1Bounds = new Rect(0, 0, 10, 10);
     v1.measure(
-        makeMeasureSpec(v1Bounds.width(), EXACTLY),
-        makeMeasureSpec(v1Bounds.height(), EXACTLY));
+        makeSizeSpec(v1Bounds.width(), EXACTLY),
+        makeSizeSpec(v1Bounds.height(), EXACTLY));
     v1.layout(v1Bounds.left, v1Bounds.top, v1Bounds.right, v1Bounds.bottom);
 
     MountItem mountItem3 = mount(2, v1);

--- a/litho-it/src/test/java/com/facebook/litho/DeprecatedLithoTooltipTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/DeprecatedLithoTooltipTest.java
@@ -11,7 +11,6 @@ package com.facebook.litho;
 
 import static org.mockito.Mockito.verify;
 
-import android.view.View;
 import com.facebook.litho.annotations.OnCreateLayout;
 import com.facebook.litho.testing.TestDrawableComponent;
 import com.facebook.litho.testing.testrunner.ComponentsTestRunner;
@@ -176,8 +175,8 @@ public class DeprecatedLithoTooltipTest {
     LithoView lithoView = new LithoView(mContext);
     lithoView.setComponentTree(componentTree);
     lithoView.measure(
-        View.MeasureSpec.makeMeasureSpec(HOST_WIDTH, View.MeasureSpec.EXACTLY),
-        View.MeasureSpec.makeMeasureSpec(HOST_HEIGHT, View.MeasureSpec.EXACTLY));
+        SizeSpec.makeSizeSpec(HOST_WIDTH, SizeSpec.EXACTLY),
+        SizeSpec.makeSizeSpec(HOST_HEIGHT, SizeSpec.EXACTLY));
     lithoView.layout(
         0,
         0,

--- a/litho-it/src/test/java/com/facebook/litho/LithoViewTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/LithoViewTest.java
@@ -9,10 +9,11 @@
 
 package com.facebook.litho;
 
-import static android.view.View.MeasureSpec.EXACTLY;
-import static android.view.View.MeasureSpec.UNSPECIFIED;
-import static android.view.View.MeasureSpec.makeMeasureSpec;
 import static com.facebook.litho.ComponentTree.create;
+import static com.facebook.litho.SizeSpec.AT_MOST;
+import static com.facebook.litho.SizeSpec.EXACTLY;
+import static com.facebook.litho.SizeSpec.UNSPECIFIED;
+import static com.facebook.litho.SizeSpec.makeSizeSpec;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
@@ -67,8 +68,8 @@ public class LithoViewTest {
   @Test
   public void measureBeforeBeingAttached() {
     mLithoView.measure(
-        makeMeasureSpec(0, UNSPECIFIED),
-        makeMeasureSpec(0, UNSPECIFIED));
+        makeSizeSpec(0, UNSPECIFIED),
+        makeSizeSpec(0, UNSPECIFIED));
     mLithoView.layout(
         0,
         0,
@@ -110,8 +111,8 @@ public class LithoViewTest {
             .build());
 
     nullLithoView.measure(
-        makeMeasureSpec(0, UNSPECIFIED),
-        makeMeasureSpec(0, UNSPECIFIED));
+        makeSizeSpec(0, UNSPECIFIED),
+        makeSizeSpec(0, UNSPECIFIED));
     nullLithoView.layout(
         0,
         0,
@@ -132,8 +133,8 @@ public class LithoViewTest {
     mLithoView.setComponentTree(mockComponentTree);
     mLithoView.suppressMeasureComponentTree(true);
     mLithoView.measure(
-        makeMeasureSpec(width, EXACTLY),
-        makeMeasureSpec(height, EXACTLY));
+        makeSizeSpec(width, EXACTLY),
+        makeSizeSpec(height, EXACTLY));
 
     verify(mockComponentTree, never())
         .measure(anyInt(), anyInt(), any(int[].class), anyBoolean());
@@ -185,7 +186,7 @@ public class LithoViewTest {
     mLithoView.setComponentTree(componentTree);
 
     mLithoView.setLayoutParams(new ViewGroup.LayoutParams(0, 200));
-    mLithoView.measure(makeMeasureSpec(0, UNSPECIFIED), makeMeasureSpec(200, EXACTLY));
+    mLithoView.measure(makeSizeSpec(0, UNSPECIFIED), makeSizeSpec(200, EXACTLY));
     mLithoView.layout(0, 0, mLithoView.getMeasuredWidth(), mLithoView.getMeasuredHeight());
 
     // View got measured.
@@ -219,9 +220,9 @@ public class LithoViewTest {
 
     mLithoView.setLayoutParams(
         new RecyclerViewLayoutManagerOverrideParams(
-            SizeSpec.makeSizeSpec(100, SizeSpec.AT_MOST),
-            SizeSpec.makeSizeSpec(200, SizeSpec.AT_MOST)));
-    mLithoView.measure(makeMeasureSpec(0, UNSPECIFIED), makeMeasureSpec(0, UNSPECIFIED));
+            makeSizeSpec(100, AT_MOST),
+            makeSizeSpec(200, AT_MOST)));
+    mLithoView.measure(makeSizeSpec(0, UNSPECIFIED), makeSizeSpec(0, UNSPECIFIED));
     mLithoView.layout(0, 0, mLithoView.getMeasuredWidth(), mLithoView.getMeasuredHeight());
 
     // View got measured.

--- a/litho-it/src/test/java/com/facebook/litho/LithoViewTestHelperTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/LithoViewTestHelperTest.java
@@ -9,8 +9,7 @@
 
 package com.facebook.litho;
 
-import static android.view.View.MeasureSpec.UNSPECIFIED;
-import static android.view.View.MeasureSpec.makeMeasureSpec;
+import static com.facebook.litho.SizeSpec.UNSPECIFIED;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 import com.facebook.litho.config.ComponentsConfiguration;
@@ -52,8 +51,8 @@ public class LithoViewTestHelperTest {
     final LithoView lithoView = new LithoView(RuntimeEnvironment.application);
     lithoView.setComponentTree(componentTree);
     lithoView.measure(
-        makeMeasureSpec(0, UNSPECIFIED),
-        makeMeasureSpec(0, UNSPECIFIED));
+        SizeSpec.makeSizeSpec(0, UNSPECIFIED),
+        SizeSpec.makeSizeSpec(0, UNSPECIFIED));
 
     final String string = LithoViewTestHelper.viewToString(lithoView);
 
@@ -89,8 +88,8 @@ public class LithoViewTestHelperTest {
     final LithoView lithoView = new LithoView(RuntimeEnvironment.application);
     lithoView.setComponentTree(componentTree);
     lithoView.measure(
-        makeMeasureSpec(0, UNSPECIFIED),
-        makeMeasureSpec(0, UNSPECIFIED));
+        SizeSpec.makeSizeSpec(0, UNSPECIFIED),
+        SizeSpec.makeSizeSpec(0, UNSPECIFIED));
     lithoView.layout(0, 0, lithoView.getMeasuredWidth(), lithoView.getMeasuredHeight());
 
     final String string = LithoViewTestHelper.viewToString(lithoView);

--- a/litho-it/src/test/java/com/facebook/litho/MountStateRemountInPlaceTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/MountStateRemountInPlaceTest.java
@@ -11,11 +11,11 @@ package com.facebook.litho;
 
 import static android.graphics.Color.BLACK;
 import static android.graphics.Color.WHITE;
-import static android.view.View.MeasureSpec.AT_MOST;
-import static android.view.View.MeasureSpec.EXACTLY;
-import static android.view.View.MeasureSpec.makeMeasureSpec;
+import static com.facebook.litho.SizeSpec.AT_MOST;
+import static com.facebook.litho.SizeSpec.EXACTLY;
 import static com.facebook.litho.FrameworkLogEvents.EVENT_PREPARE_MOUNT;
 import static com.facebook.litho.FrameworkLogEvents.PARAM_MOVED_COUNT;
+import static com.facebook.litho.SizeSpec.makeSizeSpec;
 import static com.facebook.litho.testing.TestDrawableComponent.create;
 import static com.facebook.litho.testing.helper.ComponentTestHelper.mountComponent;
 import static org.assertj.core.api.Java6Assertions.assertThat;
@@ -270,8 +270,8 @@ public class MountStateRemountInPlaceTest {
                 .incrementalMount(false)
                 .layoutDiffing(false)
                 .build(),
-            makeMeasureSpec(100, AT_MOST),
-            makeMeasureSpec(100, AT_MOST));
+            makeSizeSpec(100, AT_MOST),
+            makeSizeSpec(100, AT_MOST));
 
     assertThat(firstComponent.wasOnMountCalled()).isTrue();
     assertThat(firstComponent.wasOnBindCalled()).isTrue();
@@ -318,8 +318,8 @@ public class MountStateRemountInPlaceTest {
                 .incrementalMount(false)
                 .layoutDiffing(false)
                 .build(),
-            makeMeasureSpec(100, EXACTLY),
-            makeMeasureSpec(100, EXACTLY));
+            makeSizeSpec(100, EXACTLY),
+            makeSizeSpec(100, EXACTLY));
 
     assertThat(firstComponent.wasOnMountCalled()).isTrue();
     assertThat(firstComponent.wasOnBindCalled()).isTrue();
@@ -366,8 +366,8 @@ public class MountStateRemountInPlaceTest {
                 .incrementalMount(false)
                 .layoutDiffing(false)
                 .build(),
-            makeMeasureSpec(100, EXACTLY),
-            makeMeasureSpec(100, EXACTLY));
+            makeSizeSpec(100, EXACTLY),
+            makeSizeSpec(100, EXACTLY));
 
     assertThat(firstComponent.wasOnMountCalled()).isTrue();
     assertThat(firstComponent.wasOnBindCalled()).isTrue();

--- a/litho-it/src/test/java/com/facebook/litho/UniqueTransitionKeysTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/UniqueTransitionKeysTest.java
@@ -12,7 +12,6 @@ package com.facebook.litho;
 import static com.facebook.litho.testing.assertj.LithoAssertions.assertThat;
 import static org.robolectric.RuntimeEnvironment.application;
 
-import android.view.View;
 import com.facebook.litho.testing.testrunner.ComponentsTestRunner;
 import com.facebook.litho.testing.util.InlineLayoutSpec;
 import org.junit.Rule;
@@ -57,8 +56,8 @@ public class UniqueTransitionKeysTest {
             c,
             mHasUniqueTransitionKeys,
             ComponentTree.generateComponentTreeId(),
-            View.MeasureSpec.makeMeasureSpec(100, View.MeasureSpec.EXACTLY),
-            View.MeasureSpec.makeMeasureSpec(100, View.MeasureSpec.EXACTLY),
+            SizeSpec.makeSizeSpec(100, SizeSpec.EXACTLY),
+            SizeSpec.makeSizeSpec(100, SizeSpec.EXACTLY),
             LayoutState.CalculateLayoutSource.TEST);
     layoutState.getTransitionKeyMapping();
   }
@@ -74,8 +73,8 @@ public class UniqueTransitionKeysTest {
             c,
             mHasNonUniqueTransitionKeys,
             ComponentTree.generateComponentTreeId(),
-            View.MeasureSpec.makeMeasureSpec(100, View.MeasureSpec.EXACTLY),
-            View.MeasureSpec.makeMeasureSpec(100, View.MeasureSpec.EXACTLY),
+            SizeSpec.makeSizeSpec(100, SizeSpec.EXACTLY),
+            SizeSpec.makeSizeSpec(100, SizeSpec.EXACTLY),
             LayoutState.CalculateLayoutSource.TEST);
     assertThat(layoutState.getTransitionKeyMapping()).isNotNull();
   }

--- a/litho-it/src/test/java/com/facebook/litho/sections/processor/TreePropTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/sections/processor/TreePropTest.java
@@ -9,9 +9,9 @@
 
 package com.facebook.litho.sections.processor;
 
-import static android.view.View.MeasureSpec.EXACTLY;
-import static android.view.View.MeasureSpec.UNSPECIFIED;
-import static android.view.View.MeasureSpec.makeMeasureSpec;
+import static com.facebook.litho.SizeSpec.EXACTLY;
+import static com.facebook.litho.SizeSpec.UNSPECIFIED;
+import static com.facebook.litho.SizeSpec.makeSizeSpec;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 import android.app.Activity;
@@ -66,7 +66,7 @@ public class TreePropTest {
 
     LithoView lithoView = new LithoView(mContext);
     lithoView.setComponent(component);
-    lithoView.measure(makeMeasureSpec(1000, EXACTLY), makeMeasureSpec(0, UNSPECIFIED));
+    lithoView.measure(makeSizeSpec(1000, EXACTLY), makeSizeSpec(0, UNSPECIFIED));
 
     assertThat(propALeaf1.mProp).isEqualTo(treePropA);
     // TreePropTestMiddleSpec modifies "propB".

--- a/litho-it/src/test/java/com/facebook/litho/utils/MeasureUtilsTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/utils/MeasureUtilsTest.java
@@ -9,7 +9,6 @@
 
 package com.facebook.litho.utils;
 
-import static android.view.View.MeasureSpec.makeMeasureSpec;
 import static com.facebook.litho.SizeSpec.AT_MOST;
 import static com.facebook.litho.SizeSpec.EXACTLY;
 import static com.facebook.litho.SizeSpec.UNSPECIFIED;
@@ -20,7 +19,6 @@ import static com.facebook.litho.utils.MeasureUtils.measureWithDesiredPx;
 import static com.facebook.litho.utils.MeasureUtils.measureWithEqualDimens;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
-import android.view.View.MeasureSpec;
 import com.facebook.litho.Size;
 import com.facebook.litho.testing.testrunner.ComponentsTestRunner;
 import org.junit.Test;
@@ -322,17 +320,17 @@ public class MeasureUtilsTest {
 
   @Test
   public void testGetViewMeasureSpecExactly() {
-    assertThat(getViewMeasureSpec(makeSizeSpec(10, EXACTLY))).isEqualTo(getViewMeasureSpec(makeMeasureSpec(10, MeasureSpec.EXACTLY)));
+    assertThat(getViewMeasureSpec(makeSizeSpec(10, EXACTLY))).isEqualTo(getViewMeasureSpec(makeSizeSpec(10, EXACTLY)));
   }
 
   @Test
   public void testGetViewMeasureSpecAtMost() {
-    assertThat(getViewMeasureSpec(makeSizeSpec(10, AT_MOST))).isEqualTo(getViewMeasureSpec(makeMeasureSpec(10, MeasureSpec.AT_MOST)));
+    assertThat(getViewMeasureSpec(makeSizeSpec(10, AT_MOST))).isEqualTo(getViewMeasureSpec(makeSizeSpec(10, AT_MOST)));
   }
 
   @Test
   public void testGetViewMeasureSpecUnspecified() {
-    assertThat(getViewMeasureSpec(makeSizeSpec(10, UNSPECIFIED))).isEqualTo(getViewMeasureSpec(makeMeasureSpec(10, MeasureSpec.UNSPECIFIED)));
+    assertThat(getViewMeasureSpec(makeSizeSpec(10, UNSPECIFIED))).isEqualTo(getViewMeasureSpec(makeSizeSpec(10, UNSPECIFIED)));
   }
 
   @Test

--- a/litho-it/src/test/java/com/facebook/litho/widget/ProgressSpecTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/widget/ProgressSpecTest.java
@@ -11,9 +11,9 @@ package com.facebook.litho.widget;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
-import android.view.View;
 import com.facebook.litho.ComponentContext;
 import com.facebook.litho.LithoView;
+import com.facebook.litho.SizeSpec;
 import com.facebook.litho.testing.helper.ComponentTestHelper;
 import com.facebook.litho.testing.testrunner.ComponentsTestRunner;
 import org.junit.Before;
@@ -46,8 +46,8 @@ public class ProgressSpecTest {
     LithoView view = getMountedView();
 
     view.measure(
-        View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED),
-        View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED));
+        SizeSpec.makeSizeSpec(0, SizeSpec.UNSPECIFIED),
+        SizeSpec.makeSizeSpec(0, SizeSpec.UNSPECIFIED));
 
     assertThat(view.getMeasuredWidth()).isEqualTo(ProgressSpec.DEFAULT_SIZE);
     assertThat(view.getMeasuredHeight()).isEqualTo(ProgressSpec.DEFAULT_SIZE);

--- a/litho-testing/src/main/java/com/facebook/litho/testing/helper/ComponentTestHelper.java
+++ b/litho-testing/src/main/java/com/facebook/litho/testing/helper/ComponentTestHelper.java
@@ -9,9 +9,9 @@
 
 package com.facebook.litho.testing.helper;
 
-import static android.view.View.MeasureSpec.EXACTLY;
-import static android.view.View.MeasureSpec.UNSPECIFIED;
-import static android.view.View.MeasureSpec.makeMeasureSpec;
+import static com.facebook.litho.SizeSpec.EXACTLY;
+import static com.facebook.litho.SizeSpec.UNSPECIFIED;
+import static com.facebook.litho.SizeSpec.makeSizeSpec;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.graphics.Rect;
@@ -187,8 +187,8 @@ public final class ComponentTestHelper {
             .incrementalMount(incrementalMountEnabled)
             .layoutDiffing(false)
             .build(),
-        makeMeasureSpec(width, EXACTLY),
-        makeMeasureSpec(height, EXACTLY));
+        makeSizeSpec(width, EXACTLY),
+        makeSizeSpec(height, EXACTLY));
   }
 
   /**
@@ -204,8 +204,8 @@ public final class ComponentTestHelper {
     return mountComponent(
         lithoView,
         componentTree,
-        makeMeasureSpec(100, EXACTLY),
-        makeMeasureSpec(100, EXACTLY));
+        makeSizeSpec(100, EXACTLY),
+        makeSizeSpec(100, EXACTLY));
   }
 
   /**
@@ -308,8 +308,8 @@ public final class ComponentTestHelper {
     return getSubComponents(
         context,
         component,
-        makeMeasureSpec(1000, EXACTLY),
-        makeMeasureSpec(0, UNSPECIFIED));
+        makeSizeSpec(1000, EXACTLY),
+        makeSizeSpec(0, UNSPECIFIED));
   }
 
   /**
@@ -388,7 +388,7 @@ public final class ComponentTestHelper {
    * @param view The component view to measure and layout
    */
   public static void measureAndLayout(View view) {
-    view.measure(makeMeasureSpec(1000, EXACTLY), makeMeasureSpec(0, UNSPECIFIED));
+    view.measure(makeSizeSpec(1000, EXACTLY), makeSizeSpec(0, UNSPECIFIED));
     view.layout(0, 0, view.getMeasuredWidth(), view.getMeasuredHeight());
   }
 

--- a/litho-widget/src/main/java/com/facebook/litho/widget/HorizontalScrollSpec.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/HorizontalScrollSpec.java
@@ -244,8 +244,8 @@ class HorizontalScrollSpec {
       // component-based content, which would trigger a layout pass in the
       // UI thread.
       mLithoView.measure(
-          MeasureSpec.makeMeasureSpec(mComponentWidth, MeasureSpec.EXACTLY),
-          MeasureSpec.makeMeasureSpec(mComponentHeight, MeasureSpec.EXACTLY));
+          SizeSpec.makeSizeSpec(mComponentWidth, MeasureSpec.EXACTLY),
+          SizeSpec.makeSizeSpec(mComponentHeight, MeasureSpec.EXACTLY));
 
       // The mounted view always gets exact dimensions from the framework.
       setMeasuredDimension(

--- a/litho-widget/src/main/java/com/facebook/litho/widget/SectionsRecyclerView.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/SectionsRecyclerView.java
@@ -18,6 +18,7 @@ import com.facebook.litho.ComponentContext;
 import com.facebook.litho.ComponentTree;
 import com.facebook.litho.HasLithoViewChildren;
 import com.facebook.litho.LithoView;
+import com.facebook.litho.SizeSpec;
 import java.util.List;
 
 /**
@@ -97,7 +98,7 @@ public class SectionsRecyclerView extends SwipeRefreshLayout implements HasLitho
   private void measureStickyHeader(int parentWidth) {
     measureChild(
         mStickyHeader,
-        MeasureSpec.makeMeasureSpec(parentWidth, MeasureSpec.EXACTLY),
+        SizeSpec.makeSizeSpec(parentWidth, SizeSpec.EXACTLY),
         MeasureSpec.UNSPECIFIED);
   }
 


### PR DESCRIPTION
This fixes an overflow bug on devices running API 17 (Jelly Bean) caused by [this](https://github.com/facebook/yoga/commit/3a82d2b1a8f5b65a2c3bd1407552d3ed2226238e) update to Yoga to use a large float value for undefined.

See AOSP source for reference:
https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/view/View.java#24636