### PR TITLE
Prop default without @JvmField annotation

### DIFF
--- a/litho-processor/src/main/java/com/facebook/litho/specmodels/generator/ComponentBodyGenerator.java
+++ b/litho-processor/src/main/java/com/facebook/litho/specmodels/generator/ComponentBodyGenerator.java
@@ -33,6 +33,7 @@ import com.facebook.litho.specmodels.model.InterStageInputParamModel;
 import com.facebook.litho.specmodels.model.MethodParamModel;
 import com.facebook.litho.specmodels.model.PropModel;
 import com.facebook.litho.specmodels.model.RenderDataDiffModel;
+import com.facebook.litho.specmodels.model.SpecElementType;
 import com.facebook.litho.specmodels.model.SpecMethodModel;
 import com.facebook.litho.specmodels.model.SpecModel;
 import com.facebook.litho.specmodels.model.SpecModelUtils;
@@ -282,13 +283,31 @@ public class ComponentBodyGenerator {
                       .addMember("optional", "$L", prop.isOptional())
                       .build());
       if (prop.hasDefault(specModel.getPropDefaults())) {
-        fieldBuilder.initializer("$L.$L", specModel.getSpecName(), prop.getName());
+        assignProperInitializer(fieldBuilder, specModel, prop);
       }
 
       typeSpecDataHolder.addField(fieldBuilder.build());
     }
 
     return typeSpecDataHolder.build();
+  }
+
+  private static void assignProperInitializer(FieldSpec.Builder fieldBuilder, SpecModel specModel,
+      PropModel prop) {
+
+    boolean isKotlinSingleton = specModel.getSpecElementType() == SpecElementType.KOTLIN_SINGLETON;
+
+    if (isKotlinSingleton) {
+      String propName = prop.getName();
+      String propAccessor = "get"
+          + propName.substring(0, 1).toUpperCase()
+          + propName.substring(1)
+          + "()";
+
+      fieldBuilder.initializer("$L.$L.$L", specModel.getSpecName(), "INSTANCE", propAccessor);
+    } else {
+      fieldBuilder.initializer("$L.$L", specModel.getSpecName(), prop.getName());
+    }
   }
 
   public static TypeSpecDataHolder generateInjectedFields(SpecModel specModel) {

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/lithography/components/FeedItemComponentSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/lithography/components/FeedItemComponentSpec.kt
@@ -42,7 +42,7 @@ object FeedItemComponentSpec {
   @OnCreateLayout
   fun onCreateLayout(
       c: ComponentContext,
-      @Prop artist: Artist) =
+      @Prop artist: Artist): Component =
       Column.create(c)
           .child(
               Column.create(c)

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/lithography/components/SingleImageComponentSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/lithography/components/SingleImageComponentSpec.kt
@@ -24,7 +24,6 @@ import com.facebook.litho.fresco.FrescoImage
 @LayoutSpec
 object SingleImageComponentSpec {
   @PropDefault
-  @JvmField
   val imageAspectRatio = 1f
 
   @OnCreateLayout


### PR DESCRIPTION
This PR generates a proper accessor for not `@JvmField` annotated `PropDefaults`

* Unfortunately this won't work if the `@PropDefault` field gets annotated with `@JvmField`. Did not find any workaround to it, since @JvmField annotation is not forwarded on `PropModel`'s annotations/external annotations.

* Addresses the last issue on #267