### PR TITLE
Port `animations` to `sample-kotlin`

### DIFF
--- a/sample-kotlin/src/main/AndroidManifest.xml
+++ b/sample-kotlin/src/main/AndroidManifest.xml
@@ -29,5 +29,9 @@
         </activity>
         <activity android:name="com.fblitho.lithoktsample.lithography.LithographyActivity"/>
         <activity android:name=".errors.ErrorHandlingActivity" />
+        <activity android:name=".animations.animatedbadge.AnimatedBadgeActivity" />
+        <activity android:name=".animations.animationcomposition.ComposedAnimationsActivity" />
+        <activity android:name=".animations.expandableelement.ExpandableElementActivity" />
+        <activity android:name=".animations.bounds.BoundsAnimationActivity" />
     </application>
 </manifest>

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/NavigatableDemoActivity.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/NavigatableDemoActivity.kt
@@ -20,8 +20,9 @@ import android.support.v7.app.AppCompatActivity
 import android.view.MenuItem
 import com.fblitho.lithoktsample.demo.DataModels
 import com.fblitho.lithoktsample.demo.DemoListActivity
-import com.fblitho.lithoktsample.demo.DemoListActivity.Companion.DEFAULT_INDEX
-import com.fblitho.lithoktsample.demo.DemoListActivity.Companion.INDEX
+import com.fblitho.lithoktsample.demo.DemoListActivity.Companion.INDICES
+import com.fblitho.lithoktsample.demo.DemoListDataModel
+import java.util.Arrays
 
 @SuppressLint("Registered")
 open class NavigatableDemoActivity : AppCompatActivity() {
@@ -30,8 +31,8 @@ open class NavigatableDemoActivity : AppCompatActivity() {
     super.onCreate(savedInstanceState)
 
     intent
-        .getIntExtra(INDEX, DEFAULT_INDEX)
-        .takeIf { it != DEFAULT_INDEX }
+        .getIntArrayExtra(INDICES)
+        .takeIf { it != null }
         ?.let {
           supportActionBar?.setDisplayHomeAsUpEnabled(true)
           setTitleFromIndex(it)
@@ -39,20 +40,31 @@ open class NavigatableDemoActivity : AppCompatActivity() {
   }
 
   override fun onOptionsItemSelected(item: MenuItem): Boolean =
-      if (item.itemId == android.R.id.home) {
-        NavUtils.navigateUpFromSameTask(this)
-        true
-      } else {
-        super.onOptionsItemSelected(item)
-      }
+    if (item.itemId == android.R.id.home) {
+      NavUtils.navigateUpFromSameTask(this)
+      true
+    } else {
+      super.onOptionsItemSelected(item)
+    }
 
-  override fun getParentActivityIntent(): Intent = Intent(this, DemoListActivity::class.java)
+  override fun getParentActivityIntent(): Intent? {
+    val indices = intent.getIntArrayExtra(DemoListActivity.INDICES) ?: return null
 
-  private fun setTitleFromIndex(index: Int) {
-    index
-        .takeIf { it != DEFAULT_INDEX }
-        ?.let {
-          title = DataModels.DATA_MODELS[it].name
+    return Intent(this, DemoListActivity::class.java)
+        .also {
+          if (indices.size > 1) {
+            it.putExtra(DemoListActivity.INDICES, Arrays.copyOf(indices, indices.size - 1))
+          }
         }
+  }
+
+  private fun setTitleFromIndex(indices: IntArray) {
+    var dataModels: List<DemoListDataModel> = DataModels.DATA_MODELS
+
+    for (i in 0 until indices.size - 1) {
+      dataModels = dataModels[indices[i]].datamodels ?: dataModels
+    }
+
+    dataModels[indices[indices.size - 1]].also { title = it.name }
   }
 }

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/animatedbadge/AnimatedBadgeActivity.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/animatedbadge/AnimatedBadgeActivity.kt
@@ -1,0 +1,40 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.animations.animatedbadge
+
+import android.os.Bundle
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.LithoView
+import com.facebook.litho.config.ComponentsConfiguration
+import com.fblitho.lithoktsample.NavigatableDemoActivity
+
+class AnimatedBadgeActivity : NavigatableDemoActivity() {
+
+  private var mPrevAssignTransitionKeysToAllOutputs: Boolean = false
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+
+    mPrevAssignTransitionKeysToAllOutputs = ComponentsConfiguration.assignTransitionKeysToAllOutputs
+    ComponentsConfiguration.assignTransitionKeysToAllOutputs = true
+
+    setContentView(
+        LithoView.create(this, AnimatedBadge.create(ComponentContext(this)).build()))
+  }
+
+  override fun onDestroy() {
+    super.onDestroy()
+
+    ComponentsConfiguration.assignTransitionKeysToAllOutputs = mPrevAssignTransitionKeysToAllOutputs
+  }
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/animatedbadge/AnimatedBadgeSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/animatedbadge/AnimatedBadgeSpec.kt
@@ -1,0 +1,191 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.animations.animatedbadge
+
+import android.graphics.Color
+import android.graphics.Typeface
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.ShapeDrawable
+import android.graphics.drawable.shapes.RoundRectShape
+import android.util.TypedValue
+import com.facebook.litho.ClickEvent
+import com.facebook.litho.Column
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.Row
+import com.facebook.litho.StateValue
+import com.facebook.litho.Transition
+import com.facebook.litho.Transition.BaseTransitionUnitsBuilder
+import com.facebook.litho.animation.AnimatedProperties
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.annotations.OnCreateTransition
+import com.facebook.litho.annotations.OnEvent
+import com.facebook.litho.annotations.OnUpdateState
+import com.facebook.litho.annotations.State
+import com.facebook.litho.widget.Text
+import com.facebook.yoga.YogaAlign
+import com.facebook.yoga.YogaEdge
+import com.facebook.yoga.YogaPositionType
+import java.util.Arrays
+
+@LayoutSpec
+object AnimatedBadgeSpec {
+
+  private const val ANIMATION_DURATION = 300
+  private val ANIMATOR = Transition.timing(ANIMATION_DURATION)
+
+  private const val TRANSITION_KEY_TEXT = "text"
+
+  @OnCreateLayout
+  fun onCreateLayout(c: ComponentContext, @State state: Int): Component {
+    val expanded1 = state == 1 || state == 2
+    val expanded2 = state == 2 || state == 3
+    return Column.create(c)
+        .paddingDip(YogaEdge.ALL, 8f)
+        .child(Row.create(c).marginDip(YogaEdge.TOP, 8f).child(buildComment1(c, expanded1)))
+        .child(Row.create(c).marginDip(YogaEdge.TOP, 16f).child(buildComment2(c, expanded2)))
+        .clickHandler(AnimatedBadge.onClick(c))
+        .build()
+  }
+
+  private fun buildComment1(c: ComponentContext, expanded: Boolean): Component =
+      Column.create(c)
+          .paddingDip(YogaEdge.ALL, 8f)
+          .child(
+              Row.create(c)
+                  .alignItems(YogaAlign.CENTER)
+                  .child(
+                      Text.create(c)
+                          .textSizeSp(16f)
+                          .textStyle(Typeface.BOLD)
+                          .text("Cristobal Castilla"))
+                  .child(
+                      Row.create(c)
+                          .marginDip(YogaEdge.LEFT, 8f)
+                          .paddingDip(YogaEdge.ALL, 3f)
+                          .alignItems(YogaAlign.CENTER)
+                          .child(
+                              Column.create(c)
+                                  .heightDip(18f)
+                                  .widthDip(18f)
+                                  .background(buildRoundedRect(c, -0x48b5, 9)))
+                          .child(
+                              if (!expanded)
+                                null
+                              else
+                                Text.create(c)
+                                    .transitionKey(
+                                        TRANSITION_KEY_TEXT) // still need transition keys for
+                                    // appear/disappear animations
+                                    .key("text") // need this to prevent the global key of "+1" Text
+                                    // from changing
+                                    .marginDip(YogaEdge.LEFT, 8f)
+                                    .clipToBounds(true)
+                                    .textSizeDip(12f)
+                                    .text("Top Follower"))
+                          .child(
+                              Text.create(c)
+                                  .marginDip(YogaEdge.LEFT, 8f)
+                                  .marginDip(YogaEdge.RIGHT, 4f)
+                                  .textSizeDip(12f)
+                                  .textColor(Color.BLUE)
+                                  .text("+1"))
+                          .background(buildRoundedRect(c, Color.WHITE, 12))))
+          .child(Text.create(c).textSizeSp(18f).text("So awesome!"))
+          .background(buildRoundedRect(c, -0x222223, 20))
+          .build()
+
+  private fun buildComment2(c: ComponentContext, expanded: Boolean): Component =
+      Column.create(c)
+          .paddingDip(YogaEdge.ALL, 8f)
+          .child(
+              Row.create(c)
+                  .alignItems(YogaAlign.CENTER)
+                  .child(
+                      Text.create(c)
+                          .textSizeSp(16f)
+                          .textStyle(Typeface.BOLD)
+                          .text("Cristobal Castilla"))
+                  .child(
+                      Row.create(c)
+                          .widthDip((if (expanded) 48 else 24).toFloat())
+                          .marginDip(YogaEdge.LEFT, 8f)
+                          .paddingDip(YogaEdge.ALL, 3f)
+                          .alignItems(YogaAlign.CENTER)
+                          .child(
+                              Column.create(c)
+                                  .positionType(YogaPositionType.ABSOLUTE)
+                                  .positionDip(YogaEdge.LEFT, (if (expanded) 27 else 3).toFloat())
+                                  .heightDip(18f)
+                                  .widthDip(18f)
+                                  .background(buildRoundedRect(c, 0xFFB2CFE5.toInt(), 9)))
+                          .child(
+                              Column.create(c)
+                                  .positionType(YogaPositionType.ABSOLUTE)
+                                  .positionDip(YogaEdge.LEFT, (if (expanded) 15 else 3).toFloat())
+                                  .heightDip(18f)
+                                  .widthDip(18f)
+                                  .background(buildRoundedRect(c, 0xFF4B8C61.toInt(), 9)))
+                          .child(
+                              Column.create(c)
+                                  .heightDip(18f)
+                                  .widthDip(18f)
+                                  .background(buildRoundedRect(c, 0xFFFFB74B.toInt(), 9)))
+                          .background(buildRoundedRect(c, Color.WHITE, 12))))
+          .child(Text.create(c).textSizeSp(18f).text("So awesome!"))
+          .background(buildRoundedRect(c, 0xFFDDDDDD.toInt(), 20))
+          .build()
+
+  @OnEvent(ClickEvent::class)
+  fun onClick(c: ComponentContext) {
+    AnimatedBadge.updateState(c)
+  }
+
+  @OnUpdateState
+  fun updateState(state: StateValue<Int>) {
+    state.set((state.get() + 1) % 4)
+  }
+
+  @OnCreateTransition
+  fun onCreateTransition(c: ComponentContext): Transition =
+      Transition.parallel<BaseTransitionUnitsBuilder>(
+          Transition.allLayout().animator(ANIMATOR),
+          Transition.create(TRANSITION_KEY_TEXT)
+              .animate(AnimatedProperties.WIDTH)
+              .appearFrom(0f)
+              .disappearTo(0f)
+              .animator(ANIMATOR),
+          Transition.create(TRANSITION_KEY_TEXT)
+              .animate(AnimatedProperties.ALPHA)
+              .appearFrom(0f)
+              .disappearTo(0f)
+              .animator(ANIMATOR))
+
+  private fun buildRoundedRect(c: ComponentContext, color: Int, cornerRadiusDp: Int): Drawable {
+    val cornerRadiusPx = TypedValue
+        .applyDimension(
+            TypedValue.COMPLEX_UNIT_DIP,
+            cornerRadiusDp.toFloat(),
+            c.resources.displayMetrics
+        )
+
+    val radii = FloatArray(8)
+    Arrays.fill(radii, cornerRadiusPx)
+    val roundedRectShape = RoundRectShape(radii, null, radii)
+
+    return ShapeDrawable(roundedRectShape).also {
+      it.paint.color = color
+    }
+  }
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/animatedbadge/AnimatedBadgeSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/animatedbadge/AnimatedBadgeSpec.kt
@@ -81,19 +81,20 @@ object AnimatedBadgeSpec {
                                   .widthDip(18f)
                                   .background(buildRoundedRect(c, -0x48b5, 9)))
                           .child(
-                              if (!expanded)
+                              if (!expanded) {
                                 null
-                              else
+                              } else {
                                 Text.create(c)
-                                    .transitionKey(
-                                        TRANSITION_KEY_TEXT) // still need transition keys for
-                                    // appear/disappear animations
-                                    .key("text") // need this to prevent the global key of "+1" Text
-                                    // from changing
+                                    // still need transition keys for appear/disappear animations
+                                    .transitionKey(TRANSITION_KEY_TEXT)
+                                    // need this to prevent the global key of "+1" Text from changing
+                                    .key("text")
                                     .marginDip(YogaEdge.LEFT, 8f)
                                     .clipToBounds(true)
                                     .textSizeDip(12f)
-                                    .text("Top Follower"))
+                                    .text("Top Follower")
+                              }
+                          )
                           .child(
                               Text.create(c)
                                   .marginDip(YogaEdge.LEFT, 8f)

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/animationcomposition/ComposedAnimationsActivity.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/animationcomposition/ComposedAnimationsActivity.kt
@@ -10,10 +10,20 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package com.fblitho.lithoktsample.demo
+package com.fblitho.lithoktsample.animations.animationcomposition
 
-data class DemoListDataModel(
-    val name: String,
-    val klass: Class<*>? = null,
-    val datamodels: List<DemoListDataModel>? = null
-)
+import android.os.Bundle
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.LithoView
+import com.fblitho.lithoktsample.NavigatableDemoActivity
+
+class ComposedAnimationsActivity : NavigatableDemoActivity() {
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+
+    setContentView(
+        LithoView.create(
+            this, ComposedAnimationsComponent.create(ComponentContext(this)).build()))
+  }
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/animationcomposition/ComposedAnimationsComponentSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/animationcomposition/ComposedAnimationsComponentSpec.kt
@@ -1,0 +1,75 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.animations.animationcomposition
+
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.annotations.FromEvent
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.annotations.OnEvent
+import com.facebook.litho.sections.SectionContext
+import com.facebook.litho.sections.common.DataDiffSection
+import com.facebook.litho.sections.common.OnCheckIsSameItemEvent
+import com.facebook.litho.sections.common.RenderEvent
+import com.facebook.litho.sections.widget.RecyclerCollectionComponent
+import com.facebook.litho.widget.ComponentRenderInfo
+import com.facebook.litho.widget.RenderInfo
+
+@LayoutSpec
+object ComposedAnimationsComponentSpec {
+
+  @OnCreateLayout
+  fun onCreateLayout(c: ComponentContext): Component =
+      RecyclerCollectionComponent.create(c)
+          .disablePTR(true)
+          .section(
+              DataDiffSection.create<Any>(SectionContext(c))
+                  .data(generateData(20))
+                  .renderEventHandler(ComposedAnimationsComponent.onRender(c))
+                  .onCheckIsSameItemEventHandler(ComposedAnimationsComponent.isSameItem(c))
+                  .build())
+          .build()
+
+  @OnEvent(RenderEvent::class)
+  fun onRender(c: ComponentContext, @FromEvent index: Int): RenderInfo {
+    val numDemos = 5
+    // Keep alternating between demos
+    val component: Component = when (index % numDemos) {
+      0 -> StoryFooterComponent.create(c).key("footer").build()
+      1 -> UpDownBlocksComponent.create(c).build()
+      2 -> LeftRightBlocksComponent.create(c).build()
+      3 -> OneByOneLeftRightBlocksComponent.create(c).build()
+      4 -> LeftRightBlocksSequenceComponent.create(c).build()
+      else -> throw RuntimeException("Bad index: $index")
+    }
+    return ComponentRenderInfo.create().component(component).build()
+  }
+
+  @OnEvent(OnCheckIsSameItemEvent::class)
+  fun isSameItem(
+      c: ComponentContext,
+      @FromEvent previousItem: Data,
+      @FromEvent nextItem: Data
+  ): Boolean = previousItem.number == nextItem.number
+
+  private fun generateData(number: Int): List<Any> {
+    val dummyData = mutableListOf<Any>()
+
+    for (i in 0 until number) {
+      dummyData.add(Data(i))
+    }
+
+    return dummyData
+  }
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/animationcomposition/ComposedAnimationsComponentSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/animationcomposition/ComposedAnimationsComponentSpec.kt
@@ -34,7 +34,7 @@ object ComposedAnimationsComponentSpec {
       RecyclerCollectionComponent.create(c)
           .disablePTR(true)
           .section(
-              DataDiffSection.create<Any>(SectionContext(c))
+              DataDiffSection.create<Data>(SectionContext(c))
                   .data(generateData(20))
                   .renderEventHandler(ComposedAnimationsComponent.onRender(c))
                   .onCheckIsSameItemEventHandler(ComposedAnimationsComponent.isSameItem(c))
@@ -63,8 +63,8 @@ object ComposedAnimationsComponentSpec {
       @FromEvent nextItem: Data
   ): Boolean = previousItem.number == nextItem.number
 
-  private fun generateData(number: Int): List<Any> {
-    val dummyData = mutableListOf<Any>()
+  private fun generateData(number: Int): List<Data> {
+    val dummyData = mutableListOf<Data>()
 
     for (i in 0 until number) {
       dummyData.add(Data(i))

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/animationcomposition/Data.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/animationcomposition/Data.kt
@@ -10,10 +10,6 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package com.fblitho.lithoktsample.demo
+package com.fblitho.lithoktsample.animations.animationcomposition
 
-data class DemoListDataModel(
-    val name: String,
-    val klass: Class<*>? = null,
-    val datamodels: List<DemoListDataModel>? = null
-)
+data class Data(val number: Int)

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/animationcomposition/LeftRightBlocksComponentSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/animationcomposition/LeftRightBlocksComponentSpec.kt
@@ -1,0 +1,86 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.animations.animationcomposition
+
+import android.graphics.Color
+import android.view.animation.AccelerateDecelerateInterpolator
+import android.view.animation.BounceInterpolator
+import com.facebook.litho.ClickEvent
+import com.facebook.litho.Column
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.Row
+import com.facebook.litho.StateValue
+import com.facebook.litho.Transition
+import com.facebook.litho.Transition.TransitionUnitsBuilder
+import com.facebook.litho.animation.AnimatedProperties
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.annotations.OnCreateTransition
+import com.facebook.litho.annotations.OnEvent
+import com.facebook.litho.annotations.OnUpdateState
+import com.facebook.litho.annotations.State
+import com.facebook.yoga.YogaAlign
+
+@LayoutSpec
+object LeftRightBlocksComponentSpec {
+
+  @OnCreateLayout
+  fun onCreateLayout(c: ComponentContext, @State left: Boolean): Component =
+      Column.create(c)
+          .alignItems(if (left) YogaAlign.FLEX_START else YogaAlign.FLEX_END)
+          .child(
+              Row.create(c)
+                  .heightDip(40f)
+                  .widthDip(40f)
+                  .backgroundColor(Color.parseColor("#ee1111"))
+                  .transitionKey("red")
+                  .build())
+          .child(
+              Row.create(c)
+                  .heightDip(40f)
+                  .widthDip(40f)
+                  .backgroundColor(Color.parseColor("#1111ee"))
+                  .transitionKey("blue")
+                  .build())
+          .child(
+              Row.create(c)
+                  .heightDip(40f)
+                  .widthDip(40f)
+                  .backgroundColor(Color.parseColor("#11ee11"))
+                  .transitionKey("green")
+                  .build())
+          .clickHandler(LeftRightBlocksComponent.onClick(c))
+          .build()
+
+  @OnEvent(ClickEvent::class)
+  fun onClick(c: ComponentContext) {
+    LeftRightBlocksComponent.updateState(c)
+  }
+
+  @OnUpdateState
+  fun updateState(left: StateValue<Boolean>) {
+    left.set(left.get() != true)
+  }
+
+  @OnCreateTransition
+  fun onCreateTransition(c: ComponentContext): Transition =
+      Transition.parallel<TransitionUnitsBuilder>(
+          Transition.create("red")
+              .animate(AnimatedProperties.X)
+              .animator(Transition.timing(1000, AccelerateDecelerateInterpolator())),
+          Transition.create("blue").animate(AnimatedProperties.X).animator(Transition.timing(1000)),
+          Transition.create("green")
+              .animate(AnimatedProperties.X)
+              .animator(Transition.timing(1000, BounceInterpolator())))
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/animationcomposition/LeftRightBlocksSequenceComponentSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/animationcomposition/LeftRightBlocksSequenceComponentSpec.kt
@@ -1,0 +1,80 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.animations.animationcomposition
+
+import android.graphics.Color
+import com.facebook.litho.ClickEvent
+import com.facebook.litho.Column
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.Row
+import com.facebook.litho.StateValue
+import com.facebook.litho.Transition
+import com.facebook.litho.Transition.TransitionUnitsBuilder
+import com.facebook.litho.animation.AnimatedProperties
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.annotations.OnCreateTransition
+import com.facebook.litho.annotations.OnEvent
+import com.facebook.litho.annotations.OnUpdateState
+import com.facebook.litho.annotations.State
+import com.facebook.yoga.YogaAlign
+
+@LayoutSpec
+object LeftRightBlocksSequenceComponentSpec {
+
+  @OnCreateLayout
+  fun onCreateLayout(c: ComponentContext, @State left: Boolean): Component =
+      Column.create(c)
+          .alignItems(if (left) YogaAlign.FLEX_START else YogaAlign.FLEX_END)
+          .child(
+              Row.create(c)
+                  .heightDip(40f)
+                  .widthDip(40f)
+                  .backgroundColor(Color.parseColor("#ee1111"))
+                  .transitionKey("red")
+                  .build())
+          .child(
+              Row.create(c)
+                  .heightDip(40f)
+                  .widthDip(40f)
+                  .backgroundColor(Color.parseColor("#1111ee"))
+                  .transitionKey("blue")
+                  .build())
+          .child(
+              Row.create(c)
+                  .heightDip(40f)
+                  .widthDip(40f)
+                  .backgroundColor(Color.parseColor("#11ee11"))
+                  .transitionKey("green")
+                  .build())
+          .clickHandler(LeftRightBlocksSequenceComponent.onClick(c))
+          .build()
+
+  @OnEvent(ClickEvent::class)
+  fun onClick(c: ComponentContext) {
+    LeftRightBlocksSequenceComponent.updateState(c)
+  }
+
+  @OnUpdateState
+  fun updateState(left: StateValue<Boolean>) {
+    left.set(left.get() != true)
+  }
+
+  @OnCreateTransition
+  fun onCreateTransition(c: ComponentContext): Transition =
+      Transition.sequence<TransitionUnitsBuilder>(
+          Transition.create("red").animate(AnimatedProperties.X),
+          Transition.create("blue").animate(AnimatedProperties.X),
+          Transition.create("green").animate(AnimatedProperties.X))
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/animationcomposition/OneByOneLeftRightBlocksComponentSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/animationcomposition/OneByOneLeftRightBlocksComponentSpec.kt
@@ -1,0 +1,99 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.animations.animationcomposition
+
+import android.graphics.Color
+import com.facebook.litho.ClickEvent
+import com.facebook.litho.Column
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.Row
+import com.facebook.litho.StateValue
+import com.facebook.litho.Transition
+import com.facebook.litho.animation.AnimatedProperties
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.annotations.OnCreateTransition
+import com.facebook.litho.annotations.OnEvent
+import com.facebook.litho.annotations.OnUpdateState
+import com.facebook.litho.annotations.State
+import com.facebook.yoga.YogaAlign
+
+@LayoutSpec
+object OneByOneLeftRightBlocksComponentSpec {
+
+  private const val TRANSITION_KEY_RED = "red"
+  private const val TRANSITION_KEY_BLUE = "blue"
+  private const val TRANSITION_KEY_GREEN = "green"
+  private val ALL_TRANSITION_KEYS = arrayOf(
+      TRANSITION_KEY_RED,
+      TRANSITION_KEY_BLUE,
+      TRANSITION_KEY_GREEN
+  )
+
+  @OnCreateLayout
+  fun onCreateLayout(c: ComponentContext, @State state: Int): Component {
+    val redLeft = state == 0 || state == 4 || state == 5
+    val blueLeft = state == 0 || state == 1 || state == 5
+    val greenLeft = state == 0 || state == 1 || state == 2
+
+    return Column.create(c)
+        .child(
+            Column.create(c)
+                .alignItems(if (redLeft) YogaAlign.FLEX_START else YogaAlign.FLEX_END)
+                .child(
+                    Row.create(c)
+                        .heightDip(40f)
+                        .widthDip(40f)
+                        .backgroundColor(Color.parseColor("#ee1111"))
+                        .transitionKey(TRANSITION_KEY_RED)
+                        .build()))
+        .child(
+            Column.create(c)
+                .alignItems(if (blueLeft) YogaAlign.FLEX_START else YogaAlign.FLEX_END)
+                .child(
+                    Row.create(c)
+                        .heightDip(40f)
+                        .widthDip(40f)
+                        .backgroundColor(Color.parseColor("#1111ee"))
+                        .transitionKey(TRANSITION_KEY_BLUE)
+                        .build()))
+        .child(
+            Column.create(c)
+                .alignItems(if (greenLeft) YogaAlign.FLEX_START else YogaAlign.FLEX_END)
+                .child(
+                    Row.create(c)
+                        .heightDip(40f)
+                        .widthDip(40f)
+                        .backgroundColor(Color.parseColor("#11ee11"))
+                        .transitionKey(TRANSITION_KEY_GREEN)
+                        .build()))
+        .clickHandler(OneByOneLeftRightBlocksComponent.onClick(c))
+        .build()
+  }
+
+  @OnEvent(ClickEvent::class)
+  fun onClick(c: ComponentContext) {
+    OneByOneLeftRightBlocksComponent.updateState(c)
+  }
+
+  @OnUpdateState
+  fun updateState(state: StateValue<Int>) {
+    state.set((state.get() + 1) % 6)
+  }
+
+  @OnCreateTransition
+  fun onCreateTransition(c: ComponentContext): Transition =
+      Transition.create(*ALL_TRANSITION_KEYS)
+          .animate(AnimatedProperties.X, AnimatedProperties.Y, AnimatedProperties.ALPHA)
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/animationcomposition/StoryFooterComponentSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/animationcomposition/StoryFooterComponentSpec.kt
@@ -1,0 +1,169 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.animations.animationcomposition
+
+import android.graphics.Color
+import com.facebook.litho.ClickEvent
+import com.facebook.litho.Column
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.Diff
+import com.facebook.litho.Row
+import com.facebook.litho.StateValue
+import com.facebook.litho.Transition
+import com.facebook.litho.Transition.TransitionUnitsBuilder
+import com.facebook.litho.animation.AnimatedProperties
+import com.facebook.litho.animation.DimensionValue
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.annotations.OnCreateTransition
+import com.facebook.litho.annotations.OnEvent
+import com.facebook.litho.annotations.OnUpdateState
+import com.facebook.litho.annotations.State
+import com.facebook.litho.widget.Text
+import com.facebook.yoga.YogaAlign
+import com.facebook.yoga.YogaEdge
+import com.facebook.yoga.YogaJustify
+
+@LayoutSpec
+object StoryFooterComponentSpec {
+
+  @OnCreateLayout
+  fun onCreateLayout(c: ComponentContext, @State commentText: Boolean): Component =
+      if (!commentText) {
+        Row.create(c)
+            .backgroundColor(Color.WHITE)
+            .heightDip(56f)
+            .child(
+                Row.create(c)
+                    .widthPercent(33.3f)
+                    .alignItems(YogaAlign.CENTER)
+                    .justifyContent(YogaJustify.CENTER)
+                    .clickHandler(StoryFooterComponent.onClick(c))
+                    .testKey("like_button")
+                    .child(
+                        Column.create(c)
+                            .heightDip(24f)
+                            .widthDip(24f)
+                            .backgroundColor(Color.RED)
+                            .transitionKey("icon_like"))
+                    .child(
+                        Text.create(c)
+                            .textSizeSp(16f)
+                            .text("Like")
+                            .transitionKey("text_like")
+                            .marginDip(YogaEdge.LEFT, 8f)))
+            .child(
+                Row.create(c)
+                    .transitionKey("cont_comment")
+                    .widthPercent(33.3f)
+                    .alignItems(YogaAlign.CENTER)
+                    .justifyContent(YogaJustify.CENTER)
+                    .child(Column.create(c).heightDip(24f).widthDip(24f).backgroundColor(Color.RED))
+                    .child(
+                        Text.create(c).textSizeSp(16f).text("Comment").marginDip(YogaEdge.LEFT,
+                            8f)))
+            .child(
+                Row.create(c)
+                    .widthPercent(33.3f)
+                    .alignItems(YogaAlign.CENTER)
+                    .justifyContent(YogaJustify.CENTER)
+                    .child(
+                        Column.create(c)
+                            .transitionKey("icon_share")
+                            .heightDip(24f)
+                            .widthDip(24f)
+                            .backgroundColor(Color.RED))
+                    .child(
+                        Text.create(c)
+                            .textSizeSp(16f)
+                            .text("Share")
+                            .transitionKey("text_share")
+                            .marginDip(YogaEdge.LEFT, 8f)))
+            .build()
+      } else {
+        Row.create(c)
+            .backgroundColor(Color.WHITE)
+            .heightDip(56f)
+            .child(
+                Row.create(c)
+                    .alignItems(YogaAlign.CENTER)
+                    .justifyContent(YogaJustify.CENTER)
+                    .clickHandler(StoryFooterComponent.onClick(c))
+                    .paddingDip(YogaEdge.HORIZONTAL, 16f)
+                    .testKey("like_button")
+                    .child(
+                        Column.create(c)
+                            .transitionKey("icon_like")
+                            .heightDip(24f)
+                            .widthDip(24f)
+                            .backgroundColor(Color.RED)))
+            .child(
+                Column.create(c)
+                    .flexGrow(1f)
+                    .transitionKey("comment_editText")
+                    .child(Text.create(c).text("Input here").textSizeSp(16f)))
+            .child(
+                Row.create(c)
+                    .transitionKey("cont_share")
+                    .alignItems(YogaAlign.CENTER)
+                    .clickHandler(StoryFooterComponent.onClick(c))
+                    .paddingDip(YogaEdge.ALL, 16f)
+                    .backgroundColor(0xFF0000FF.toInt())
+                    .child(
+                        Column.create(c)
+                            .transitionKey("icon_share")
+                            .heightDip(24f)
+                            .widthDip(24f)
+                            .backgroundColor(Color.RED)))
+            .build()
+      }
+
+  @OnEvent(ClickEvent::class)
+  fun onClick(c: ComponentContext) {
+    StoryFooterComponent.updateState(c)
+  }
+
+  @OnUpdateState
+  fun updateState(commentText: StateValue<Boolean>) {
+    commentText.set(commentText.get() != true)
+  }
+
+  @OnCreateTransition
+  fun onCreateTransition(c: ComponentContext, @State commentText: Diff<Boolean>): Transition? =
+      if (commentText.previous == null) {
+        null
+      } else {
+        Transition.parallel<TransitionUnitsBuilder>(
+            Transition.create("comment_editText")
+                .animate(AnimatedProperties.ALPHA)
+                .appearFrom(0f)
+                .disappearTo(0f)
+                .animate(AnimatedProperties.X)
+                .appearFrom(DimensionValue.widthPercentageOffset(-50f))
+                .disappearTo(DimensionValue.widthPercentageOffset(-50f)),
+            Transition.create("cont_comment")
+                .animate(AnimatedProperties.ALPHA)
+                .appearFrom(0f)
+                .disappearTo(0f),
+            Transition.create("icon_like", "icon_share").animate(AnimatedProperties.X),
+            Transition.create("text_like", "text_share")
+                .animate(AnimatedProperties.ALPHA)
+                .appearFrom(0f)
+                .disappearTo(0f)
+                .animate(AnimatedProperties.X)
+                .appearFrom(DimensionValue.widthPercentageOffset(50f))
+                .disappearTo(DimensionValue.widthPercentageOffset(50f)))
+      }
+}
+

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/animationcomposition/UpDownBlocksComponentSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/animationcomposition/UpDownBlocksComponentSpec.kt
@@ -1,0 +1,81 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.animations.animationcomposition
+
+import android.graphics.Color
+import com.facebook.litho.ClickEvent
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.Row
+import com.facebook.litho.StateValue
+import com.facebook.litho.Transition
+import com.facebook.litho.Transition.TransitionUnitsBuilder
+import com.facebook.litho.animation.AnimatedProperties
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.annotations.OnCreateTransition
+import com.facebook.litho.annotations.OnEvent
+import com.facebook.litho.annotations.OnUpdateState
+import com.facebook.litho.annotations.State
+import com.facebook.yoga.YogaAlign
+
+@LayoutSpec
+object UpDownBlocksComponentSpec {
+
+  @OnCreateLayout
+  fun onCreateLayout(c: ComponentContext, @State top: Boolean): Component =
+      Row.create(c)
+          .heightDip(200f)
+          .alignItems(if (top) YogaAlign.FLEX_START else YogaAlign.FLEX_END)
+          .child(
+              Row.create(c)
+                  .heightDip(40f)
+                  .flexGrow(1f)
+                  .backgroundColor(Color.parseColor("#ee1111"))
+                  .transitionKey("red")
+                  .build())
+          .child(
+              Row.create(c)
+                  .heightDip(40f)
+                  .flexGrow(1f)
+                  .backgroundColor(Color.parseColor("#1111ee"))
+                  .transitionKey("blue")
+                  .build())
+          .child(
+              Row.create(c)
+                  .heightDip(40f)
+                  .flexGrow(1f)
+                  .backgroundColor(Color.parseColor("#11ee11"))
+                  .transitionKey("green")
+                  .build())
+          .clickHandler(UpDownBlocksComponent.onClick(c))
+          .build()
+
+  @OnEvent(ClickEvent::class)
+  fun onClick(c: ComponentContext) {
+    UpDownBlocksComponent.updateState(c)
+  }
+
+  @OnUpdateState
+  fun updateState(top: StateValue<Boolean>) {
+    top.set(!top.get())
+  }
+
+  @OnCreateTransition
+  fun onCreateTransition(c: ComponentContext): Transition =
+      Transition.stagger<TransitionUnitsBuilder>(
+          200,
+          Transition.create("red").animate(AnimatedProperties.Y),
+          Transition.create("blue").animate(AnimatedProperties.Y),
+          Transition.create("green").animate(AnimatedProperties.Y))
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/bounds/BoundsAnimationActivity.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/bounds/BoundsAnimationActivity.kt
@@ -10,10 +10,20 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package com.fblitho.lithoktsample.demo
+package com.fblitho.lithoktsample.animations.bounds
 
-data class DemoListDataModel(
-    val name: String,
-    val klass: Class<*>? = null,
-    val datamodels: List<DemoListDataModel>? = null
-)
+import android.os.Bundle
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.LithoView
+import com.fblitho.lithoktsample.NavigatableDemoActivity
+
+class BoundsAnimationActivity : NavigatableDemoActivity() {
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+
+    setContentView(
+        LithoView.create(
+            this, BoundsAnimationComponent.create(ComponentContext(this)).build()))
+  }
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/bounds/BoundsAnimationComponentSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/bounds/BoundsAnimationComponentSpec.kt
@@ -1,0 +1,277 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.animations.bounds
+
+import android.graphics.Color
+import android.graphics.Typeface
+import com.facebook.litho.ClickEvent
+import com.facebook.litho.Column
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.Row
+import com.facebook.litho.StateValue
+import com.facebook.litho.Transition
+import com.facebook.litho.animation.AnimatedProperties
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.annotations.OnCreateTransition
+import com.facebook.litho.annotations.OnEvent
+import com.facebook.litho.annotations.OnUpdateState
+import com.facebook.litho.annotations.State
+import com.facebook.litho.widget.Text
+import com.facebook.yoga.YogaAlign
+import com.facebook.yoga.YogaEdge
+import com.facebook.yoga.YogaJustify
+
+@LayoutSpec
+object BoundsAnimationComponentSpec {
+
+  private const val TRANSITION_KEY_CONTAINER_1 = "container_1"
+  private const val TRANSITION_KEY_CHILD_1_1 = "child_1_1"
+  private const val TRANSITION_KEY_CHILD_1_2 = "child_1_2"
+  private const val TRANSITION_KEY_CHILD_1_3 = "child_1_3"
+  private const val TRANSITION_KEY_CONTAINER_2 = "container_2"
+  private const val TRANSITION_KEY_CHILD_2_1 = "child_2_1"
+  private const val TRANSITION_KEY_CHILD_2_2 = "child_2_2"
+  private const val TRANSITION_KEY_CONTAINER_3 = "container_3"
+  private const val TRANSITION_KEY_CHILD_3_1 = "child_3_1"
+  private const val TRANSITION_KEY_CONTAINER_4 = "container_4"
+  private const val TRANSITION_KEY_CONTAINER_4_1 = "container_4_1"
+  private const val TRANSITION_KEY_CONTAINER_4_2 = "container_4_2"
+  private const val TRANSITION_KEY_CHILD_4_1_1 = "child_4_1_1"
+  private const val TRANSITION_KEY_CHILD_4_1_2 = "child_4_1_2"
+  private const val TRANSITION_KEY_CHILD_4_2_1 = "child_4_2_1"
+  private const val TRANSITION_KEY_CHILD_4_2_2 = "child_4_2_2"
+
+  @OnCreateLayout
+  fun onCreateLayout(
+      c: ComponentContext,
+      @State autoBoundsTransitionEnabled: Boolean,
+      @State flag1: Boolean,
+      @State flag2: Boolean,
+      @State flag3: Boolean,
+      @State flag4: Boolean
+  ): Component = Column.create(c)
+      .backgroundColor(Color.WHITE)
+      .alignItems(YogaAlign.CENTER)
+      .paddingDip(YogaEdge.VERTICAL, 8f)
+      .child(
+          Text.create(c)
+              .text("ABT " + if (autoBoundsTransitionEnabled) "enabled" else "disabled")
+              .textSizeSp(20f)
+              .textStyle(Typeface.BOLD)
+              .clickHandler(BoundsAnimationComponent.onABTClick(c)))
+      .child(
+          Text.create(c).marginDip(YogaEdge.VERTICAL, 8f).text("Affected Children").textSizeSp(20f))
+      .child(affectedChildren(c, flag1))
+      .child(
+          Text.create(c).marginDip(YogaEdge.VERTICAL, 8f).text("Affected Siblings").textSizeSp(20f))
+      .child(affectedSiblings(c, flag2))
+      .child(
+          Text.create(c).marginDip(YogaEdge.VERTICAL, 8f).text("Affected Parent").textSizeSp(20f))
+      .child(affectedParent(c, flag3))
+      .child(altogether(c, flag4))
+      .build()
+
+  @OnEvent(ClickEvent::class)
+  fun onABTClick(c: ComponentContext) {
+    BoundsAnimationComponent.toggleABT(c)
+  }
+
+  @OnUpdateState
+  fun toggleABT(autoBoundsTransitionEnabled: StateValue<Boolean>) {
+    autoBoundsTransitionEnabled.set(!autoBoundsTransitionEnabled.get())
+  }
+
+  private fun affectedChildren(c: ComponentContext, flag1: Boolean): Component =
+      Row.create(c)
+          .transitionKey(TRANSITION_KEY_CONTAINER_1)
+          .heightDip((60 + 2 * 8).toFloat())
+          .widthDip(3 * 60 * (if (flag1) 0.5f else 1f) + 4 * 8)
+          .paddingDip(YogaEdge.ALL, 8f)
+          .backgroundColor(Color.YELLOW)
+          .child(
+              Column.create(c)
+                  .transitionKey(TRANSITION_KEY_CHILD_1_1)
+                  .flex(1f)
+                  .backgroundColor(Color.RED))
+          .child(
+              Column.create(c)
+                  .transitionKey(TRANSITION_KEY_CHILD_1_2)
+                  .flex(1f)
+                  .backgroundColor(Color.RED)
+                  .marginDip(YogaEdge.HORIZONTAL, 8f))
+          .child(
+              Column.create(c)
+                  .flex(1f)
+                  .transitionKey(TRANSITION_KEY_CHILD_1_3)
+                  .backgroundColor(Color.RED))
+          .clickHandler(BoundsAnimationComponent.onFirstComponentClick(c))
+          .build()
+
+  @OnEvent(ClickEvent::class)
+  fun onFirstComponentClick(c: ComponentContext) {
+    BoundsAnimationComponent.toggleFlag1(c)
+  }
+
+  @OnUpdateState
+  fun toggleFlag1(flag1: StateValue<Boolean>) {
+    flag1.set(!flag1.get())
+  }
+
+  private fun affectedSiblings(c: ComponentContext, flag2: Boolean): Component =
+      Row.create(c)
+          .transitionKey(TRANSITION_KEY_CONTAINER_2)
+          .heightDip((60 + 2 * 8).toFloat())
+          .widthDip((3 * 60 + 3 * 8).toFloat())
+          .paddingDip(YogaEdge.ALL, 8f)
+          .backgroundColor(Color.LTGRAY)
+          .child(
+              Column.create(c)
+                  .transitionKey(TRANSITION_KEY_CHILD_2_1)
+                  .flex(1f)
+                  .backgroundColor(Color.RED))
+          .child(
+              Column.create(c)
+                  .transitionKey(TRANSITION_KEY_CHILD_2_2)
+                  .flex((if (flag2) 1 else 2).toFloat())
+                  .backgroundColor(Color.YELLOW)
+                  .marginDip(YogaEdge.LEFT, 8f))
+          .clickHandler(BoundsAnimationComponent.onSecondComponentClick(c))
+          .build()
+
+  @OnEvent(ClickEvent::class)
+  fun onSecondComponentClick(c: ComponentContext) {
+    BoundsAnimationComponent.toggleFlag2(c)
+  }
+
+  @OnUpdateState
+  fun toggleFlag2(flag2: StateValue<Boolean>) {
+    flag2.set(!flag2.get())
+  }
+
+  private fun affectedParent(c: ComponentContext, flag3: Boolean): Component =
+      Row.create(c)
+          .justifyContent(YogaJustify.CENTER)
+          .child(
+              Row.create(c)
+                  .transitionKey(TRANSITION_KEY_CONTAINER_3)
+                  .heightDip((60 + 2 * 8).toFloat())
+                  .paddingDip(YogaEdge.ALL, 8f)
+                  .backgroundColor(Color.LTGRAY)
+                  .child(
+                      Column.create(c)
+                          .transitionKey(TRANSITION_KEY_CHILD_3_1)
+                          .widthDip((60 * if (flag3) 1 else 2).toFloat())
+                          .backgroundColor(Color.YELLOW))
+                  .clickHandler(BoundsAnimationComponent.onThirdComponentClick(c)))
+          .build()
+
+  @OnEvent(ClickEvent::class)
+  fun onThirdComponentClick(c: ComponentContext) {
+    BoundsAnimationComponent.toggleFlag3(c)
+  }
+
+  @OnUpdateState
+  fun toggleFlag3(flag3: StateValue<Boolean>) {
+    flag3.set(!flag3.get())
+  }
+
+  private fun altogether(c: ComponentContext, flag4: Boolean): Component =
+      Column.create(c)
+          .transitionKey(TRANSITION_KEY_CONTAINER_4)
+          .marginDip(YogaEdge.TOP, 24f)
+          .heightDip((60 * 2 + 3 * 8).toFloat())
+          .paddingDip(YogaEdge.ALL, 8f)
+          .backgroundColor(Color.LTGRAY)
+          .child(
+              Row.create(c)
+                  .transitionKey(TRANSITION_KEY_CONTAINER_4_1)
+                  .heightDip(60f)
+                  .paddingDip(YogaEdge.ALL, 6f)
+                  .backgroundColor(Color.GRAY)
+                  .child(
+                      Column.create(c)
+                          .transitionKey(TRANSITION_KEY_CHILD_4_1_1)
+                          .marginDip(YogaEdge.RIGHT, 6f)
+                          .flex(1f)
+                          .backgroundColor(Color.RED))
+                  .child(
+                      Column.create(c)
+                          .transitionKey(TRANSITION_KEY_CHILD_4_1_2)
+                          .flex(1f)
+                          .backgroundColor(Color.RED)))
+          .child(
+              Row.create(c)
+                  .transitionKey(TRANSITION_KEY_CONTAINER_4_2)
+                  .heightDip(60f)
+                  .marginDip(YogaEdge.TOP, 8f)
+                  .paddingDip(YogaEdge.ALL, 6f)
+                  .backgroundColor(Color.GRAY)
+                  .child(
+                      Column.create(c)
+                          .transitionKey(TRANSITION_KEY_CHILD_4_2_1)
+                          .marginDip(YogaEdge.RIGHT, 6f)
+                          .widthDip(100f)
+                          .backgroundColor(Color.RED))
+                  .child(
+                      Column.create(c)
+                          .transitionKey(TRANSITION_KEY_CHILD_4_2_2)
+                          .widthDip((if (flag4) 200 else 100).toFloat())
+                          .backgroundColor(Color.YELLOW)))
+          .clickHandler(BoundsAnimationComponent.onFourthComponentClick(c))
+          .build()
+
+  @OnEvent(ClickEvent::class)
+  fun onFourthComponentClick(c: ComponentContext) {
+    BoundsAnimationComponent.toggleFlag4(c)
+  }
+
+  @OnUpdateState
+  fun toggleFlag4(flag4: StateValue<Boolean>) {
+    flag4.set(!flag4.get())
+  }
+
+  @OnCreateTransition
+  fun animate(c: ComponentContext, @State autoBoundsTransitionEnabled: Boolean): Transition {
+    val transitionKeys = if (autoBoundsTransitionEnabled) {
+      arrayOf(
+          TRANSITION_KEY_CONTAINER_1,
+          TRANSITION_KEY_CHILD_1_1,
+          TRANSITION_KEY_CHILD_1_2,
+          TRANSITION_KEY_CHILD_1_3,
+          TRANSITION_KEY_CONTAINER_2,
+          TRANSITION_KEY_CHILD_2_1,
+          TRANSITION_KEY_CHILD_2_2,
+          TRANSITION_KEY_CONTAINER_3,
+          TRANSITION_KEY_CHILD_3_1,
+          TRANSITION_KEY_CONTAINER_4,
+          TRANSITION_KEY_CONTAINER_4_1,
+          TRANSITION_KEY_CONTAINER_4_2,
+          TRANSITION_KEY_CHILD_4_1_1,
+          TRANSITION_KEY_CHILD_4_1_2,
+          TRANSITION_KEY_CHILD_4_2_1,
+          TRANSITION_KEY_CHILD_4_2_2)
+    } else {
+      arrayOf(
+          TRANSITION_KEY_CONTAINER_1,
+          TRANSITION_KEY_CHILD_2_2,
+          TRANSITION_KEY_CHILD_3_1,
+          TRANSITION_KEY_CHILD_4_2_2)
+    }
+
+    return Transition.create(*transitionKeys)
+        .animate(AnimatedProperties.WIDTH, AnimatedProperties.X)
+        .animator(Transition.timing(1000))
+  }
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/expandableelement/ExpandableElementActivity.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/expandableelement/ExpandableElementActivity.kt
@@ -1,0 +1,33 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.animations.expandableelement
+
+import android.os.Bundle
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.LithoView
+import com.fblitho.lithoktsample.NavigatableDemoActivity
+import com.fblitho.lithoktsample.animations.messages.Message.Companion.MESSAGES
+
+class ExpandableElementActivity : NavigatableDemoActivity() {
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+
+    val lithoView = LithoView.create(
+        this,
+        ExpandableElementRootComponent.create(ComponentContext(this))
+            .initialMessages(MESSAGES)
+            .build())
+    setContentView(lithoView)
+  }
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/expandableelement/ExpandableElementMeSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/expandableelement/ExpandableElementMeSpec.kt
@@ -1,0 +1,107 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.animations.expandableelement
+
+import android.graphics.Color
+import com.facebook.litho.ClickEvent
+import com.facebook.litho.Column
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.Row
+import com.facebook.litho.StateValue
+import com.facebook.litho.Transition
+import com.facebook.litho.Transition.BaseTransitionUnitsBuilder
+import com.facebook.litho.animation.AnimatedProperties
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.annotations.OnCreateTransition
+import com.facebook.litho.annotations.OnEvent
+import com.facebook.litho.annotations.OnUpdateState
+import com.facebook.litho.annotations.Param
+import com.facebook.litho.annotations.Prop
+import com.facebook.litho.annotations.State
+import com.facebook.litho.widget.Text
+import com.facebook.yoga.YogaEdge
+import com.facebook.yoga.YogaJustify
+import com.fblitho.lithoktsample.animations.expandableelement.ExpandableElementUtil.TRANSITION_MSG_PARENT
+
+@LayoutSpec
+object ExpandableElementMeSpec {
+
+  @OnCreateLayout
+  fun onCreateLayout(
+      c: ComponentContext,
+      @Prop messageText: String,
+      @Prop timestamp: String,
+      @Prop(optional = true) seen: Boolean,
+      @State expanded: Boolean?
+  ): Component {
+    val isExpanded = expanded ?: false
+
+    return Column.create(c)
+        .paddingDip(YogaEdge.TOP, 8f)
+        .transitionKey(TRANSITION_MSG_PARENT)
+        .clickHandler(ExpandableElementMe.onClick(c))
+        .child(ExpandableElementUtil.maybeCreateTopDetailComponent(c, isExpanded, timestamp))
+        .child(
+            Column.create(c)
+                .transitionKey(ExpandableElementUtil.TRANSITION_TEXT_MESSAGE_WITH_BOTTOM)
+                .child(
+                    Row.create(c)
+                        .justifyContent(YogaJustify.FLEX_END)
+                        .paddingDip(YogaEdge.START, 75f)
+                        .paddingDip(YogaEdge.END, 5f)
+                        .child(createMessageContent(c, messageText)))
+                .child(ExpandableElementUtil.maybeCreateBottomDetailComponent(c, isExpanded, seen)))
+        .build()
+  }
+
+  @OnEvent(ClickEvent::class)
+  fun onClick(c: ComponentContext, @State expanded: Boolean?) {
+    val isExpanded = expanded ?: false
+    ExpandableElementMe.updateExpandedState(c, !isExpanded)
+  }
+
+  @OnUpdateState
+  fun updateExpandedState(expanded: StateValue<Boolean>, @Param expand: Boolean) {
+    expanded.set(expand)
+  }
+
+  @OnCreateTransition
+  fun onCreateTransition(
+      c: ComponentContext,
+      @State expanded: Boolean?,
+      @Prop(optional = true) forceAnimateOnAppear: Boolean
+  ): Transition? = if (!forceAnimateOnAppear && expanded == null) {
+    null
+  } else {
+    Transition.parallel<BaseTransitionUnitsBuilder>(
+        Transition.allLayout(),
+        Transition.create(TRANSITION_MSG_PARENT).animate(AnimatedProperties.HEIGHT).appearFrom(0f),
+        Transition.create(ExpandableElementUtil.TRANSITION_TOP_DETAIL)
+            .animate(AnimatedProperties.HEIGHT)
+            .appearFrom(0f)
+            .disappearTo(0f),
+        Transition.create(ExpandableElementUtil.TRANSITION_BOTTOM_DETAIL)
+            .animate(AnimatedProperties.HEIGHT)
+            .appearFrom(0f)
+            .disappearTo(0f))
+  }
+
+  private fun createMessageContent(c: ComponentContext, messageText: String): Component.Builder<*> =
+      Row.create(c)
+          .paddingDip(YogaEdge.ALL, 8f)
+          .marginDip(YogaEdge.ALL, 8f)
+          .background(ExpandableElementUtil.getMessageBackground(c, 0xFF0084FF.toInt()))
+          .child(Text.create(c).textSizeDip(18f).textColor(Color.WHITE).text(messageText))
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/expandableelement/ExpandableElementOtherSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/expandableelement/ExpandableElementOtherSpec.kt
@@ -1,0 +1,110 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.animations.expandableelement
+
+import android.graphics.Color
+import android.graphics.drawable.ShapeDrawable
+import android.graphics.drawable.shapes.OvalShape
+import com.facebook.litho.ClickEvent
+import com.facebook.litho.Column
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.Row
+import com.facebook.litho.StateValue
+import com.facebook.litho.Transition
+import com.facebook.litho.Transition.BaseTransitionUnitsBuilder
+import com.facebook.litho.animation.AnimatedProperties
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.annotations.OnEvent
+import com.facebook.litho.annotations.OnUpdateStateWithTransition
+import com.facebook.litho.annotations.Param
+import com.facebook.litho.annotations.Prop
+import com.facebook.litho.annotations.State
+import com.facebook.litho.widget.Text
+import com.facebook.yoga.YogaAlign
+import com.facebook.yoga.YogaEdge
+
+@LayoutSpec
+object ExpandableElementOtherSpec {
+
+  @OnCreateLayout
+  fun onCreateLayout(
+      c: ComponentContext,
+      @Prop messageText: String,
+      @Prop timestamp: String,
+      @Prop(optional = true) seen: Boolean,
+      @State expanded: Boolean?
+  ): Component {
+    val isExpanded = expanded ?: false
+
+    return Column.create(c)
+        .paddingDip(YogaEdge.TOP, 8f)
+        .transitionKey(ExpandableElementUtil.TRANSITION_MSG_PARENT)
+        .clickHandler(ExpandableElementOther.onClick(c))
+        .child(ExpandableElementUtil.maybeCreateTopDetailComponent(c, isExpanded, timestamp))
+        .child(
+            Column.create(c)
+                .transitionKey(ExpandableElementUtil.TRANSITION_TEXT_MESSAGE_WITH_BOTTOM)
+                .child(
+                    Row.create(c)
+                        .paddingDip(YogaEdge.END, 5f)
+                        .child(createSenderTile(c))
+                        .child(createMessageContent(c, messageText)))
+                .child(ExpandableElementUtil.maybeCreateBottomDetailComponent(c, isExpanded, seen)))
+        .build()
+  }
+
+  @OnEvent(ClickEvent::class)
+  fun onClick(c: ComponentContext, @State expanded: Boolean?) {
+    val isExpanded = expanded ?: false
+    ExpandableElementOther.updateExpandedStateWithTransition(c, !isExpanded)
+  }
+
+  @OnUpdateStateWithTransition
+  fun updateExpandedState(expanded: StateValue<Boolean>, @Param expand: Boolean): Transition {
+    expanded.set(expand)
+
+    return Transition.parallel<BaseTransitionUnitsBuilder>(
+        Transition.allLayout(),
+        Transition.create(ExpandableElementUtil.TRANSITION_TOP_DETAIL)
+            .animate(AnimatedProperties.HEIGHT)
+            .appearFrom(0f)
+            .disappearTo(0f),
+        Transition.create(ExpandableElementUtil.TRANSITION_BOTTOM_DETAIL)
+            .animate(AnimatedProperties.HEIGHT)
+            .appearFrom(0f)
+            .disappearTo(0f))
+  }
+
+  private fun createSenderTile(c: ComponentContext): Component.Builder<*> =
+      Row.create(c)
+          .marginDip(YogaEdge.ALL, 5f)
+          .alignSelf(YogaAlign.CENTER)
+          .widthDip(55f)
+          .heightDip(55f)
+          .flexShrink(0f)
+          .background(getCircle(c))
+
+  private fun getCircle(c: ComponentContext): ShapeDrawable = ShapeDrawable(OvalShape())
+      .also {
+        it.paint.color = Color.LTGRAY
+      }
+
+  private fun createMessageContent(c: ComponentContext, messageText: String): Component.Builder<*> =
+      Row.create(c)
+          .paddingDip(YogaEdge.ALL, 8f)
+          .marginDip(YogaEdge.ALL, 8f)
+          .background(ExpandableElementUtil.getMessageBackground(c, 0xFFEAEAEA.toInt()))
+          .child(Text.create(c).textSizeDip(18f).textColor(Color.BLACK).text(messageText))
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/expandableelement/ExpandableElementRootComponentSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/expandableelement/ExpandableElementRootComponentSpec.kt
@@ -1,0 +1,133 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.animations.expandableelement
+
+import android.graphics.Color
+import android.text.Layout
+import com.facebook.litho.ClickEvent
+import com.facebook.litho.Column
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.Row
+import com.facebook.litho.StateValue
+import com.facebook.litho.annotations.FromEvent
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateInitialState
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.annotations.OnEvent
+import com.facebook.litho.annotations.OnUpdateState
+import com.facebook.litho.annotations.Param
+import com.facebook.litho.annotations.Prop
+import com.facebook.litho.annotations.State
+import com.facebook.litho.sections.SectionContext
+import com.facebook.litho.sections.common.DataDiffSection
+import com.facebook.litho.sections.common.RenderEvent
+import com.facebook.litho.sections.widget.NotAnimatedItemAnimator
+import com.facebook.litho.sections.widget.RecyclerCollectionComponent
+import com.facebook.litho.widget.RenderInfo
+import com.facebook.litho.widget.Text
+import com.facebook.yoga.YogaAlign
+import com.facebook.yoga.YogaEdge
+import com.fblitho.lithoktsample.animations.messages.Message
+import java.util.ArrayList
+
+@LayoutSpec
+object ExpandableElementRootComponentSpec {
+
+  @OnCreateInitialState
+  fun onCreateInitialState(
+      c: ComponentContext,
+      messages: StateValue<List<Message>>,
+      counter: StateValue<Int>,
+      @Prop initialMessages: List<Message>
+  ) {
+    messages.set(initialMessages)
+    counter.set(1)
+  }
+
+  @OnCreateLayout
+  internal fun onCreateLayout(
+      c: ComponentContext,
+      @State messages: List<Message>,
+      @State counter: Int
+  ): Component = Column.create(c)
+      .child(
+          Row.create(c)
+              .backgroundColor(Color.LTGRAY)
+              .child(
+                  Text.create(c)
+                      .paddingDip(YogaEdge.ALL, 10f)
+                      .text("INSERT")
+                      .textSizeSp(20f)
+                      .flexGrow(1f)
+                      .alignSelf(YogaAlign.CENTER)
+                      .testKey("INSERT")
+                      .textAlignment(Layout.Alignment.ALIGN_CENTER)
+                      .clickHandler(ExpandableElementRootComponent.onClick(c, true)))
+              .child(
+                  Text.create(c)
+                      .paddingDip(YogaEdge.ALL, 10f)
+                      .text("DELETE")
+                      .textSizeSp(20f)
+                      .flexGrow(1f)
+                      .alignSelf(YogaAlign.CENTER)
+                      .textAlignment(Layout.Alignment.ALIGN_CENTER)
+                      .clickHandler(ExpandableElementRootComponent.onClick(c, false))))
+      .child(
+          RecyclerCollectionComponent.create(c)
+              .flexGrow(1f)
+              .disablePTR(true)
+              .itemAnimator(NotAnimatedItemAnimator())
+              .section(
+                  DataDiffSection.create<Message>(SectionContext(c))
+                      .data(messages)
+                      .renderEventHandler(ExpandableElementRootComponent.onRender(c))
+                      .build())
+              .paddingDip(YogaEdge.TOP, 8f))
+      .build()
+
+  @OnEvent(ClickEvent::class)
+  fun onClick(
+      c: ComponentContext,
+      @Prop initialMessages: List<Message>,
+      @Param adding: Boolean
+  ) {
+    ExpandableElementRootComponent.onUpdateList(c, adding, initialMessages.size)
+  }
+
+  @OnUpdateState
+  fun onUpdateList(
+      messages: StateValue<List<Message>>,
+      counter: StateValue<Int>,
+      @Param adding: Boolean,
+      @Param initialMessagesSize: Int
+  ) {
+    val updatedMessageList = ArrayList(messages.get())
+
+    val counterValue = counter.get()
+    if (adding) {
+      updatedMessageList.add(
+          1,
+          Message(true, "Just Added #$counterValue",
+              true, "Recently", true))
+      counter.set(counterValue + 1)
+    } else if (initialMessagesSize < updatedMessageList.size) {
+      updatedMessageList.removeAt(1)
+    }
+    messages.set(updatedMessageList)
+  }
+
+  @OnEvent(RenderEvent::class)
+  fun onRender(c: ComponentContext, @FromEvent model: Message): RenderInfo =
+      model.createComponent(c)
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/expandableelement/ExpandableElementUtil.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/expandableelement/ExpandableElementUtil.kt
@@ -1,0 +1,71 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.animations.expandableelement
+
+import android.graphics.Color
+import android.graphics.drawable.ShapeDrawable
+import android.graphics.drawable.shapes.RoundRectShape
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.widget.Text
+import com.facebook.yoga.YogaAlign
+import com.facebook.yoga.YogaEdge
+
+object ExpandableElementUtil {
+  const val TRANSITION_MSG_PARENT = "transition_msg_parent"
+  const val TRANSITION_TEXT_MESSAGE_WITH_BOTTOM = "transition_text_msg_with_bottom"
+  const val TRANSITION_TOP_DETAIL = "transition_top_detail"
+  const val TRANSITION_BOTTOM_DETAIL = "transition_bottom_detail"
+
+  fun getMessageBackground(c: ComponentContext, color: Int): ShapeDrawable {
+    val roundedRectShape = RoundRectShape(
+        floatArrayOf(40f, 40f, 40f, 40f, 40f, 40f, 40f, 40f),
+        null,
+        floatArrayOf(40f, 40f, 40f, 40f, 40f, 40f, 40f, 40f))
+    return ShapeDrawable(roundedRectShape)
+        .also {
+          it.paint.color = color
+        }
+  }
+
+  fun maybeCreateBottomDetailComponent(
+      c: ComponentContext,
+      expanded: Boolean,
+      seen: Boolean
+  ): Component.Builder<*>? = if (!expanded) {
+    null
+  } else {
+    Text.create(c)
+        .textSizeDip(14f)
+        .textColor(Color.GRAY)
+        .alignSelf(YogaAlign.FLEX_END)
+        .paddingDip(YogaEdge.RIGHT, 10f)
+        .transitionKey(TRANSITION_BOTTOM_DETAIL)
+        .text(if (seen) "Seen" else "Sent")
+  }
+
+  fun maybeCreateTopDetailComponent(
+      c: ComponentContext,
+      expanded: Boolean,
+      timestamp: String
+  ): Component.Builder<*>? = if (!expanded) {
+    null
+  } else {
+    Text.create(c)
+        .textSizeDip(14f)
+        .textColor(Color.GRAY)
+        .alignSelf(YogaAlign.CENTER)
+        .transitionKey(TRANSITION_TOP_DETAIL)
+        .text(timestamp)
+  }
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/messages/Message.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/messages/Message.kt
@@ -1,0 +1,116 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.fblitho.lithoktsample.animations.messages
+
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.widget.ComponentRenderInfo
+import com.facebook.litho.widget.RenderInfo
+import com.fblitho.lithoktsample.animations.expandableelement.ExpandableElementMe
+import com.fblitho.lithoktsample.animations.expandableelement.ExpandableElementOther
+
+class Message {
+
+  private val mIsMe: Boolean
+  private val mMessage: String
+  private val mSeen: Boolean
+  private val mTimestamp: String
+  private val mForceAnimateOnAppear: Boolean
+
+  constructor(isMe: Boolean, message: String, seen: Boolean, timestamp: String) {
+    mIsMe = isMe
+    mMessage = message
+    mSeen = seen
+    mTimestamp = timestamp
+    mForceAnimateOnAppear = false
+  }
+
+  constructor(
+      isMe: Boolean,
+      message: String,
+      seen: Boolean,
+      timestamp: String,
+      forceAnimateOnInsert: Boolean
+  ) {
+    mIsMe = isMe
+    mMessage = message
+    mSeen = seen
+    mTimestamp = timestamp
+    mForceAnimateOnAppear = forceAnimateOnInsert
+  }
+
+  fun createComponent(c: ComponentContext): RenderInfo {
+    val component = if (mIsMe) {
+      ExpandableElementMe.create(c)
+          .messageText(mMessage)
+          .timestamp(mTimestamp)
+          .seen(mSeen)
+          .forceAnimateOnAppear(mForceAnimateOnAppear)
+          .build()
+    } else {
+      ExpandableElementOther.create(c)
+          .messageText(mMessage)
+          .timestamp(mTimestamp)
+          .seen(mSeen)
+          .build()
+    }
+
+    return ComponentRenderInfo.create().component(component).build()
+  }
+
+  companion object {
+    val MESSAGES = listOf(
+        Message(true,
+            "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque "
+                + "laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi "
+                + "architecto beatae vitae dicta sunt explicabo",
+            true,
+            "DEC 25 AT 9:55"),
+        Message(false,
+            "Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit",
+            true,
+            "DEC 25 AT 9:58"),
+        Message(false,
+            "sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.",
+            true,
+            "DEC 25 AT 9:59"),
+        Message(true, "Neque porro quisquam est", true, "DEC 25 AT 9:59"),
+        Message(false, "qui dolorem ipsum quia dolor sit amet", true, "DEC 25 AT 10:01"),
+        Message(true, "consectetur, adipisci velit", true, "DEC 25 AT 10:02"),
+        Message(true,
+            ("sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam "
+                + "quaerat voluptatem"),
+            true,
+            "DEC 25 AT 10:07"),
+        Message(true,
+            ("Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit "
+                + "laboriosam"),
+            true,
+            "DEC 25 AT 10:11"),
+        Message(false, "nisi ut aliquid ex ea commodi consequatur?", true, "DEC 25 AT 10:16"),
+        Message(true,
+            ("Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil"
+                + " molestiae consequatur"),
+            true,
+            "DEC 25 AT 10:21"),
+        Message(false,
+            "vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?",
+            false,
+            "DEC 25 AT 10:25"),
+        Message(false,
+            ("At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis "
+                + "praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias "
+                + "excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui "
+                + "officia deserunt mollitia animi, id est laborum et dolorum fuga."),
+            false,
+            "DEC 25 AT 10:29"))
+  }
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DataModels.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DataModels.kt
@@ -12,14 +12,45 @@
 
 package com.fblitho.lithoktsample.demo
 
+import com.fblitho.lithoktsample.animations.animatedbadge.AnimatedBadgeActivity
+import com.fblitho.lithoktsample.animations.animationcomposition.ComposedAnimationsActivity
+import com.fblitho.lithoktsample.animations.bounds.BoundsAnimationActivity
+import com.fblitho.lithoktsample.animations.expandableelement.ExpandableElementActivity
 import com.fblitho.lithoktsample.errors.ErrorHandlingActivity
 import com.fblitho.lithoktsample.lithography.LithographyActivity
 
 object DataModels {
 
   val DATA_MODELS = listOf(
-      DemoListDataModel("Lithography", LithographyActivity::class.java),
-      DemoListDataModel("Error boundaries", ErrorHandlingActivity::class.java))
+      DemoListDataModel(
+          name = "Lithography",
+          klass = LithographyActivity::class.java
+      ),
+      DemoListDataModel(
+          name = "Error boundaries",
+          klass = ErrorHandlingActivity::class.java
+      ),
+      DemoListDataModel(
+          name = "Animations",
+          datamodels = listOf(
+              DemoListDataModel(
+                  name = "Animations Composition",
+                  klass = ComposedAnimationsActivity::class.java
+              ),
+              DemoListDataModel(
+                  name = "Expandable Element",
+                  klass = ExpandableElementActivity::class.java
+              ),
+              DemoListDataModel(
+                  name = "Animated Badge",
+                  klass = AnimatedBadgeActivity::class.java
+              ),
+              DemoListDataModel(
+                  name = "Bounds Animation",
+                  klass = BoundsAnimationActivity::class.java)
+          )
+      )
+  )
 
   fun getDataModels(index: Int): List<DemoListDataModel> =
       if (index == DemoListActivity.DEFAULT_INDEX) {

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DataModels.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DataModels.kt
@@ -52,10 +52,17 @@ object DataModels {
       )
   )
 
-  fun getDataModels(index: Int): List<DemoListDataModel> =
-      if (index == DemoListActivity.DEFAULT_INDEX) {
-        DATA_MODELS
-      } else {
-        DATA_MODELS[index].datamodels ?: emptyList()
-      }
+  fun getDataModels(indices: IntArray?): List<DemoListDataModel> {
+    if (indices == null) {
+      return DATA_MODELS
+    }
+
+    var dataModels: List<DemoListDataModel> = DATA_MODELS
+
+    indices.forEach {
+      dataModels = dataModels[it].datamodels ?: dataModels
+    }
+
+    return dataModels
+  }
 }

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DemoListActivity.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DemoListActivity.kt
@@ -22,8 +22,8 @@ class DemoListActivity : NavigatableDemoActivity() {
   public override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
-    val index = intent.getIntExtra(INDEX, DEFAULT_INDEX)
-    val dataModels = DataModels.getDataModels(index)
+    val indices = intent.getIntArrayExtra(INDICES)
+    val dataModels = DataModels.getDataModels(indices)
 
     val componentContext = ComponentContext(this)
     setContentView(
@@ -31,11 +31,11 @@ class DemoListActivity : NavigatableDemoActivity() {
             this,
             DemoListComponent.create(componentContext)
                 .dataModels(dataModels)
+                .parentIndices(indices)
                 .build()))
   }
 
   companion object {
-    const val INDEX = "INDEX"
-    const val DEFAULT_INDEX = -1
+    const val INDICES = "INDICES"
   }
 }

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DemoListComponentSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DemoListComponentSpec.kt
@@ -27,6 +27,7 @@ import com.facebook.litho.sections.common.RenderEvent
 import com.facebook.litho.sections.widget.RecyclerCollectionComponent
 import com.facebook.litho.widget.ComponentRenderInfo
 import com.facebook.litho.widget.RenderInfo
+import java.util.Arrays
 
 @LayoutSpec
 object DemoListComponentSpec {
@@ -50,6 +51,7 @@ object DemoListComponentSpec {
   @OnEvent(RenderEvent::class)
   fun onRender(
       c: ComponentContext,
+      @Prop parentIndices: IntArray?,
       @FromEvent model: DemoListDataModel,
       @FromEvent index: Int
   ): RenderInfo =
@@ -57,9 +59,18 @@ object DemoListComponentSpec {
           .component(
               DemoListItemComponent.create(c)
                   .model(model)
-                  .currentIndex(index)
+                  .currentIndices(getUpdatedIndices(parentIndices, index))
                   .build())
           .build()
+
+  private fun getUpdatedIndices(parentIndices: IntArray?, currentIndex: Int): IntArray =
+      if (parentIndices == null) {
+        intArrayOf(currentIndex)
+      } else {
+        val updatedIndices = Arrays.copyOf(parentIndices, parentIndices.size + 1)
+        updatedIndices[parentIndices.size] = currentIndex
+        updatedIndices
+      }
 
   /**
    * Called during DataDiffSection's diffing to determine if two objects represent the same item.

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DemoListItemComponentSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DemoListItemComponentSpec.kt
@@ -43,7 +43,7 @@ object DemoListItemComponentSpec {
       c: ComponentContext,
       @FromEvent view: View,
       @Prop model: DemoListDataModel,
-      @Prop currentIndex: Int
+      @Prop currentIndices: IntArray
   ) {
     val activityClass = if (model.datamodels == null) {
       model.klass
@@ -52,7 +52,7 @@ object DemoListItemComponentSpec {
     }
 
     val intent = Intent(c, activityClass)
-    intent.putExtra(DemoListActivity.INDEX, currentIndex)
+    intent.putExtra(DemoListActivity.INDICES, currentIndices)
     c.startActivity(intent)
   }
 }


### PR DESCRIPTION
This PR follows a similar path as the previous one :) It ports `animations` package from Java `sample` to Kotlin `sample-kotlin`.

A nice side effect of it is that even more parts of the framework are being "tested" in Kotlin code, which will allow catching Kotlin-related issues earlier.