### PR TITLE
Synchronize against source map when copying TreeProps

### DIFF
--- a/litho-core/src/main/java/com/facebook/litho/TreeProps.java
+++ b/litho-core/src/main/java/com/facebook/litho/TreeProps.java
@@ -51,7 +51,9 @@ public class TreeProps {
   public static TreeProps copy(TreeProps source) {
     final TreeProps newProps = ComponentsPools.acquireTreeProps();
     if (source != null) {
-      newProps.mMap.putAll(source.mMap);
+      synchronized (source.mMap) {
+        newProps.mMap.putAll(source.mMap);
+      }
     }
 
     return newProps;


### PR DESCRIPTION
Internally, putAll iterates over the source map, which requires synchronizing according to Collections.synchronizedMap documentation.

This is a follow-up to eb60ba23ff6334f47614aa9725718688ac03e95b and  009555525681f19b28309e7a987e24a09557fc9b