### PR TITLE
Fix varArg builder methods for Kotlin

### DIFF
--- a/litho-it/src/test/java/com/facebook/litho/specmodels/generator/BuilderGeneratorTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/specmodels/generator/BuilderGeneratorTest.java
@@ -18,6 +18,8 @@ package com.facebook.litho.specmodels.generator;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
+import com.facebook.litho.Component;
+import com.facebook.litho.ComponentContext;
 import com.facebook.litho.annotations.LayoutSpec;
 import com.facebook.litho.annotations.OnCreateLayout;
 import com.facebook.litho.annotations.OnEvent;
@@ -88,9 +90,22 @@ public class BuilderGeneratorTest {
     public void dimenResTypeWithBoxFloatArg(@Prop(resType = ResType.DIMEN_TEXT) Float size) {}
   }
 
+  @LayoutSpec
+  static class TestKotlinVarArgSpec {
+    public static final TestKotlinVarArgSpec INSTANCE = null;
+
+    @OnCreateLayout
+    public final Component onCreateLayout(
+        ComponentContext c,
+        @Prop(varArg = "color") java.util.List<? extends android.graphics.Color> colors) {
+      return null;
+    }
+  }
+
   private SpecModel mSpecModel;
   private SpecModel mResTypeVarArgsSpecModel;
   private SpecModel mDimenResTypeWithBoxFloatArgSpecModel;
+  private SpecModel mKotlinWildcardsVarArgBuildersSpecModel;
 
   @Before
   public void setUp() {
@@ -120,6 +135,17 @@ public class BuilderGeneratorTest {
             RunMode.NORMAL,
             null,
             null);
+
+    TypeElement typeElementKotlinVarArgsWildcards = elements.getTypeElement(TestKotlinVarArgSpec
+        .class.getCanonicalName());
+    mKotlinWildcardsVarArgBuildersSpecModel = mLayoutSpecModelFactory.create(
+        elements,
+        types,
+        typeElementKotlinVarArgsWildcards,
+        mMessager,
+        RunMode.NORMAL,
+        null,
+        null);
   }
 
   @Test
@@ -527,5 +553,77 @@ public class BuilderGeneratorTest {
                 + "    mContext = null;\n"
                 + "  }\n"
                 + "}\n");
+  }
+
+  @Test
+  public void testKotlinVarArgWildcardsGenerate() {
+    TypeSpecDataHolder dataHolder =
+        BuilderGenerator.generate(mKotlinWildcardsVarArgBuildersSpecModel);
+    assertThat(dataHolder.getTypeSpecs()).hasSize(1);
+    assertThat(dataHolder.getTypeSpecs().get(0).toString())
+        .isEqualTo("public static class Builder extends com.facebook.litho.Component.Builder<Builder> {\n"
+            + "  private static final java.lang.String[] REQUIRED_PROPS_NAMES = new String[] {\"colors\"};\n"
+            + "\n"
+            + "  private static final int REQUIRED_PROPS_COUNT = 1;\n"
+            + "\n"
+            + "  TestKotlinVarArg mTestKotlinVarArg;\n"
+            + "\n"
+            + "  com.facebook.litho.ComponentContext mContext;\n"
+            + "\n"
+            + "  private final java.util.BitSet mRequired = new java.util.BitSet(REQUIRED_PROPS_COUNT);\n"
+            + "\n"
+            + "  private void init(com.facebook.litho.ComponentContext context, int defStyleAttr, int defStyleRes,\n"
+            + "      TestKotlinVarArg testKotlinVarArgRef) {\n"
+            + "    super.init(context, defStyleAttr, defStyleRes, testKotlinVarArgRef);\n"
+            + "    mTestKotlinVarArg = testKotlinVarArgRef;\n"
+            + "    mContext = context;\n"
+            + "    mRequired.clear();\n"
+            + "  }\n"
+            + "\n"
+            + "  public Builder color(android.graphics.Color color) {\n"
+            + "    if (color == null) {\n"
+            + "      return this;\n"
+            + "    }\n"
+            + "    if (this.mTestKotlinVarArg.colors == null) {\n"
+            + "      this.mTestKotlinVarArg.colors = new java.util.ArrayList<android.graphics.Color>();\n"
+            + "    }\n"
+            + "    this.mTestKotlinVarArg.colors.add(color);\n"
+            + "    mRequired.set(0);\n"
+            + "    return this;\n"
+            + "  }\n"
+            + "\n"
+            + "  public Builder colors(java.util.List<android.graphics.Color> colors) {\n"
+            + "    if (colors == null) {\n"
+            + "      return this;\n"
+            + "    }\n"
+            + "    if (this.mTestKotlinVarArg.colors == null || this.mTestKotlinVarArg.colors.isEmpty()) {\n"
+            + "      this.mTestKotlinVarArg.colors = colors;\n"
+            + "    } else {\n"
+            + "      this.mTestKotlinVarArg.colors.addAll(colors);\n"
+            + "    }\n"
+            + "    mRequired.set(0);\n"
+            + "    return this;\n"
+            + "  }\n"
+            + "\n"
+            + "  @java.lang.Override\n"
+            + "  public Builder getThis() {\n"
+            + "    return this;\n"
+            + "  }\n"
+            + "\n"
+            + "  @java.lang.Override\n"
+            + "  public com.facebook.litho.specmodels.generator.BuilderGeneratorTest.TestKotlinVarArg build() {\n"
+            + "    checkArgs(REQUIRED_PROPS_COUNT, mRequired, REQUIRED_PROPS_NAMES);\n"
+            + "    TestKotlinVarArg testKotlinVarArgRef = mTestKotlinVarArg;\n"
+            + "    release();\n"
+            + "    return testKotlinVarArgRef;\n"
+            + "  }\n"
+            + "\n"
+            + "  @java.lang.Override\n"
+            + "  protected void release() {\n"
+            + "    super.release();\n"
+            + "    mTestKotlinVarArg = null;\n"
+            + "    mContext = null;\n"
+            + "  }\n"
+            + "}\n");
   }
 }

--- a/litho-it/src/test/java/com/facebook/litho/specmodels/generator/ComponentBodyGeneratorTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/specmodels/generator/ComponentBodyGeneratorTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import android.support.annotation.Nullable;
 import com.facebook.litho.Component;
+import com.facebook.litho.ComponentContext;
 import com.facebook.litho.Row;
 import com.facebook.litho.annotations.LayoutSpec;
 import com.facebook.litho.annotations.OnCreateLayout;
@@ -117,8 +118,21 @@ public class ComponentBodyGeneratorTest {
     public void testUpdateStateWithTransitionMethod() {}
   }
 
+  @LayoutSpec
+  static class TestKotlinWildcardsSpec {
+    public static final TestKotlinWildcardsSpec INSTANCE = null;
+
+    @OnCreateLayout
+    public final Component onCreateLayout(
+        ComponentContext c,
+        @Prop(varArg = "color") java.util.List<? extends android.graphics.Color> colors) {
+      return null;
+    }
+  }
+
   private SpecModel mSpecModelDI;
   private SpecModel mSpecModelWithTransitionDI;
+  private SpecModel mKotlinWildcardsSpecModel;
 
   @Before
   public void setUp() {
@@ -135,6 +149,11 @@ public class ComponentBodyGeneratorTest {
     mSpecModelWithTransitionDI =
         mLayoutSpecModelFactory.create(
             elements, types, typeElementWithTransition, mMessager, RunMode.NORMAL, null, null);
+
+    TypeElement typeElementKotlinVarArgsWildcards = elements.getTypeElement(TestKotlinWildcardsSpec
+        .class.getCanonicalName());
+    mKotlinWildcardsSpecModel = mLayoutSpecModelFactory.create(
+        elements, types, typeElementKotlinVarArgsWildcards, mMessager, RunMode.NORMAL, null, null);
   }
 
   @Test
@@ -214,6 +233,18 @@ public class ComponentBodyGeneratorTest {
                 + "    optional = false\n"
                 + ")\n"
                 + "com.facebook.litho.Component arg4;\n");
+  }
+
+  @Test
+  public void testGeneratePropsForKotlinWildcards() {
+    TypeSpecDataHolder dataHolder = ComponentBodyGenerator.generateProps(mKotlinWildcardsSpecModel);
+    assertThat(dataHolder.getFieldSpecs()).hasSize(1);
+    assertThat(dataHolder.getFieldSpecs().get(0).toString())
+        .isEqualTo("@com.facebook.litho.annotations.Prop(\n"
+            + "    resType = com.facebook.litho.annotations.ResType.NONE,\n"
+            + "    optional = false\n"
+            + ")\n"
+            + "java.util.List<android.graphics.Color> colors;\n");
   }
 
   @Test

--- a/litho-processor/src/main/java/com/facebook/litho/specmodels/generator/ComponentBodyGenerator.java
+++ b/litho-processor/src/main/java/com/facebook/litho/specmodels/generator/ComponentBodyGenerator.java
@@ -275,7 +275,7 @@ public class ComponentBodyGenerator {
 
     for (PropModel prop : props) {
       final FieldSpec.Builder fieldBuilder =
-          FieldSpec.builder(prop.getTypeName(), prop.getName())
+          FieldSpec.builder(getFieldTypeName(specModel, prop.getTypeName()), prop.getName())
               .addAnnotations(prop.getExternalAnnotations())
               .addAnnotation(
                   AnnotationSpec.builder(Prop.class)
@@ -304,6 +304,52 @@ public class ComponentBodyGenerator {
     } else {
       fieldBuilder.initializer("$L.$L", specModel.getSpecName(), prop.getName());
     }
+  }
+
+  private static TypeName getFieldTypeName(SpecModel specModel,
+      TypeName fieldTypeName) {
+
+    final boolean isKotlinSpec = specModel.getSpecElementType() == SpecElementType.KOTLIN_SINGLETON;
+
+    TypeName varArgTypeName;
+
+    if (isKotlinSpec) {
+      final String rawFieldType = fieldTypeName.toString();
+      final boolean isNotJvmSuppressWildcardsAnnotated =
+          KotlinSpecUtils.isNotJvmSuppressWildcardsAnnotated(rawFieldType);
+
+      /*
+       * If it is a JvmSuppressWildcards annotated type on a Kotlin Spec,
+       * we should fallback to previous type detection way.
+       * */
+      if (!isNotJvmSuppressWildcardsAnnotated) {
+        varArgTypeName = fieldTypeName;
+      } else {
+        String parameterizedFieldType = KotlinSpecUtils.getParameterizedFieldType(rawFieldType);
+
+        final String[] typeParts = parameterizedFieldType.split(" ");
+
+        // Just in case something has gone pretty wrong
+        if(typeParts.length < 3) {
+          varArgTypeName = fieldTypeName;
+        } else {
+          // Calculate appropriate ClassNames
+          final int indexOfStartDiamond = rawFieldType.indexOf("<");
+
+          final String fieldType = rawFieldType.substring(0, indexOfStartDiamond);
+          final ClassName rawType = KotlinSpecUtils.buildClassName(fieldType);
+
+          final String pureTypeName = typeParts[2];
+          final ClassName enclosedType = KotlinSpecUtils.buildClassName(pureTypeName);
+
+          varArgTypeName = ParameterizedTypeName.get(rawType, enclosedType);
+        }
+      }
+    } else {
+      // Fallback when it is a Java spec
+      varArgTypeName = fieldTypeName;
+    }
+    return varArgTypeName;
   }
 
   public static TypeSpecDataHolder generateInjectedFields(SpecModel specModel) {

--- a/litho-processor/src/main/java/com/facebook/litho/specmodels/generator/KotlinSpecUtils.java
+++ b/litho-processor/src/main/java/com/facebook/litho/specmodels/generator/KotlinSpecUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.litho.specmodels.generator;
+
+import com.squareup.javapoet.ClassName;
+
+/*
+* Helper methods to ease the way with Kotlin generated code
+* */
+public class KotlinSpecUtils {
+
+  public static boolean isNotJvmSuppressWildcardsAnnotated(String type) {
+    return type.contains("extends");
+  }
+
+  public static ClassName buildClassName(String typeName) {
+    final int lastIndexOfDotForPackage = typeName.lastIndexOf('.');
+    final int lastIndexOfDotForClass = typeName.lastIndexOf('.') + 1;
+
+    final String packageName = typeName.substring(0, lastIndexOfDotForPackage);
+    final String className = typeName.substring(lastIndexOfDotForClass);
+
+    return ClassName.get(packageName, className);
+  }
+
+  public static String getParameterizedFieldType(String type) {
+    final int indexOfStartDiamond = type.indexOf("<");
+    final int indexOfEndDiamond = type.indexOf(">");
+
+    return type.substring(indexOfStartDiamond + 1, indexOfEndDiamond);
+  }
+}


### PR DESCRIPTION
Due to Kotlin compiler applying wildcards on List types, there was an issue when generating from a Kotlin spec and using `varArg` Props.

Easy fix was to annotate List type with `JvmSuppressWildcards` but just in case someone forgets to do it, this PR is taking care of handling it seamlessly, by removing wildcards iff generating from Kotlin specs.

Addresses #373 