### PR TITLE
Port `errors` into `sample-kotlin`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ ext.deps = [
         supportTestRules   : 'com.android.support.test:rules:1.0.2',
         supportMultidex    : 'com.android.support:multidex:1.0.1',
         // Arch
-        archPaging         : 'android.arch.paging:runtime:1.0.0-alpha3',
+        archLifecycle      : 'android.arch.lifecycle:extensions:1.1.1',
         // First-party
         fresco             : 'com.facebook.fresco:fresco:1.9.0',
         soloader           : 'com.facebook.soloader:soloader:0.4.1',

--- a/sample-kotlin/build.gradle
+++ b/sample-kotlin/build.gradle
@@ -49,5 +49,5 @@ dependencies {
     implementation deps.kotlinStandardLib
     implementation deps.supportAppCompat
 
-    implementation deps.archPaging
+    implementation deps.archLifecycle
 }

--- a/sample-kotlin/src/main/AndroidManifest.xml
+++ b/sample-kotlin/src/main/AndroidManifest.xml
@@ -21,11 +21,13 @@
         android:allowBackup="true"
         android:label="Litho Sample"
         android:theme="@style/Theme.AppCompat.Light.DarkActionBar">
-        <activity android:name="com.fblitho.lithoktsample.MainActivity">
+        <activity android:name=".demo.DemoListActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <activity android:name="com.fblitho.lithoktsample.lithography.LithographyActivity"/>
+        <activity android:name=".errors.ErrorHandlingActivity" />
     </application>
 </manifest>

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/NavigatableDemoActivity.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/NavigatableDemoActivity.kt
@@ -20,6 +20,7 @@ import android.support.v7.app.AppCompatActivity
 import android.view.MenuItem
 import com.fblitho.lithoktsample.demo.DataModels
 import com.fblitho.lithoktsample.demo.DemoListActivity
+import com.fblitho.lithoktsample.demo.DemoListActivity.Companion.DEFAULT_INDEX
 import com.fblitho.lithoktsample.demo.DemoListActivity.Companion.INDEX
 
 @SuppressLint("Registered")
@@ -29,8 +30,8 @@ open class NavigatableDemoActivity : AppCompatActivity() {
     super.onCreate(savedInstanceState)
 
     intent
-        .getIntExtra(INDEX, -1)
-        .takeIf { it > -1 }
+        .getIntExtra(INDEX, DEFAULT_INDEX)
+        .takeIf { it != DEFAULT_INDEX }
         ?.let {
           supportActionBar?.setDisplayHomeAsUpEnabled(true)
           setTitleFromIndex(it)
@@ -49,7 +50,7 @@ open class NavigatableDemoActivity : AppCompatActivity() {
 
   private fun setTitleFromIndex(index: Int) {
     index
-        .takeIf { it > -1 }
+        .takeIf { it != DEFAULT_INDEX }
         ?.let {
           title = DataModels.DATA_MODELS[it].name
         }

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/NavigatableDemoActivity.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/NavigatableDemoActivity.kt
@@ -1,0 +1,73 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample
+
+import android.annotation.SuppressLint
+import android.content.Intent
+import android.os.Bundle
+import android.support.v4.app.NavUtils
+import android.support.v7.app.AppCompatActivity
+import android.view.MenuItem
+import com.fblitho.lithoktsample.demo.DataModels
+import com.fblitho.lithoktsample.demo.DemoListActivity
+import com.fblitho.lithoktsample.demo.DemoListActivity.Companion.INDICES
+import com.fblitho.lithoktsample.demo.DemoListDataModel
+import java.util.Arrays
+
+@SuppressLint("Registered")
+open class NavigatableDemoActivity : AppCompatActivity() {
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+
+    val indices = intent.getIntArrayExtra(INDICES)
+
+    if (indices != null) {
+      supportActionBar?.setDisplayHomeAsUpEnabled(true)
+      setTitleFromIndices(indices)
+    }
+  }
+
+  override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    when (item.itemId) {
+    // Respond to the action bar's Up/Home button
+      android.R.id.home -> {
+        NavUtils.navigateUpFromSameTask(this)
+        return true
+      }
+    }
+    return super.onOptionsItemSelected(item)
+  }
+
+  override fun getParentActivityIntent(): Intent? {
+    val indices = intent.getIntArrayExtra(DemoListActivity.INDICES) ?: return null
+
+    val parentIntent = Intent(this, DemoListActivity::class.java)
+    if (indices.size > 1) {
+      parentIntent.putExtra(DemoListActivity.INDICES, Arrays.copyOf(indices, indices.size - 1))
+    }
+
+    return parentIntent
+  }
+
+  private fun setTitleFromIndices(indices: IntArray) {
+    var dataModels: List<DemoListDataModel>? = DataModels.DATA_MODELS
+
+    for (i in 0 until indices.size - 1) {
+      dataModels = dataModels?.get(indices[i])?.datamodels
+    }
+
+    val title = dataModels?.get(indices[indices.size - 1])?.name
+    setTitle(title)
+  }
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/NavigatableDemoActivity.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/NavigatableDemoActivity.kt
@@ -20,9 +20,7 @@ import android.support.v7.app.AppCompatActivity
 import android.view.MenuItem
 import com.fblitho.lithoktsample.demo.DataModels
 import com.fblitho.lithoktsample.demo.DemoListActivity
-import com.fblitho.lithoktsample.demo.DemoListActivity.Companion.INDICES
-import com.fblitho.lithoktsample.demo.DemoListDataModel
-import java.util.Arrays
+import com.fblitho.lithoktsample.demo.DemoListActivity.Companion.INDEX
 
 @SuppressLint("Registered")
 open class NavigatableDemoActivity : AppCompatActivity() {
@@ -30,44 +28,30 @@ open class NavigatableDemoActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
-    val indices = intent.getIntArrayExtra(INDICES)
-
-    if (indices != null) {
-      supportActionBar?.setDisplayHomeAsUpEnabled(true)
-      setTitleFromIndices(indices)
-    }
+    intent
+        .getIntExtra(INDEX, -1)
+        .takeIf { it > -1 }
+        ?.let {
+          supportActionBar?.setDisplayHomeAsUpEnabled(true)
+          setTitleFromIndex(it)
+        }
   }
 
-  override fun onOptionsItemSelected(item: MenuItem): Boolean {
-    when (item.itemId) {
-    // Respond to the action bar's Up/Home button
-      android.R.id.home -> {
+  override fun onOptionsItemSelected(item: MenuItem): Boolean =
+      if (item.itemId == android.R.id.home) {
         NavUtils.navigateUpFromSameTask(this)
-        return true
+        true
+      } else {
+        super.onOptionsItemSelected(item)
       }
-    }
-    return super.onOptionsItemSelected(item)
-  }
 
-  override fun getParentActivityIntent(): Intent? {
-    val indices = intent.getIntArrayExtra(DemoListActivity.INDICES) ?: return null
+  override fun getParentActivityIntent(): Intent = Intent(this, DemoListActivity::class.java)
 
-    val parentIntent = Intent(this, DemoListActivity::class.java)
-    if (indices.size > 1) {
-      parentIntent.putExtra(DemoListActivity.INDICES, Arrays.copyOf(indices, indices.size - 1))
-    }
-
-    return parentIntent
-  }
-
-  private fun setTitleFromIndices(indices: IntArray) {
-    var dataModels: List<DemoListDataModel>? = DataModels.DATA_MODELS
-
-    for (i in 0 until indices.size - 1) {
-      dataModels = dataModels?.get(indices[i])?.datamodels
-    }
-
-    val title = dataModels?.get(indices[indices.size - 1])?.name
-    setTitle(title)
+  private fun setTitleFromIndex(index: Int) {
+    index
+        .takeIf { it > -1 }
+        ?.let {
+          title = DataModels.DATA_MODELS[it].name
+        }
   }
 }

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DataModels.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DataModels.kt
@@ -1,0 +1,36 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.demo
+
+import com.fblitho.lithoktsample.lithography.LithographyActivity
+import com.fblitho.lithoktsample.errors.ErrorHandlingActivity
+
+object DataModels {
+
+  val DATA_MODELS = listOf(
+      DemoListDataModel("Lithography", LithographyActivity::class.java),
+      DemoListDataModel("Error boundaries", ErrorHandlingActivity::class.java))
+
+  fun getDataModels(indices: IntArray?): List<DemoListDataModel>? {
+    var dataModels: List<DemoListDataModel>? = DATA_MODELS
+
+    if (indices == null) {
+      return dataModels
+    }
+
+    for (i in indices.indices) {
+      dataModels = dataModels?.get(indices[i])?.datamodels
+    }
+    return dataModels
+  }
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DataModels.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DataModels.kt
@@ -22,7 +22,7 @@ object DataModels {
       DemoListDataModel("Error boundaries", ErrorHandlingActivity::class.java))
 
   fun getDataModels(index: Int): List<DemoListDataModel> =
-      if (index == -1) {
+      if (index == DemoListActivity.DEFAULT_INDEX) {
         DATA_MODELS
       } else {
         DATA_MODELS[index].datamodels ?: emptyList()

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DataModels.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DataModels.kt
@@ -12,8 +12,8 @@
 
 package com.fblitho.lithoktsample.demo
 
-import com.fblitho.lithoktsample.lithography.LithographyActivity
 import com.fblitho.lithoktsample.errors.ErrorHandlingActivity
+import com.fblitho.lithoktsample.lithography.LithographyActivity
 
 object DataModels {
 
@@ -21,16 +21,10 @@ object DataModels {
       DemoListDataModel("Lithography", LithographyActivity::class.java),
       DemoListDataModel("Error boundaries", ErrorHandlingActivity::class.java))
 
-  fun getDataModels(indices: IntArray?): List<DemoListDataModel>? {
-    var dataModels: List<DemoListDataModel>? = DATA_MODELS
-
-    if (indices == null) {
-      return dataModels
-    }
-
-    for (i in indices.indices) {
-      dataModels = dataModels?.get(indices[i])?.datamodels
-    }
-    return dataModels
-  }
+  fun getDataModels(index: Int): List<DemoListDataModel> =
+      if (index == -1) {
+        DATA_MODELS
+      } else {
+        DATA_MODELS[index].datamodels ?: emptyList()
+      }
 }

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DemoListActivity.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DemoListActivity.kt
@@ -22,7 +22,7 @@ class DemoListActivity : NavigatableDemoActivity() {
   public override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
-    val index = intent.getIntExtra(INDEX, -1)
+    val index = intent.getIntExtra(INDEX, DEFAULT_INDEX)
     val dataModels = DataModels.getDataModels(index)
 
     val componentContext = ComponentContext(this)
@@ -36,5 +36,6 @@ class DemoListActivity : NavigatableDemoActivity() {
 
   companion object {
     const val INDEX = "INDEX"
+    const val DEFAULT_INDEX = -1
   }
 }

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DemoListActivity.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DemoListActivity.kt
@@ -22,20 +22,20 @@ class DemoListActivity : NavigatableDemoActivity() {
   public override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
-    val indices = intent.getIntArrayExtra(INDICES)
-    val dataModels = DataModels.getDataModels(indices)
+    val index = intent.getIntExtra(INDEX, -1)
+    val dataModels = DataModels.getDataModels(index)
 
     val componentContext = ComponentContext(this)
     setContentView(
         LithoView.create(
             this,
             DemoListComponent.create(componentContext)
-                .dataModels(dataModels ?: emptyList())
-                .parentIndices(indices)
+                .dataModels(dataModels)
+                .parentIndex(index)
                 .build()))
   }
 
   companion object {
-    const val INDICES = "INDICES"
+    const val INDEX = "INDEX"
   }
 }

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DemoListActivity.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DemoListActivity.kt
@@ -1,0 +1,41 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.demo
+
+import android.os.Bundle
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.LithoView
+import com.fblitho.lithoktsample.NavigatableDemoActivity
+
+class DemoListActivity : NavigatableDemoActivity() {
+
+  public override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+
+    val indices = intent.getIntArrayExtra(INDICES)
+    val dataModels = DataModels.getDataModels(indices)
+
+    val componentContext = ComponentContext(this)
+    setContentView(
+        LithoView.create(
+            this,
+            DemoListComponent.create(componentContext)
+                .dataModels(dataModels ?: emptyList())
+                .parentIndices(indices)
+                .build()))
+  }
+
+  companion object {
+    const val INDICES = "INDICES"
+  }
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DemoListActivity.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DemoListActivity.kt
@@ -31,7 +31,6 @@ class DemoListActivity : NavigatableDemoActivity() {
             this,
             DemoListComponent.create(componentContext)
                 .dataModels(dataModels)
-                .parentIndex(index)
                 .build()))
   }
 

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DemoListComponentSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DemoListComponentSpec.kt
@@ -27,7 +27,6 @@ import com.facebook.litho.sections.common.RenderEvent
 import com.facebook.litho.sections.widget.RecyclerCollectionComponent
 import com.facebook.litho.widget.ComponentRenderInfo
 import com.facebook.litho.widget.RenderInfo
-import java.util.Arrays
 
 @LayoutSpec
 object DemoListComponentSpec {
@@ -51,27 +50,17 @@ object DemoListComponentSpec {
   @OnEvent(RenderEvent::class)
   fun onRender(
       c: ComponentContext,
-      @Prop parentIndices: IntArray?,
+      @Prop parentIndex: Int,
       @FromEvent model: DemoListDataModel,
-      @FromEvent index: Int): RenderInfo =
+      @FromEvent index: Int
+  ): RenderInfo =
       ComponentRenderInfo.create()
           .component(
               DemoListItemComponent.create(c)
                   .model(model)
-                  .currentIndices(getUpdatedIndices(parentIndices, index))
+                  .currentIndex(index)
                   .build())
           .build()
-
-  fun getUpdatedIndices(parentIndices: IntArray?, currentIndex: Int): IntArray {
-    if (parentIndices == null) {
-      return intArrayOf(currentIndex)
-    }
-
-    val updatedIndices = Arrays.copyOf(parentIndices, parentIndices.size + 1)
-    updatedIndices[parentIndices.size] = currentIndex
-
-    return updatedIndices
-  }
 
   /**
    * Called during DataDiffSection's diffing to determine if two objects represent the same item.
@@ -80,7 +69,8 @@ object DemoListComponentSpec {
    * @return true if the two objects in the event represent the same item.
    */
   @OnEvent(OnCheckIsSameItemEvent::class)
-  fun isSameItem(c: ComponentContext,
+  fun isSameItem(
+      c: ComponentContext,
       @FromEvent previousItem: DemoListDataModel,
       @FromEvent nextItem: DemoListDataModel
   ): Boolean = previousItem === nextItem
@@ -95,7 +85,8 @@ object DemoListComponentSpec {
   fun isSameContent(
       c: ComponentContext,
       @FromEvent previousItem: DemoListDataModel?,
-      @FromEvent nextItem: DemoListDataModel?): Boolean =
+      @FromEvent nextItem: DemoListDataModel?
+  ): Boolean =
   // We're only displaying the name so checking if that's equal here is enough for our use case.
       if (previousItem == null) {
         nextItem == null

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DemoListComponentSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DemoListComponentSpec.kt
@@ -1,0 +1,106 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.demo
+
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.annotations.FromEvent
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.annotations.OnEvent
+import com.facebook.litho.annotations.Prop
+import com.facebook.litho.sections.SectionContext
+import com.facebook.litho.sections.common.DataDiffSection
+import com.facebook.litho.sections.common.OnCheckIsSameContentEvent
+import com.facebook.litho.sections.common.OnCheckIsSameItemEvent
+import com.facebook.litho.sections.common.RenderEvent
+import com.facebook.litho.sections.widget.RecyclerCollectionComponent
+import com.facebook.litho.widget.ComponentRenderInfo
+import com.facebook.litho.widget.RenderInfo
+import java.util.Arrays
+
+@LayoutSpec
+object DemoListComponentSpec {
+
+  private val MAIN_SCREEN = "main_screen"
+
+  @OnCreateLayout
+  fun onCreateLayout(c: ComponentContext, @Prop dataModels: List<DemoListDataModel>): Component =
+      RecyclerCollectionComponent.create(c)
+          .section(
+              DataDiffSection.create<DemoListDataModel>(SectionContext(c))
+                  .data(dataModels)
+                  .renderEventHandler(DemoListComponent.onRender(c))
+                  .onCheckIsSameItemEventHandler(DemoListComponent.isSameItem(c))
+                  .onCheckIsSameContentEventHandler(DemoListComponent.isSameContent(c))
+                  .build())
+          .disablePTR(true)
+          .testKey(MAIN_SCREEN)
+          .build()
+
+  @OnEvent(RenderEvent::class)
+  fun onRender(
+      c: ComponentContext,
+      @Prop parentIndices: IntArray?,
+      @FromEvent model: DemoListDataModel,
+      @FromEvent index: Int): RenderInfo =
+      ComponentRenderInfo.create()
+          .component(
+              DemoListItemComponent.create(c)
+                  .model(model)
+                  .currentIndices(getUpdatedIndices(parentIndices, index))
+                  .build())
+          .build()
+
+  fun getUpdatedIndices(parentIndices: IntArray?, currentIndex: Int): IntArray {
+    if (parentIndices == null) {
+      return intArrayOf(currentIndex)
+    }
+
+    val updatedIndices = Arrays.copyOf(parentIndices, parentIndices.size + 1)
+    updatedIndices[parentIndices.size] = currentIndex
+
+    return updatedIndices
+  }
+
+  /**
+   * Called during DataDiffSection's diffing to determine if two objects represent the same item.
+   * See [android.support.v7.util.DiffUtil.Callback.areItemsTheSame] for more info.
+   *
+   * @return true if the two objects in the event represent the same item.
+   */
+  @OnEvent(OnCheckIsSameItemEvent::class)
+  fun isSameItem(c: ComponentContext,
+      @FromEvent previousItem: DemoListDataModel,
+      @FromEvent nextItem: DemoListDataModel
+  ): Boolean = previousItem === nextItem
+
+  /**
+   * Called during DataDiffSection's diffing to determine if two objects contain the same data. This
+   * is used to detect of contents of an item have changed. See [ ][android.support.v7.util.DiffUtil.Callback.areContentsTheSame] for more info.
+   *
+   * @return true if the two objects contain the same data.
+   */
+  @OnEvent(OnCheckIsSameContentEvent::class)
+  fun isSameContent(
+      c: ComponentContext,
+      @FromEvent previousItem: DemoListDataModel?,
+      @FromEvent nextItem: DemoListDataModel?): Boolean =
+  // We're only displaying the name so checking if that's equal here is enough for our use case.
+      if (previousItem == null) {
+        nextItem == null
+      } else {
+        nextItem?.name == previousItem.name
+      }
+
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DemoListComponentSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DemoListComponentSpec.kt
@@ -50,7 +50,6 @@ object DemoListComponentSpec {
   @OnEvent(RenderEvent::class)
   fun onRender(
       c: ComponentContext,
-      @Prop parentIndex: Int,
       @FromEvent model: DemoListDataModel,
       @FromEvent index: Int
   ): RenderInfo =

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DemoListDataModel.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DemoListDataModel.kt
@@ -1,0 +1,19 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.demo
+
+data class DemoListDataModel(
+    val name: String,
+    val klass: Class<*>,
+    val datamodels: List<DemoListDataModel>? = null
+)

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DemoListItemComponentSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DemoListItemComponentSpec.kt
@@ -43,11 +43,16 @@ object DemoListItemComponentSpec {
       c: ComponentContext,
       @FromEvent view: View,
       @Prop model: DemoListDataModel,
-      @Prop currentIndices: IntArray
+      @Prop currentIndex: Int
   ) {
-    val intent = Intent(c,
-        if (model.datamodels == null) model.klass else DemoListActivity::class.java)
-    intent.putExtra(DemoListActivity.INDICES, currentIndices)
+    val activityClass = if (model.datamodels == null) {
+      model.klass
+    } else {
+      DemoListActivity::class.java
+    }
+
+    val intent = Intent(c, activityClass)
+    intent.putExtra(DemoListActivity.INDEX, currentIndex)
     c.startActivity(intent)
   }
 }

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DemoListItemComponentSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DemoListItemComponentSpec.kt
@@ -1,0 +1,53 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.demo
+
+import android.content.Intent
+import android.view.View
+import com.facebook.litho.ClickEvent
+import com.facebook.litho.Column
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.annotations.FromEvent
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.annotations.OnEvent
+import com.facebook.litho.annotations.Prop
+import com.facebook.litho.widget.Text
+
+import com.facebook.yoga.YogaEdge.ALL
+
+@LayoutSpec
+object DemoListItemComponentSpec {
+
+  @OnCreateLayout
+  fun onCreateLayout(c: ComponentContext, @Prop model: DemoListDataModel): Component =
+      Column.create(c)
+          .paddingDip(ALL, 16f)
+          .child(Text.create(c).text(model.name).textSizeSp(18f).build())
+          .clickHandler(DemoListItemComponent.onClick(c))
+          .build()
+
+  @OnEvent(ClickEvent::class)
+  fun onClick(
+      c: ComponentContext,
+      @FromEvent view: View,
+      @Prop model: DemoListDataModel,
+      @Prop currentIndices: IntArray
+  ) {
+    val intent = Intent(c,
+        if (model.datamodels == null) model.klass else DemoListActivity::class.java)
+    intent.putExtra(DemoListActivity.INDICES, currentIndices)
+    c.startActivity(intent)
+  }
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/errors/DebugErrorComponentSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/errors/DebugErrorComponentSpec.kt
@@ -38,13 +38,13 @@ object DebugErrorComponentSpec {
   private const val TAG = "DebugErrorComponentSpec"
 
   @ColorInt
-  private val DARK_RED_FRAME = -0x32b6d8
+  private val DARK_RED_FRAME = 0xffcd4928.toInt()
 
   @ColorInt
-  private val LIGHT_RED_BACKGROUND = -0x31317
+  private val LIGHT_RED_BACKGROUND = 0xfffcece9.toInt()
 
   @ColorInt
-  private val LIGHT_GRAY_TEXT = -0x9f9890
+  private val LIGHT_GRAY_TEXT = 0xff606770.toInt()
 
   @OnCreateLayout
   fun onCreateLayout(

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/errors/DebugErrorComponentSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/errors/DebugErrorComponentSpec.kt
@@ -1,0 +1,82 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.errors
+
+import android.graphics.Typeface
+import android.support.annotation.ColorInt
+import android.util.Log
+import com.facebook.litho.ClickEvent
+import com.facebook.litho.Column
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.annotations.OnEvent
+import com.facebook.litho.annotations.Prop
+import com.facebook.litho.utils.StacktraceHelper
+import com.facebook.litho.widget.Text
+import com.facebook.yoga.YogaEdge
+
+
+/**
+ * Renders a throwable as a text with a title and provides a touch callback that logs the throwable
+ * with WTF level.
+ */
+@LayoutSpec
+object DebugErrorComponentSpec {
+
+  private const val TAG = "DebugErrorComponentSpec"
+
+  @ColorInt
+  private val DARK_RED_FRAME = -0x32b6d8
+
+  @ColorInt
+  private val LIGHT_RED_BACKGROUND = -0x31317
+
+  @ColorInt
+  private val LIGHT_GRAY_TEXT = -0x9f9890
+
+  @OnCreateLayout
+  fun onCreateLayout(
+      c: ComponentContext,
+      @Prop message: String,
+      @Prop throwable: Throwable
+  ): Component {
+    Log.e(TAG, message, throwable)
+
+    return Column.create(c)
+        .backgroundColor(DARK_RED_FRAME)
+        .paddingDip(YogaEdge.ALL, 1f)
+        .child(
+            Text.create(c)
+                .backgroundColor(LIGHT_RED_BACKGROUND)
+                .paddingDip(YogaEdge.ALL, 4f)
+                .textSizeDip(16f)
+                .text(message))
+        .child(
+            Text.create(c)
+                .backgroundColor(LIGHT_RED_BACKGROUND)
+                .paddingDip(YogaEdge.ALL, 4f)
+                .textSizeDip(12f)
+                .textColor(LIGHT_GRAY_TEXT)
+                .typeface(Typeface.MONOSPACE)
+                .text(StacktraceHelper.formatStacktrace(throwable)))
+        .clickHandler(DebugErrorComponent.onClick(c))
+        .build()
+  }
+
+  @OnEvent(ClickEvent::class)
+  fun onClick(c: ComponentContext, @Prop message: String, @Prop throwable: Throwable) {
+    Log.wtf(TAG, message, throwable)
+  }
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/errors/ErrorBoundarySpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/errors/ErrorBoundarySpec.kt
@@ -1,0 +1,65 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.errors
+
+import com.facebook.litho.Column
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.StateValue
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateInitialState
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.annotations.OnError
+import com.facebook.litho.annotations.OnUpdateState
+import com.facebook.litho.annotations.Param
+import com.facebook.litho.annotations.Prop
+import com.facebook.litho.annotations.State
+import com.facebook.yoga.YogaEdge
+import java.util.Optional
+
+@LayoutSpec
+object ErrorBoundarySpec {
+
+  @OnCreateLayout
+  fun onCreateLayout(
+      c: ComponentContext,
+      @Prop child: Component,
+      @State error: Optional<Exception>
+  ): Component = if (error.isPresent) {
+    Column.create(c)
+        .marginDip(YogaEdge.ALL, 16f)
+        .child(
+            DebugErrorComponent.create(c)
+                .message("Error Boundary")
+                .throwable(error.get())
+                .build())
+        .build()
+  } else {
+    child
+  }
+
+  @OnCreateInitialState
+  fun createInitialState(c: ComponentContext, error: StateValue<Optional<Exception>>) {
+    error.set(Optional.empty())
+  }
+
+  @OnUpdateState
+  fun updateError(error: StateValue<Optional<Exception>>, @Param e: Exception) {
+    error.set(Optional.of(e))
+  }
+
+  @OnError
+  fun onError(c: ComponentContext, error: Exception) {
+    ErrorBoundary.updateError(c, error)
+  }
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/errors/ErrorHandlingActivity.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/errors/ErrorHandlingActivity.kt
@@ -1,0 +1,43 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.errors
+
+import android.os.Bundle
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.LithoView
+import com.facebook.litho.config.ComponentsConfiguration
+import com.fblitho.lithoktsample.NavigatableDemoActivity
+
+class ErrorHandlingActivity : NavigatableDemoActivity() {
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+
+    // This feature is currently experimental and not enabled by default.
+    ComponentsConfiguration.enableOnErrorHandling = true
+
+    setContentView(
+        LithoView.create(
+            this,
+            ErrorRootComponent.create(ComponentContext(this))
+                .dataModels(DATA)
+                .build()))
+  }
+
+  companion object {
+    private val DATA = listOf(ListRow("First Title", "First Subtitle"),
+        ListRow("Second Title", "Second Subtitle"), ListRow("Third Title", "Third Subtitle"),
+        ListRow("Fourth Title", "Fourth Subtitle"), ListRow("Fifth Title", "Fifth Subtitle"),
+        ListRow("Sixth Title", "Sixth Subtitle"), ListRow("Seventh Title", "Seventh Subtitle"))
+  }
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/errors/ErrorRootComponentSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/errors/ErrorRootComponentSpec.kt
@@ -1,0 +1,48 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.errors
+
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.annotations.FromEvent
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.annotations.OnEvent
+import com.facebook.litho.annotations.Prop
+import com.facebook.litho.sections.SectionContext
+import com.facebook.litho.sections.common.DataDiffSection
+import com.facebook.litho.sections.common.RenderEvent
+import com.facebook.litho.sections.widget.RecyclerCollectionComponent
+import com.facebook.litho.widget.ComponentRenderInfo
+import com.facebook.litho.widget.RenderInfo
+import com.facebook.yoga.YogaEdge
+
+@LayoutSpec
+object ErrorRootComponentSpec {
+
+  @OnCreateLayout
+  fun onCreateLayout(c: ComponentContext, @Prop dataModels: List<ListRow>): Component =
+      RecyclerCollectionComponent.create(c)
+          .disablePTR(true)
+          .section(
+              DataDiffSection.create<ListRow>(SectionContext(c))
+                  .data(dataModels)
+                  .renderEventHandler(ErrorRootComponent.onRender(c))
+                  .build())
+          .paddingDip(YogaEdge.TOP, 8f)
+          .build()
+
+  @OnEvent(RenderEvent::class)
+  fun onRender(c: ComponentContext, @FromEvent model: ListRow): RenderInfo =
+      ComponentRenderInfo.create().component(model.createComponent(c)).build()
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/errors/ListRow.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/errors/ListRow.kt
@@ -1,0 +1,21 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.errors
+
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+
+data class ListRow(val title: String, val subtitle: String) {
+  fun createComponent(c: ComponentContext): Component =
+      ErrorBoundary.create(c).child(ListRowComponent.create(c).row(this).build()).build()
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/errors/ListRowComponentSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/errors/ListRowComponentSpec.kt
@@ -1,0 +1,41 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.fblitho.lithoktsample.errors
+
+import com.facebook.litho.Column
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.annotations.Prop
+import com.facebook.litho.widget.Card
+import com.facebook.yoga.YogaEdge
+
+@LayoutSpec
+object ListRowComponentSpec {
+
+  @OnCreateLayout
+  fun onCreateLayout(c: ComponentContext, @Prop row: ListRow): Component =
+      Column.create(c)
+          .paddingDip(YogaEdge.VERTICAL, 8f)
+          .paddingDip(YogaEdge.HORIZONTAL, 32f)
+          .child(
+              Card.create(c)
+                  .content(
+                      Column.create(c)
+                          .marginDip(YogaEdge.ALL, 32f)
+                          .child(TitleComponent.create(c).title(row.title))
+                          .child(PossiblyCrashingSubTitleComponent.create(c).subtitle(row.subtitle))
+                          .build())
+                  .build())
+          .build()
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/errors/PossiblyCrashingSubTitleComponentSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/errors/PossiblyCrashingSubTitleComponentSpec.kt
@@ -1,0 +1,34 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.errors
+
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.annotations.Prop
+import com.facebook.litho.annotations.ResType.STRING
+import com.facebook.litho.widget.Text
+
+@LayoutSpec
+object PossiblyCrashingSubTitleComponentSpec {
+
+  @OnCreateLayout
+  fun onCreateLayout(c: ComponentContext, @Prop(resType = STRING) subtitle: String): Component {
+    if (Math.random() >= 0.7) {
+      throw RuntimeException("Oh no, a random error!")
+    }
+
+    return Text.create(c).text(subtitle).textSizeDip(18f).build()
+  }
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/errors/TitleComponentSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/errors/TitleComponentSpec.kt
@@ -1,0 +1,36 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.errors
+
+import android.graphics.Typeface.BOLD
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.annotations.Prop
+import com.facebook.litho.annotations.ResType.STRING
+import com.facebook.litho.widget.Text
+import com.facebook.yoga.YogaEdge
+
+@LayoutSpec
+object TitleComponentSpec {
+
+  @OnCreateLayout
+  fun onCreateLayout(c: ComponentContext, @Prop(resType = STRING) title: String): Component =
+      Text.create(c)
+          .text(title)
+          .textStyle(BOLD)
+          .textSizeDip(24f)
+          .positionDip(YogaEdge.BOTTOM, 16f)
+          .build()
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/lithography/LithographyActivity.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/lithography/LithographyActivity.kt
@@ -10,22 +10,22 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package com.fblitho.lithoktsample
+package com.fblitho.lithoktsample.lithography
 
 import android.arch.lifecycle.Observer
 import android.arch.lifecycle.ViewModelProviders
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
 import com.facebook.litho.Component
 import com.facebook.litho.LithoView
 import com.facebook.litho.sections.SectionContext
 import com.facebook.litho.sections.widget.RecyclerCollectionComponent
+import com.fblitho.lithoktsample.NavigatableDemoActivity
 import com.fblitho.lithoktsample.lithography.data.DataFetcher
 import com.fblitho.lithoktsample.lithography.data.DecadeViewModel
 import com.fblitho.lithoktsample.lithography.data.Model
 import com.fblitho.lithoktsample.lithography.sections.LithoFeedSection
 
-class MainActivity : AppCompatActivity() {
+class LithographyActivity : NavigatableDemoActivity() {
 
   private val sectionContext: SectionContext by lazy { SectionContext(this) }
   private val lithoView: LithoView by lazy { LithoView(sectionContext) }


### PR DESCRIPTION
Part of this commit as well, is that I had to restructure `sample-kotlin` navigation like the one available in `sample`. It will make it easier to port Animations as well.