### PR TITLE
Fix getting-started anchor

### DIFF
--- a/docs/_docs/getting-started.md
+++ b/docs/_docs/getting-started.md
@@ -20,7 +20,7 @@ permalink: /docs/getting-started
 <article class="code-block" id="doc-buck">
     {{ buck | markdownify }}
 </article>
-<article class="code-block" id="doc-testing">
+<article class="code-block" id="doc-testing-java">
     {{ testing-java | markdownify }}
 </article>
 <article class="code-block" id="doc-testing-kt">


### PR DESCRIPTION
Woops, my bad. Didn't match with the link before.

Test Plan:
Edited in Chrome inspector and works now.