### PR TITLE
Allow publish_snapshot job to run for master branch only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,3 +376,6 @@ workflows:
             - buck_litho_it_tests_run
             - buck_litho_it_powermock_tests_run
             - gradle_tests_run
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
Currently, `publish_snapshot` runs for every commit which adds around 2-3 mins per `Workflow` run but then fails if the commit was not in `master`. Adding a filter on that Job allows it to shut down early instead of spending time restoring not needed caches, only to fail after.