### PR TITLE
Add parallelism on CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
     docker:
       - image: passy/android-circleci-litho:v27-2
     resource_class: large
+    parallelism: 4
     steps:
       - checkout
       - run:


### PR DESCRIPTION
* Add a parallelism flag with value equal to 4, same as the number_of_threads
for the build jobs for Gradle & BUCK

Related to #254 