### PR TITLE
Restructure Circle CI config.yml to use Workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.0
 
 container_config: &container_config
   docker:
-    - image: passy/android-circleci-litho:v27-2
+    - image: passy/android-circleci-litho:v27-3
   working_directory: ~/litho-working-dir
   environment:
     # Borrowed from https://github.com/chrisbanes/tivi/blob/master/.circleci/config.yml
@@ -30,18 +30,12 @@ gradle_caches_path: &gradle_caches_path
 gradle_wrapper_path: &gradle_wrapper_path
   ~/.gradle/wrapper
 
-buck_path: &buck_path
-  ~/buck
-
-android_sdk_path: &android_sdk_path
-  ~/android-sdk
-
 attach_workspace: &attach_workspace
   attach_workspace:
     at: ~/litho-working-dir/workspace
 
 repo_cache_key: &repo_cache_key
-  key: v1-jars-{{ checksum "workspace/repo/build.gradle" }}-{{ checksum  "workspace/repo/gradle.properties" }}
+  key: v2-jars-{{ checksum "workspace/repo/build.gradle" }}-{{ checksum  "workspace/repo/gradle.properties" }}
 
 restore_repo: &restore_repo
   restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,18 @@ container_config: &container_config
     ANDROID_HOME: '/home/circleci/android-sdk'
     ANDROID_NDK_REPOSITORY: "/home/circleci/android-ndk"
 
+circle_ci_android_container_config: &circle_ci_android_container_config
+  docker:
+    - image: circleci/android:api-27-alpha
+  working_directory: ~/litho-working-dir
+  environment:
+    # Borrowed from https://github.com/chrisbanes/tivi/blob/master/.circleci/config.yml 
+    # Sometimes gradle_tests_run job would fail with OOM error from CI. This is an attempt to fix it!
+    _JAVA_OPTIONS: "-Xmx1500m -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -XX:ParallelGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2"
+    TERM: 'dumb'
+    ANDROID_HOME: '/home/circleci/litho-working-dir/workspace/android-sdk'
+    ANDROID_NDK_REPOSITORY: '/home/circleci/litho-working-dir/workspace/android-ndk'
+
 gradle_caches_path: &gradle_caches_path
   ~/.gradle/caches
 
@@ -29,7 +41,7 @@ attach_workspace: &attach_workspace
     at: ~/litho-working-dir/workspace
 
 repo_cache_key: &repo_cache_key
-  key: jars-{{ checksum "workspace/repo/build.gradle" }}-{{ checksum  "workspace/repo/gradle.properties" }}
+  key: v1-jars-{{ checksum "workspace/repo/build.gradle" }}-{{ checksum  "workspace/repo/gradle.properties" }}
 
 restore_repo: &restore_repo
   restore_cache:
@@ -37,7 +49,7 @@ restore_repo: &restore_repo
 
 setup_buck: &setup_buck
   name: Set up BUCK
-  command: echo "export PATH=$HOME/buck/bin:$PATH" >> $BASH_ENV
+  command: echo "export PATH=$HOME/litho-working-dir/workspace/buck/bin:$PATH" >> $BASH_ENV
 
 setup_keys: &setup_keys
   name: Set up keys
@@ -55,7 +67,7 @@ download_buck_dependencies: &download_buck_dependencies
   name: Buck Dependencies
   command: |
     cd workspace/repo
-    $HOME/buck/bin/buck fetch //...
+    $HOME/litho-working-dir/workspace/buck/bin/buck fetch //...
 
 save_litho_gradle_tests_results: &save_litho_gradle_tests_results
   name: Save Litho Gradle tests results
@@ -89,14 +101,20 @@ jobs:
     steps:
       - run: mkdir -p workspace
       - run: mkdir -p repo
+      - run: mv $HOME/buck/ ~/litho-working-dir/workspace/
+      - run: mv $HOME/android-sdk/ ~/litho-working-dir/workspace/
+      - run: mv $HOME/android-ndk/ ~/litho-working-dir/workspace/
       - checkout:
           path: workspace/repo
       - persist_to_workspace:
           root: workspace
           paths:
             - repo
+            - buck
+            - android-sdk
+            - android-ndk
   build:
-    <<: *container_config
+    <<: *circle_ci_android_container_config
     steps:
       - *attach_workspace
       - restore_cache:
@@ -116,11 +134,9 @@ jobs:
           paths:
             - *gradle_caches_path
             - *gradle_wrapper_path
-            - *buck_path
-            - *android_sdk_path
 
   buck_sample_build:
-    <<: *container_config
+    <<: *circle_ci_android_container_config
     steps:
       - *attach_workspace
       - restore_cache:
@@ -135,7 +151,7 @@ jobs:
             buck build sample --num-threads=4
 
   buck_sample_barebones_build:
-    <<: *container_config
+    <<: *circle_ci_android_container_config
     steps:
       - *attach_workspace
       - restore_cache:
@@ -150,7 +166,7 @@ jobs:
             buck build sample-barebones --num-threads=4
 
   buck_sample_codelab_build:
-    <<: *container_config
+    <<: *circle_ci_android_container_config
     steps:
       - *attach_workspace
       - restore_cache:
@@ -165,7 +181,7 @@ jobs:
             buck build sample-codelab --num-threads=4
 
   gradle_sample_kotlin_build:
-    <<: *container_config
+    <<: *circle_ci_android_container_config
     steps:
       - *attach_workspace
       - restore_cache:
@@ -179,7 +195,7 @@ jobs:
             ./gradlew :sample-kotlin:assembleDebug --no-daemon --max-workers 2
 
   buck_litho_it_tests_run:
-    <<: *container_config
+    <<: *circle_ci_android_container_config
     steps:
       - *attach_workspace
       - restore_cache:
@@ -198,7 +214,7 @@ jobs:
       - *store_litho_artifacts
 
   buck_litho_it_powermock_tests_run:
-    <<: *container_config
+    <<: *circle_ci_android_container_config
     steps:
       - *attach_workspace
       - restore_cache:
@@ -217,7 +233,7 @@ jobs:
       - *store_litho_artifacts
 
   gradle_tests_run:
-    <<: *container_config
+    <<: *circle_ci_android_container_config
     steps:
       - *attach_workspace
       - restore_cache:
@@ -235,11 +251,9 @@ jobs:
       - *store_litho_artifacts
 
   publish_snapshot:
-    <<: *container_config
+    <<: *circle_ci_android_container_config
     steps:
       - *attach_workspace
-      - restore_cache:
-          <<: *repo_cache_key
       - run:
           name: Publish Snapshot
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,131 @@
 version: 2.0
+aliases:
+  # NDK Cache aliases
+  - &restore-cache-ndk
+    keys:
+      - v1-android-ndk-{{ arch }}-r15c-{{ checksum "workspace/repo/scripts/circle-ci-android-setup.sh" }}
+  - &save-cache-ndk
+    paths:
+      - /opt/ndk
+    key: v1-android-ndk-{{ arch }}-r15c-{{ checksum "workspace/repo/scripts/circle-ci-android-setup.sh" }}
 
-container_config: &container_config
-  docker:
-    - image: passy/android-circleci-litho:v27-3
-  working_directory: ~/litho-working-dir
-  environment:
-    # Borrowed from https://github.com/chrisbanes/tivi/blob/master/.circleci/config.yml
-    # Sometimes gradle_tests_run job would fail with OOM error from CI. This is an attempt to fix it!
-    _JAVA_OPTIONS: "-Xmx1500m -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -XX:ParallelGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2"
-    TERM: 'dumb'
-    ANDROID_HOME: '/home/circleci/android-sdk'
-    ANDROID_NDK_REPOSITORY: "/home/circleci/android-ndk"
+  # SDK Cache aliases
+  - &restore-cache-android-packages
+    keys:
+      - v1-android-sdkmanager-packages-{{ arch }}-api-27-alpha-{{ checksum "workspace/repo/scripts/circle-ci-android-setup.sh" }}
+  - &save-cache-android-packages
+    paths:
+      - /opt/android/sdk
+    key: v1-android-sdkmanager-packages-{{ arch }}-api-27-alpha-{{ checksum "workspace/repo/scripts/circle-ci-android-setup.sh" }}
+
+  # BUCK Cache aliases
+  - &restore-cache-buck
+    keys:
+      - v2-buck-{{ arch }}-master
+  - &save-cache-buck
+    paths:
+      - workspace/buck
+    key: v2-buck-{{ arch }}-master
+
+  # Build dependencies Cache aliases
+  - &restore-cache-apt
+    keys:
+      - v1-apt-{{ arch }}-{{ .Branch }}-{{ checksum "workspace/repo/scripts/apt-get-android-deps.sh" }}
+  - &save-cache-apt
+    paths:
+      - ~/vendor/apt
+    key: v1-apt-{{ arch }}-{{ .Branch }}-{{ checksum "workspace/repo/scripts/apt-get-android-deps.sh" }}
+
+  # Repo Cache aliases
+  - &restore-repo-cache
+    keys:
+      - v2-jars-{{ checksum "workspace/repo/build.gradle" }}-{{ checksum  "workspace/repo/gradle.properties" }}
+  - &save-repo-cache
+    paths:
+      - ~/.gradle/caches
+      - ~/.gradle/wrapper
+    key: v2-jars-{{ checksum "workspace/repo/build.gradle" }}-{{ checksum  "workspace/repo/gradle.properties" }}
+
+  # Install Android NDK packages needed
+  - &install-ndk
+    name: Install Android NDK
+    command: source $HOME/litho-working-dir/workspace/repo/scripts/circle-ci-android-setup.sh && getAndroidNDK
+
+  # Install Android SDK packages needed
+  - &install-android-packages
+    name: Install Android SDK Packages
+    command: source $HOME/litho-working-dir/workspace/repo/scripts/circle-ci-android-setup.sh && installAndroidSDK
+
+  # Install build dependencies
+  - &install-android-build-dependencies
+    name: Install Android Build Dependencies
+    command: $HOME/litho-working-dir/workspace/repo/scripts/apt-get-android-deps.sh
+
+  #  Create Android NDK directory
+  - &create-android-ndk-dir
+    name: Create Android NDK Directory
+    command: |
+      if [[ ! -e /opt/ndk ]]; then
+        sudo mkdir /opt/ndk
+      fi
+      sudo chown ${USER:=$(/usr/bin/id -run)}:$USER /opt/ndk
+
+  # Download and build BUCK
+  - &download-buck
+    name: Install BUCK
+    command: |
+      if [[ ! -e $HOME/litho-working-dir/workspace/buck ]]; then
+        git clone https://github.com/facebook/buck.git $HOME/litho-working-dir/workspace/buck --branch master --depth=1
+      fi
+      cd $HOME/litho-working-dir/workspace/buck && ant
+      $HOME/litho-working-dir/workspace/buck/bin/buck --version
+
+  # Export BUCK in PATH
+  - &setup-buck
+    name: Set up BUCK
+    command: echo "export PATH=$HOME/litho-working-dir/workspace/buck/bin:$PATH" >> $BASH_ENV
+
+  # Setup KEY
+  - &setup-keys
+    name: Set up keys
+    command: "[ -n \"$KEY\" ] && openssl aes-256-cbc -d -in scripts/setup-keys.enc -k $KEY >> gradle.properties || true"
+
+  # Unset KEY
+  - &unset-key
+    name: Unset key
+    command: "export KEY=\"<unset>\""
+
+  # Download project Gradle dependencies
+  - &download-gradle-dependencies
+    name: Download Gradle dependencies
+    command: ./workspace/repo/gradlew dependencies --no-daemon
+  
+  # Download project BUCK dependencies
+  - &download-buck-dependencies
+    name: Buck Dependencies
+    command: |
+      cd workspace/repo
+      $HOME/litho-working-dir/workspace/buck/bin/buck fetch //...
+
+  # Save Litho BUCK test results
+  - &save-litho-buck-tests-results
+    name: Save Litho BUCK tests results
+    command: |
+      cd workspace
+      mkdir -p junit
+      cd repo
+      find . -type f -name "litho_it_*tests*.xml" -exec cp {} ~/litho-working-dir/workspace/junit/ \;
+    when: always
+
+  # Save Litho Gradle test results
+  - &save-litho-gradle-tests-results
+    name: Save Litho Gradle tests results
+    command: |
+      cd workspace
+      mkdir -p junit
+      cd repo
+      find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/litho-working-dir/workspace/junit/ \;
+    when: always
 
 circle_ci_android_container_config: &circle_ci_android_container_config
   docker:
@@ -21,65 +136,11 @@ circle_ci_android_container_config: &circle_ci_android_container_config
     # Sometimes gradle_tests_run job would fail with OOM error from CI. This is an attempt to fix it!
     _JAVA_OPTIONS: "-Xmx1500m -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -XX:ParallelGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2"
     TERM: 'dumb'
-    ANDROID_HOME: '/home/circleci/litho-working-dir/workspace/android-sdk'
-    ANDROID_NDK_REPOSITORY: '/home/circleci/litho-working-dir/workspace/android-ndk'
-
-gradle_caches_path: &gradle_caches_path
-  ~/.gradle/caches
-
-gradle_wrapper_path: &gradle_wrapper_path
-  ~/.gradle/wrapper
+    ANDROID_NDK_REPOSITORY: '/opt/ndk'
 
 attach_workspace: &attach_workspace
   attach_workspace:
     at: ~/litho-working-dir/workspace
-
-repo_cache_key: &repo_cache_key
-  key: v2-jars-{{ checksum "workspace/repo/build.gradle" }}-{{ checksum  "workspace/repo/gradle.properties" }}
-
-restore_repo: &restore_repo
-  restore_cache:
-    <<: *repo_cache_key
-
-setup_buck: &setup_buck
-  name: Set up BUCK
-  command: echo "export PATH=$HOME/litho-working-dir/workspace/buck/bin:$PATH" >> $BASH_ENV
-
-setup_keys: &setup_keys
-  name: Set up keys
-  command: "[ -n \"$KEY\" ] && openssl aes-256-cbc -d -in scripts/setup-keys.enc -k $KEY >> gradle.properties || true"
-
-unset_key: &unset_key
-  name: Unset key
-  command: "export KEY=\"<unset>\""
-
-download_gradle_dependencies: &download_gradle_dependencies
-  name: Download Gradle dependencies
-  command: ./workspace/repo/gradlew dependencies --no-daemon
-
-download_buck_dependencies: &download_buck_dependencies
-  name: Buck Dependencies
-  command: |
-    cd workspace/repo
-    $HOME/litho-working-dir/workspace/buck/bin/buck fetch //...
-
-save_litho_gradle_tests_results: &save_litho_gradle_tests_results
-  name: Save Litho Gradle tests results
-  command: |
-    cd workspace
-    mkdir -p junit
-    cd repo
-    find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/litho-working-dir/workspace/junit/ \;
-  when: always
-
-save_litho_buck_tests_results: &save_litho_buck_tests_results
-  name: Save Litho BUCK tests results
-  command: |
-    cd workspace
-    mkdir -p junit
-    cd repo
-    find . -type f -name "litho_it_*tests*.xml" -exec cp {} ~/litho-working-dir/workspace/junit/ \;
-  when: always
 
 store_litho_tests_results: &store_litho_tests_results
   store_test_results:
@@ -91,52 +152,68 @@ store_litho_artifacts: &store_litho_artifacts
 
 jobs:
   checkout_code:
-    <<: *container_config
+    <<: *circle_ci_android_container_config
     steps:
+      # Create folders needed
       - run: mkdir -p workspace
       - run: mkdir -p repo
-      - run: mv $HOME/buck/ ~/litho-working-dir/workspace/
-      - run: mv $HOME/android-sdk/ ~/litho-working-dir/workspace/
-      - run: mv $HOME/android-ndk/ ~/litho-working-dir/workspace/
+      
+      # Checkout code into repo
       - checkout:
           path: workspace/repo
+      
+      # Manage Android NDK caches
+      - run: *create-android-ndk-dir
+      - restore-cache: *restore-cache-ndk
+      - run: *install-ndk
+      - save-cache: *save-cache-ndk
+
+      # Manage Android build depencies caches
+      - restore-cache: *restore-cache-apt
+      - run: *install-android-build-dependencies
+      - save-cache: *save-cache-apt
+
+      # Manage Android SDK caches
+      - restore-cache: *restore-cache-android-packages
+      - run: *install-android-packages
+      - save-cache: *save-cache-android-packages
+
+      # Manage BUCK caches
+      - restore-cache: *restore-cache-buck
+      - run: *download-buck
+      - save-cache: *save-cache-buck
+      
+      # Persist repo code
       - persist_to_workspace:
           root: workspace
           paths:
             - repo
-            - buck
-            - android-sdk
-            - android-ndk
+      
   build:
     <<: *circle_ci_android_container_config
     steps:
       - *attach_workspace
-      - restore_cache:
-          <<: *repo_cache_key
-      - run:
-          <<: *setup_keys
-      - run:
-          <<: *unset_key
-      - run:
-          <<: *download_gradle_dependencies
-      - run:
-          <<: *setup_buck
-      - run:
-          <<: *download_buck_dependencies
-      - save_cache:
-          <<: *repo_cache_key
-          paths:
-            - *gradle_caches_path
-            - *gradle_wrapper_path
+      - run: *create-android-ndk-dir
+      - restore-cache: *restore-cache-ndk
+      - restore-cache: *restore-cache-buck
+      - restore_cache: *restore-repo-cache
+      - run: *setup-keys
+      - run: *unset-key
+      - run: *download-gradle-dependencies
+      - run: *setup-buck
+      - run: *download-buck-dependencies
+      - save_cache: *save-repo-cache
 
   buck_sample_build:
     <<: *circle_ci_android_container_config
     steps:
       - *attach_workspace
-      - restore_cache:
-          <<: *repo_cache_key
-      - run:
-          <<: *setup_buck
+      - run: *create-android-ndk-dir
+      - restore_cache: *restore-repo-cache
+      - restore-cache: *restore-cache-ndk
+      - restore-cache: *restore-cache-buck
+      - restore-cache: *restore-cache-android-packages
+      - run: *setup-buck
       - run:
           name: Build sample with BUCK
           command: |
@@ -148,10 +225,12 @@ jobs:
     <<: *circle_ci_android_container_config
     steps:
       - *attach_workspace
-      - restore_cache:
-          <<: *repo_cache_key
-      - run:
-          <<: *setup_buck
+      - run: *create-android-ndk-dir
+      - restore_cache: *restore-repo-cache
+      - restore-cache: *restore-cache-ndk
+      - restore-cache: *restore-cache-buck
+      - restore-cache: *restore-cache-android-packages
+      - run: *setup-buck
       - run:
           name: Build sample-barebones with BUCK
           command: |
@@ -163,10 +242,12 @@ jobs:
     <<: *circle_ci_android_container_config
     steps:
       - *attach_workspace
-      - restore_cache:
-          <<: *repo_cache_key
-      - run:
-          <<: *setup_buck
+      - run: *create-android-ndk-dir
+      - restore_cache: *restore-repo-cache
+      - restore-cache: *restore-cache-ndk
+      - restore-cache: *restore-cache-buck
+      - restore-cache: *restore-cache-android-packages
+      - run: *setup-buck
       - run:
           name: Build sample-codelab with BUCK
           command: |
@@ -178,10 +259,12 @@ jobs:
     <<: *circle_ci_android_container_config
     steps:
       - *attach_workspace
-      - restore_cache:
-          <<: *repo_cache_key
-      - run:
-          <<: *setup_buck
+      - run: *create-android-ndk-dir
+      - restore_cache: *restore-repo-cache
+      - restore-cache: *restore-cache-ndk
+      - restore-cache: *restore-cache-buck
+      - restore-cache: *restore-cache-android-packages
+      - run: *setup-buck
       - run:
           name: Build sample-kotlin with Gradle
           command: |
@@ -192,18 +275,19 @@ jobs:
     <<: *circle_ci_android_container_config
     steps:
       - *attach_workspace
-      - restore_cache:
-          <<: *repo_cache_key
-      - run:
-          <<: *setup_buck
+      - run: *create-android-ndk-dir
+      - restore_cache: *restore-repo-cache
+      - restore-cache: *restore-cache-ndk
+      - restore-cache: *restore-cache-buck
+      - restore-cache: *restore-cache-android-packages
+      - run: *setup-buck
       - run:
           name: Run litho-it tests with BUCK
           command: |
             cd workspace/repo
             buck fetch //...
             buck test litho-it/src/test/... --num-threads=4 --xml litho_it_tests.xml
-      - run:
-          <<: *save_litho_buck_tests_results
+      - run: *save-litho-buck-tests-results
       - *store_litho_tests_results
       - *store_litho_artifacts
 
@@ -211,18 +295,19 @@ jobs:
     <<: *circle_ci_android_container_config
     steps:
       - *attach_workspace
-      - restore_cache:
-          <<: *repo_cache_key
-      - run:
-          <<: *setup_buck
+      - run: *create-android-ndk-dir
+      - restore_cache: *restore-repo-cache
+      - restore-cache: *restore-cache-ndk
+      - restore-cache: *restore-cache-buck
+      - restore-cache: *restore-cache-android-packages
+      - run: *setup-buck
       - run:
           name: Run lith-it-powermock tests with BUCK
           command: |
             cd workspace/repo
             buck fetch //...
             buck test litho-it-powermock/src/test/... --num-threads=4 --xml litho_it_powermock_tests.xml
-      - run:
-          <<: *save_litho_buck_tests_results
+      - run: *save-litho-buck-tests-results
       - *store_litho_tests_results
       - *store_litho_artifacts
 
@@ -230,17 +315,18 @@ jobs:
     <<: *circle_ci_android_container_config
     steps:
       - *attach_workspace
-      - restore_cache:
-          <<: *repo_cache_key
-      - run:
-          <<: *setup_buck
+      - run: *create-android-ndk-dir
+      - restore_cache: *restore-repo-cache
+      - restore-cache: *restore-cache-ndk
+      - restore-cache: *restore-cache-buck
+      - restore-cache: *restore-cache-android-packages
+      - run: *setup-buck
       - run:
           name: Run tests with Gradle
           command: |
             cd workspace/repo
             ./gradlew test --no-daemon --max-workers 2
-      - run:
-          <<: *save_litho_gradle_tests_results
+      - run: *save-litho-gradle-tests-results
       - *store_litho_tests_results
       - *store_litho_artifacts
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,58 +1,282 @@
-version: 2
+version: 2.0
+
+container_config: &container_config
+  docker:
+    - image: passy/android-circleci-litho:v27-2
+  working_directory: ~/litho-working-dir
+  environment:
+    # Borrowed from https://github.com/chrisbanes/tivi/blob/master/.circleci/config.yml
+    # Sometimes gradle_tests_run job would fail with OOM error from CI. This is an attempt to fix it!
+    _JAVA_OPTIONS: "-Xmx1500m -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -XX:ParallelGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2"
+    TERM: 'dumb'
+    ANDROID_HOME: '/home/circleci/android-sdk'
+    ANDROID_NDK_REPOSITORY: "/home/circleci/android-ndk"
+
+gradle_caches_path: &gradle_caches_path
+  ~/.gradle/caches
+
+gradle_wrapper_path: &gradle_wrapper_path
+  ~/.gradle/wrapper
+
+buck_path: &buck_path
+  ~/buck
+
+android_sdk_path: &android_sdk_path
+  ~/android-sdk
+
+attach_workspace: &attach_workspace
+  attach_workspace:
+    at: ~/litho-working-dir/workspace
+
+repo_cache_key: &repo_cache_key
+  key: jars-{{ checksum "workspace/repo/build.gradle" }}-{{ checksum  "workspace/repo/gradle.properties" }}
+
+restore_repo: &restore_repo
+  restore_cache:
+    <<: *repo_cache_key
+
+setup_buck: &setup_buck
+  name: Set up BUCK
+  command: echo "export PATH=$HOME/buck/bin:$PATH" >> $BASH_ENV
+
+setup_keys: &setup_keys
+  name: Set up keys
+  command: "[ -n \"$KEY\" ] && openssl aes-256-cbc -d -in scripts/setup-keys.enc -k $KEY >> gradle.properties || true"
+
+unset_key: &unset_key
+  name: Unset key
+  command: "export KEY=\"<unset>\""
+
+download_gradle_dependencies: &download_gradle_dependencies
+  name: Download Gradle dependencies
+  command: ./workspace/repo/gradlew dependencies --no-daemon
+
+download_buck_dependencies: &download_buck_dependencies
+  name: Buck Dependencies
+  command: |
+    cd workspace/repo
+    $HOME/buck/bin/buck fetch //...
+
+save_litho_gradle_tests_results: &save_litho_gradle_tests_results
+  name: Save Litho Gradle tests results
+  command: |
+    cd workspace
+    mkdir -p junit
+    cd repo
+    find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/litho-working-dir/workspace/junit/ \;
+  when: always
+
+save_litho_buck_tests_results: &save_litho_buck_tests_results
+  name: Save Litho BUCK tests results
+  command: |
+    cd workspace
+    mkdir -p junit
+    cd repo
+    find . -type f -name "litho_it_*tests*.xml" -exec cp {} ~/litho-working-dir/workspace/junit/ \;
+  when: always
+
+store_litho_tests_results: &store_litho_tests_results
+  store_test_results:
+    path: ~/litho-working-dir/workspace/junit
+
+store_litho_artifacts: &store_litho_artifacts
+  store_artifacts:
+    path: ~/litho-working-dir/workspace/junit
+
 jobs:
-  build:
-    environment:
-      TERM: 'dumb'
-      ANDROID_HOME: '/home/circleci/android-sdk'
-      ANDROID_NDK_REPOSITORY: "/home/circleci/android-ndk"
-    docker:
-      - image: passy/android-circleci-litho:v27-3
-    resource_class: large
+  checkout_code:
+    <<: *container_config
     steps:
-      - checkout
-      - run:
-          name: Set up keys
-          command: "[ -n \"$KEY\" ] && openssl aes-256-cbc -d -in scripts/setup-keys.enc -k $KEY >> gradle.properties || true"
-      - run:
-          name: Unset key
-          command: "export KEY=\"<unset>\""
-      - restore_cache:
-          key: jars-v2-{{ checksum "build.gradle" }}-{{ checksum "gradle.properties" }}
-      - run:
-          name: Set up Buck
-          command: echo "export PATH=$HOME/buck/bin:$PATH" >> $BASH_ENV
-      - run:
-          name: Gradle Dependencies
-          command: ./gradlew androidDependencies
-      - run:
-          name: Buck Dependencies
-          command: $HOME/buck/bin/buck fetch //...
-      - save_cache:
+      - run: mkdir -p workspace
+      - run: mkdir -p repo
+      - checkout:
+          path: workspace/repo
+      - persist_to_workspace:
+          root: workspace
           paths:
-            - ~/.gradle
-          key: jars-v2-{{ checksum "build.gradle" }}-{{ checksum "gradle.properties" }}
+            - repo
+  build:
+    <<: *container_config
+    steps:
+      - *attach_workspace
+      - restore_cache:
+          <<: *repo_cache_key
       - run:
-          name: Run Tests
+          <<: *setup_keys
+      - run:
+          <<: *unset_key
+      - run:
+          <<: *download_gradle_dependencies
+      - run:
+          <<: *setup_buck
+      - run:
+          <<: *download_buck_dependencies
+      - save_cache:
+          <<: *repo_cache_key
+          paths:
+            - *gradle_caches_path
+            - *gradle_wrapper_path
+            - *buck_path
+            - *android_sdk_path
+
+  buck_sample_build:
+    <<: *container_config
+    steps:
+      - *attach_workspace
+      - restore_cache:
+          <<: *repo_cache_key
+      - run:
+          <<: *setup_buck
+      - run:
+          name: Build sample with BUCK
           command: |
-            export PATH="$HOME/buck/bin:$PATH"
-            echo "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" >> .buckjavaargs.local
+            cd workspace/repo
+            buck fetch //...
             buck build sample --num-threads=4
+
+  buck_sample_barebones_build:
+    <<: *container_config
+    steps:
+      - *attach_workspace
+      - restore_cache:
+          <<: *repo_cache_key
+      - run:
+          <<: *setup_buck
+      - run:
+          name: Build sample-barebones with BUCK
+          command: |
+            cd workspace/repo
+            buck fetch //...
             buck build sample-barebones --num-threads=4
+
+  buck_sample_codelab_build:
+    <<: *container_config
+    steps:
+      - *attach_workspace
+      - restore_cache:
+          <<: *repo_cache_key
+      - run:
+          <<: *setup_buck
+      - run:
+          name: Build sample-codelab with BUCK
+          command: |
+            cd workspace/repo
+            buck fetch //...
             buck build sample-codelab --num-threads=4
-            buck test litho-it/src/test/... --num-threads=4
-            buck test litho-it-powermock/src/test/... --num-threads=4
-            ./gradlew test
-            ./gradlew :sample-kotlin:assembleDebug
+
+  gradle_sample_kotlin_build:
+    <<: *container_config
+    steps:
+      - *attach_workspace
+      - restore_cache:
+          <<: *repo_cache_key
+      - run:
+          <<: *setup_buck
+      - run:
+          name: Build sample-kotlin with Gradle
+          command: |
+            cd workspace/repo
+            ./gradlew :sample-kotlin:assembleDebug --no-daemon --max-workers 2
+
+  buck_litho_it_tests_run:
+    <<: *container_config
+    steps:
+      - *attach_workspace
+      - restore_cache:
+          <<: *repo_cache_key
+      - run:
+          <<: *setup_buck
+      - run:
+          name: Run litho-it tests with BUCK
+          command: |
+            cd workspace/repo
+            buck fetch //...
+            buck test litho-it/src/test/... --num-threads=4 --xml litho_it_tests.xml
+      - run:
+          <<: *save_litho_buck_tests_results
+      - *store_litho_tests_results
+      - *store_litho_artifacts
+
+  buck_litho_it_powermock_tests_run:
+    <<: *container_config
+    steps:
+      - *attach_workspace
+      - restore_cache:
+          <<: *repo_cache_key
+      - run:
+          <<: *setup_buck
+      - run:
+          name: Run lith-it-powermock tests with BUCK
+          command: |
+            cd workspace/repo
+            buck fetch //...
+            buck test litho-it-powermock/src/test/... --num-threads=4 --xml litho_it_powermock_tests.xml
+      - run:
+          <<: *save_litho_buck_tests_results
+      - *store_litho_tests_results
+      - *store_litho_artifacts
+
+  gradle_tests_run:
+    <<: *container_config
+    steps:
+      - *attach_workspace
+      - restore_cache:
+          <<: *repo_cache_key
+      - run:
+          <<: *setup_buck
+      - run:
+          name: Run tests with Gradle
+          command: |
+            cd workspace/repo
+            ./gradlew test --no-daemon --max-workers 2
+      - run:
+          <<: *save_litho_gradle_tests_results
+      - *store_litho_tests_results
+      - *store_litho_artifacts
+
+  publish_snapshot:
+    <<: *container_config
+    steps:
+      - *attach_workspace
+      - restore_cache:
+          <<: *repo_cache_key
       - run:
           name: Publish Snapshot
-          command: scripts/circle-ci-publish-snapshot.sh
-      - run:
-          name: Save test results
           command: |
-            mkdir -p ~/junit/
-            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/junit/ \;
-          when: always
-      - store_test_results:
-          path: ~/junit
-      - store_artifacts:
-          path: ~/junit
+            cd workspace/repo
+            scripts/circle-ci-publish-snapshot.sh
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - checkout_code
+      - build:
+          requires:
+            - checkout_code
+      - buck_sample_build:
+          requires:
+            - build
+      - buck_sample_barebones_build:
+          requires:
+            - build
+      - buck_sample_codelab_build:
+          requires:
+            - build
+      - gradle_sample_kotlin_build:
+          requires:
+            - build
+      - buck_litho_it_tests_run:
+          requires:
+            - build
+      - buck_litho_it_powermock_tests_run:
+          requires:
+            - build
+      - gradle_tests_run:
+          requires:
+            - build
+      - publish_snapshot:
+          requires:
+            - buck_litho_it_tests_run
+            - buck_litho_it_powermock_tests_run
+            - gradle_tests_run

--- a/scripts/apt-get-android-deps.sh
+++ b/scripts/apt-get-android-deps.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+echo "Downloading package lists..."
+sudo apt-get update -y
+
+if ! [[ -d ~/vendor/apt ]]; then
+  mkdir -p ~/vendor/apt
+fi
+
+# First check for archives cache
+if ! [[ -d ~/vendor/apt/archives ]]; then
+  # It doesn't so download the packages
+  echo "Downloading build dependencies..."
+  sudo apt-get install --download-only ant autoconf automake g++ gcc libqt5widgets5 lib32z1 lib32stdc++6 make maven python-dev python3-dev qml-module-qtquick-controls qtdeclarative5-dev file -y
+  # Then move them to our cache directory
+  sudo cp -R /var/cache/apt ~/vendor/
+  # Making sure our user has ownership, in order to cache
+  sudo chown -R ${USER:=$(/usr/bin/id -run)}:$USER ~/vendor/apt
+fi
+
+# Install all packages in the cache
+echo "Installing build dependencies..."
+sudo dpkg -i ~/vendor/apt/archives/*.deb

--- a/scripts/circle-ci-android-setup.sh
+++ b/scripts/circle-ci-android-setup.sh
@@ -44,7 +44,5 @@ function installAndroidSDK {
   echo > $ANDROID_HOME/licenses/android-sdk-license
   echo -n d56f5187479451eabf01fb78af6dfcb131a6481e > $ANDROID_HOME/licenses/android-sdk-license
 
-  ls -la $ANDROID_HOME
-
   installsdk 'build-tools;25.0.3' 'build-tools;26.0.2' 'platforms;android-25' 'platforms;android-26' 'ndk-bundle' 'extras;android;m2repository'
 }

--- a/scripts/circle-ci-android-setup.sh
+++ b/scripts/circle-ci-android-setup.sh
@@ -22,29 +22,29 @@ function installsdk() {
   echo y | "$ANDROID_HOME"/tools/bin/sdkmanager $PROXY_ARGS "$@"
 }
 
+function getAndroidNDK {
+  NDK_HOME="/opt/ndk"
+  DEPS="$NDK_HOME/installed-dependencies"
+
+  if [ ! -e $DEPS ]; then
+    cd $NDK_HOME
+    echo "Downloading NDK..."
+    curl -o ndk.zip https://dl.google.com/android/repository/android-ndk-r15c-linux-x86_64.zip
+    unzip -o -q ndk.zip
+    echo "Installed Android NDK at $NDK_HOME"
+    touch $DEPS
+    rm ndk.zip
+  fi
+}
+
 function installAndroidSDK {
-  if [[ ! -d "$HOME/android-sdk" ]]; then
-    TMP=/tmp/sdk$$.zip
-    download 'https://dl.google.com/android/repository/tools_r25.2.3-linux.zip' $TMP
-    unzip -qod "$HOME/android-sdk" $TMP
-    rm $TMP
-  fi
-
-  export ANDROID_NDK_REPOSITORY=$HOME/android-ndk
-  if [[ ! -d "$ANDROID_NDK_REPOSITORY/android-ndk-r15c" ]]; then
-    TMP=/tmp/ndk$$.zip
-    mkdir -p "$ANDROID_NDK_REPOSITORY"
-    download 'https://dl.google.com/android/repository/android-ndk-r15c-linux-x86_64.zip' $TMP
-    unzip -qod "$ANDROID_NDK_REPOSITORY" "$TMP"
-    rm $TMP
-  fi
-
-  export ANDROID_HOME=$HOME/android-sdk
   export PATH="$ANDROID_HOME/platform-tools:$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin:$PATH"
 
   mkdir -p $ANDROID_HOME/licenses/
   echo > $ANDROID_HOME/licenses/android-sdk-license
   echo -n d56f5187479451eabf01fb78af6dfcb131a6481e > $ANDROID_HOME/licenses/android-sdk-license
+
+  ls -la $ANDROID_HOME
 
   installsdk 'build-tools;25.0.3' 'build-tools;26.0.2' 'platforms;android-25' 'platforms;android-26' 'ndk-bundle' 'extras;android;m2repository'
 }


### PR DESCRIPTION
This PR leverages CircleCI Workflows in order to build samples & run tests in parallel.

It first builds the whole project and then starts to run the following jobs in parallel:

1) `sample` build with BUCK
2) `sample-barebones` build with BUCK
3) `sample-codelab` build with BUCK
4) `sample-kotlin` build with Gradle
5) `litho-it` tests run with BUCK
6) `litho-it-powermock` tests run with BUCK
7) Tests run with Gradle

Every job that runs tests, also stores test results and artifacts. Note on this, the previous `regex` used was not grepping tests results from `litho-it` & `litho-it-powermock`. In order to save those results as well, I modified the jobs that run tests using `BUCK` to output the results in a `*.xml` file respectively.

## Structure of `config.yml` file

* Declare any references to be used in following steps
* Declare Jobs that will run in Workflow
  -  Each Job consists of:
     - Container Configuration
     - Workspace attaching
     - Cache restoration
     - Main work execution (checkout code/build/test runs)
     - Store tests results (optional)
     - Store tests artifacts
* Declare the Workflow alongside Jobs execution order and Jobs inter-dependencies

## Points to improve

* Currently `Workflow` is based on @passy 's Docker image specially created for `Litho`: 
1) Based on `circle-ci-android` Docker image
2) Installs `BUCK`
3) Installs `androidSdk`
4) Warms up some caches in order to reduce build time on the first job.

Although this is great, Circle CI caches images on `containers` so it was pretty hard to end up on a container with that specific Docker image cached. It did happen though a few times (luckily enough there were some times I needed quick feedback loop and the container had the image cached), effectively letting the Job setup the environment in 1 second. 

By switching to `circle-ci-android` Docker image and pulling inside a configuration job, that would of course run as a first Job in the `Workflow` would drammatically increase our chances to find a cached Docker image and decrease the 5-6 mins of environment setup to 1 second. Considering the number of jobs in the `Workflow` (10 atm) it can help reduce the average completion time at an order of magnitude 😃 

## Interesting facts about this PR

* It took me around 3 days or so 🕵️
* Ultimately final working version in my branch on my fork consisted of 59 fixup commits 😂 
* It took 269 job runs to finally get it to work 😮
* Average `Workflow` run is 40 mins (will explain below some tips that can improve the time) ⏲
* CI provisioning is a tough task 😂 

## Some related pics

### Cached image inside container
![Cached image inside container](https://user-images.githubusercontent.com/1070871/39297768-10c17ad8-494d-11e8-8884-a420b9fb8e72.png)

### Final success Workflow run
![Final success Workflow run](https://user-images.githubusercontent.com/1070871/39297781-16b11a8e-494d-11e8-9f93-cc8ae944e654.png)
