### PR TITLE
Port 'bordereffects' to 'sample-kotlin'

### DIFF
--- a/sample-kotlin/src/main/AndroidManifest.xml
+++ b/sample-kotlin/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
-        android:name="com.fblitho.lithoktsample.LithoApplication"
+        android:name=".LithoApplication"
         android:allowBackup="true"
         android:label="Litho Sample"
         android:theme="@style/Theme.AppCompat.Light.DarkActionBar">
@@ -27,8 +27,9 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
-        <activity android:name="com.fblitho.lithoktsample.lithography.LithographyActivity"/>
+        <activity android:name=".lithography.LithographyActivity"/>
         <activity android:name=".errors.ErrorHandlingActivity" />
+        <activity android:name=".bordereffects.BorderEffectsActivity" />
         <activity android:name=".animations.animatedbadge.AnimatedBadgeActivity" />
         <activity android:name=".animations.animationcomposition.ComposedAnimationsActivity" />
         <activity android:name=".animations.expandableelement.ExpandableElementActivity" />

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/bordereffects/AllBorderSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/bordereffects/AllBorderSpec.kt
@@ -1,0 +1,38 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.bordereffects
+
+import com.facebook.litho.Border
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.Row
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.widget.Text
+import com.facebook.yoga.YogaEdge
+
+@LayoutSpec
+object AllBorderSpec {
+
+  @OnCreateLayout
+  fun onCreateLayout(c: ComponentContext): Component =
+      Row.create(c)
+          .child(
+              Text.create(c)
+                  .textSizeSp(20f)
+                  .text("This component has all borders specified to the same color + width"))
+          .border(
+              Border.create(c).color(YogaEdge.ALL, NiceColor.BLUE).widthDip(YogaEdge.ALL, 5)
+                  .build())
+          .build()
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/bordereffects/AlternateColorBorderSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/bordereffects/AlternateColorBorderSpec.kt
@@ -1,0 +1,44 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.bordereffects
+
+import com.facebook.litho.Border
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.Row
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.widget.Text
+import com.facebook.yoga.YogaEdge
+
+@LayoutSpec
+object AlternateColorBorderSpec {
+
+  @OnCreateLayout
+  fun onCreateLayout(c: ComponentContext): Component =
+      Row.create(c)
+          .child(
+              Text.create(c)
+                  .textSizeSp(20f)
+                  .text(
+                      "This component has all borders specified to the same width, but not colors"))
+          .border(
+              Border.create(c)
+                  .color(YogaEdge.LEFT, NiceColor.RED)
+                  .color(YogaEdge.TOP, NiceColor.YELLOW)
+                  .color(YogaEdge.RIGHT, NiceColor.GREEN)
+                  .color(YogaEdge.BOTTOM, NiceColor.BLUE)
+                  .widthDip(YogaEdge.ALL, 5)
+                  .build())
+          .build()
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/bordereffects/AlternateColorCornerPathEffectBorderSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/bordereffects/AlternateColorCornerPathEffectBorderSpec.kt
@@ -1,0 +1,45 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.bordereffects
+
+import com.facebook.litho.Border
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.Row
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.widget.Text
+import com.facebook.yoga.YogaEdge
+
+@LayoutSpec
+object AlternateColorCornerPathEffectBorderSpec {
+
+  @OnCreateLayout
+  fun onCreateLayout(c: ComponentContext): Component =
+      Row.create(c)
+          .child(
+              Text.create(c)
+                  .textSizeSp(20f)
+                  .text("This component has a path effect with rounded corners + multiple colors"))
+          .border(
+              Border.create(c)
+                  .widthDip(YogaEdge.ALL, 20)
+                  .color(YogaEdge.LEFT, NiceColor.RED)
+                  .color(YogaEdge.TOP, NiceColor.ORANGE)
+                  .color(YogaEdge.RIGHT, NiceColor.GREEN)
+                  .color(YogaEdge.BOTTOM, NiceColor.BLUE)
+                  .radiusDip(20f)
+                  .build())
+          .build()
+
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/bordereffects/AlternateColorPathEffectBorderSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/bordereffects/AlternateColorPathEffectBorderSpec.kt
@@ -1,0 +1,44 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.bordereffects
+
+import com.facebook.litho.Border
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.Row
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.widget.Text
+import com.facebook.yoga.YogaEdge
+
+@LayoutSpec
+object AlternateColorPathEffectBorderSpec {
+
+  @OnCreateLayout
+  fun onCreateLayout(c: ComponentContext): Component =
+      Row.create(c)
+          .child(
+              Text.create(c)
+                  .textSizeSp(20f)
+                  .text("This component has a path effect with multiple colors"))
+          .border(
+              Border.create(c)
+                  .color(YogaEdge.LEFT, NiceColor.RED)
+                  .color(YogaEdge.TOP, NiceColor.ORANGE)
+                  .color(YogaEdge.RIGHT, NiceColor.GREEN)
+                  .color(YogaEdge.BOTTOM, NiceColor.BLUE)
+                  .widthDip(YogaEdge.ALL, 5)
+                  .discreteEffect(5f, 10f)
+                  .build())
+          .build()
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/bordereffects/AlternateColorWidthBorderSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/bordereffects/AlternateColorWidthBorderSpec.kt
@@ -1,0 +1,46 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.bordereffects
+
+import com.facebook.litho.Border
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.Row
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.widget.Text
+import com.facebook.yoga.YogaEdge
+
+@LayoutSpec
+object AlternateColorWidthBorderSpec {
+
+  @OnCreateLayout
+  fun onCreateLayout(c: ComponentContext): Component =
+      Row.create(c)
+          .child(
+              Text.create(c)
+                  .textSizeSp(20f)
+                  .text("This component has each border specified to a different color + width"))
+          .border(
+              Border.create(c)
+                  .color(YogaEdge.LEFT, NiceColor.RED)
+                  .color(YogaEdge.TOP, NiceColor.YELLOW)
+                  .color(YogaEdge.RIGHT, NiceColor.GREEN)
+                  .color(YogaEdge.BOTTOM, NiceColor.BLUE)
+                  .widthDip(YogaEdge.LEFT, 2)
+                  .widthDip(YogaEdge.TOP, 4)
+                  .widthDip(YogaEdge.RIGHT, 8)
+                  .widthDip(YogaEdge.BOTTOM, 16)
+                  .build())
+          .build()
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/bordereffects/AlternateWidthBorderSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/bordereffects/AlternateWidthBorderSpec.kt
@@ -1,0 +1,45 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.bordereffects
+
+import com.facebook.litho.Border
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.Row
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.widget.Text
+import com.facebook.yoga.YogaEdge
+
+@LayoutSpec
+object AlternateWidthBorderSpec {
+
+  @OnCreateLayout
+  fun onCreateLayout(c: ComponentContext): Component =
+      Row.create(c)
+          .child(
+              Text.create(c)
+                  .textSizeSp(20f)
+                  .text(
+                      "This component has all borders specified to the same color, but not width"))
+          .border(
+              Border.create(c)
+                  .color(YogaEdge.ALL, NiceColor.MAGENTA)
+                  .widthDip(YogaEdge.LEFT, 2)
+                  .widthDip(YogaEdge.TOP, 4)
+                  .widthDip(YogaEdge.RIGHT, 8)
+                  .widthDip(YogaEdge.BOTTOM, 16)
+                  .build())
+          .build()
+
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/bordereffects/BorderEffectsActivity.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/bordereffects/BorderEffectsActivity.kt
@@ -1,0 +1,26 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.bordereffects
+
+import android.os.Bundle
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.LithoView
+import com.fblitho.lithoktsample.NavigatableDemoActivity
+
+class BorderEffectsActivity : NavigatableDemoActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContentView(
+        LithoView.create(this, BorderEffectsComponent.create(ComponentContext(this)).build()))
+  }
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/bordereffects/BorderEffectsComponentSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/bordereffects/BorderEffectsComponentSpec.kt
@@ -1,0 +1,78 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.bordereffects
+
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.annotations.FromEvent
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.annotations.OnEvent
+import com.facebook.litho.sections.SectionContext
+import com.facebook.litho.sections.common.DataDiffSection
+import com.facebook.litho.sections.common.RenderEvent
+import com.facebook.litho.sections.widget.RecyclerCollectionComponent
+import com.facebook.litho.widget.ComponentRenderInfo
+import com.facebook.litho.widget.RenderInfo
+import com.facebook.litho.widget.Text
+import java.lang.reflect.InvocationTargetException
+
+@LayoutSpec
+object BorderEffectsComponentSpec {
+
+  private val componentsToBuild = listOf(
+      AlternateColorBorder::class.java,
+      AlternateWidthBorder::class.java,
+      AlternateColorWidthBorder::class.java,
+      RtlColorWidthBorder::class.java,
+      DashPathEffectBorder::class.java,
+      VerticalDashPathEffectBorder::class.java,
+      AlternateColorPathEffectBorder::class.java,
+      AlternateColorCornerPathEffectBorder::class.java,
+      CompositePathEffectBorder::class.java,
+      VaryingRadiiBorder::class.java)
+
+  @OnCreateLayout
+  fun onCreateLayout(c: ComponentContext): Component =
+      RecyclerCollectionComponent.create(c)
+          .disablePTR(true)
+          .section(
+              DataDiffSection.create<Class<out Component>>(SectionContext(c))
+                  .data(componentsToBuild)
+                  .renderEventHandler(BorderEffectsComponent.onRender(c))
+                  .build())
+          .build()
+
+  @OnEvent(RenderEvent::class)
+  fun onRender(c: ComponentContext, @FromEvent model: Class<out Component>): RenderInfo {
+    val component = try {
+      val createMethod = model.getMethod("create", ComponentContext::class.java)
+      val componentBuilder = createMethod.invoke(null, c) as Component.Builder<*>
+      componentBuilder.build()
+    } catch (ex: Exception) {
+      val textComponent = Text.create(c).textSizeDip(32f).text(ex.localizedMessage).build()
+
+      when (ex) {
+        is NoSuchMethodException,
+        is IllegalAccessException,
+        is IllegalArgumentException,
+        is InvocationTargetException -> textComponent
+        else -> textComponent
+      }
+    }
+
+    return ComponentRenderInfo.create()
+        .component(component)
+        .build()
+  }
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/bordereffects/CompositePathEffectBorderSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/bordereffects/CompositePathEffectBorderSpec.kt
@@ -1,0 +1,46 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.bordereffects
+
+import com.facebook.litho.Border
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.Row
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.widget.Text
+import com.facebook.yoga.YogaEdge
+
+@LayoutSpec
+object CompositePathEffectBorderSpec {
+
+  @OnCreateLayout
+  fun onCreateLayout(c: ComponentContext): Component =
+      Row.create(c)
+          .child(
+              Text.create(c)
+                  .textSizeSp(20f)
+                  .text("This component has a composite path effect of discrete + corner"))
+          .border(
+              Border.create(c)
+                  .widthDip(YogaEdge.ALL, 20)
+                  .color(YogaEdge.LEFT, NiceColor.RED)
+                  .color(YogaEdge.TOP, NiceColor.ORANGE)
+                  .color(YogaEdge.RIGHT, NiceColor.GREEN)
+                  .color(YogaEdge.BOTTOM, NiceColor.BLUE)
+                  .dashEffect(floatArrayOf(10f, 5f), 0f)
+                  .radiusDip(20f)
+                  .build())
+          .build()
+
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/bordereffects/DashPathEffectBorderSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/bordereffects/DashPathEffectBorderSpec.kt
@@ -1,0 +1,39 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.bordereffects
+
+import com.facebook.litho.Border
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.Row
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.widget.Text
+import com.facebook.yoga.YogaEdge
+
+@LayoutSpec
+object DashPathEffectBorderSpec {
+
+  @OnCreateLayout
+  fun onCreateLayout(c: ComponentContext): Component =
+      Row.create(c)
+          .child(
+              Text.create(c).textSizeSp(20f).text("This component has a dash path effect applied"))
+          .border(
+              Border.create(c)
+                  .color(YogaEdge.ALL, NiceColor.BLUE)
+                  .widthDip(YogaEdge.ALL, 5)
+                  .dashEffect(floatArrayOf(10f, 5f), 0f)
+                  .build())
+          .build()
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/bordereffects/NiceColor.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/bordereffects/NiceColor.kt
@@ -1,0 +1,33 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.bordereffects
+
+object NiceColor {
+  val RED: Int
+    get() = 0xffee4035.toInt()
+
+  val ORANGE: Int
+    get() = 0xfff37736.toInt()
+
+  val YELLOW: Int
+    get() = 0xfffdf498.toInt()
+
+  val GREEN: Int
+    get() = 0xff7bc043.toInt()
+
+  val BLUE: Int
+    get() = 0xff0392cf.toInt()
+
+  val MAGENTA: Int
+    get() = 0xffba02cf.toInt()
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/bordereffects/RtlColorWidthBorderSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/bordereffects/RtlColorWidthBorderSpec.kt
@@ -1,0 +1,46 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.bordereffects
+
+import com.facebook.litho.Border
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.Row
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.widget.Text
+import com.facebook.yoga.YogaDirection
+import com.facebook.yoga.YogaEdge
+
+@LayoutSpec
+object RtlColorWidthBorderSpec {
+
+  @OnCreateLayout
+  fun onCreateLayout(c: ComponentContext): Component =
+      Row.create(c)
+          .layoutDirection(YogaDirection.RTL)
+          .child(Text.create(c).textSizeSp(20f).text("This component is RTL"))
+          .border(
+              Border.create(c)
+                  .color(YogaEdge.START, NiceColor.RED)
+                  .color(YogaEdge.TOP, NiceColor.YELLOW)
+                  .color(YogaEdge.END, NiceColor.GREEN)
+                  .color(YogaEdge.BOTTOM, NiceColor.BLUE)
+                  .widthDip(YogaEdge.START, 2)
+                  .widthDip(YogaEdge.TOP, 4)
+                  .widthDip(YogaEdge.END, 8)
+                  .widthDip(YogaEdge.BOTTOM, 16)
+                  .build())
+          .build()
+
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/bordereffects/VaryingRadiiBorderSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/bordereffects/VaryingRadiiBorderSpec.kt
@@ -1,0 +1,47 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.bordereffects
+
+import android.graphics.Color
+import com.facebook.litho.Border
+import com.facebook.litho.Border.Corner
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.Row
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.widget.Text
+import com.facebook.yoga.YogaEdge
+
+@LayoutSpec
+object VaryingRadiiBorderSpec {
+
+  @OnCreateLayout
+  fun onCreateLayout(c: ComponentContext): Component =
+      Row.create(c)
+          .child(Text.create(c).textSizeSp(20f).text("This component has varying corner radii"))
+          .border(
+              Border.create(c)
+                  .widthDip(YogaEdge.ALL, 3)
+                  .color(YogaEdge.LEFT, Color.BLACK)
+                  .color(YogaEdge.TOP, NiceColor.GREEN)
+                  .color(YogaEdge.BOTTOM, NiceColor.BLUE)
+                  .color(YogaEdge.RIGHT, NiceColor.RED)
+                  .radiusDip(Corner.TOP_LEFT, 10f)
+                  .radiusDip(Corner.TOP_RIGHT, 5f)
+                  .radiusDip(Corner.BOTTOM_RIGHT, 20f)
+                  .radiusDip(Corner.BOTTOM_LEFT, 30f)
+                  .build())
+          .build()
+
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/bordereffects/VerticalDashPathEffectBorderSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/bordereffects/VerticalDashPathEffectBorderSpec.kt
@@ -1,0 +1,41 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.fblitho.lithoktsample.bordereffects
+
+import com.facebook.litho.Border
+import com.facebook.litho.Component
+import com.facebook.litho.ComponentContext
+import com.facebook.litho.Row
+import com.facebook.litho.annotations.LayoutSpec
+import com.facebook.litho.annotations.OnCreateLayout
+import com.facebook.litho.widget.Text
+import com.facebook.yoga.YogaEdge
+
+@LayoutSpec
+object VerticalDashPathEffectBorderSpec {
+
+  @OnCreateLayout
+  fun onCreateLayout(c: ComponentContext): Component =
+      Row.create(c)
+          .child(
+              Text.create(c)
+                  .textSizeSp(20f)
+                  .text("This component has a dash path effect on its vertical edges"))
+          .border(
+              Border.create(c)
+                  .color(YogaEdge.VERTICAL, NiceColor.RED)
+                  .widthDip(YogaEdge.ALL, 5)
+                  .dashEffect(floatArrayOf(20f, 5f), 0f)
+                  .build())
+          .build()
+}

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DataModels.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/demo/DataModels.kt
@@ -16,6 +16,7 @@ import com.fblitho.lithoktsample.animations.animatedbadge.AnimatedBadgeActivity
 import com.fblitho.lithoktsample.animations.animationcomposition.ComposedAnimationsActivity
 import com.fblitho.lithoktsample.animations.bounds.BoundsAnimationActivity
 import com.fblitho.lithoktsample.animations.expandableelement.ExpandableElementActivity
+import com.fblitho.lithoktsample.bordereffects.BorderEffectsActivity
 import com.fblitho.lithoktsample.errors.ErrorHandlingActivity
 import com.fblitho.lithoktsample.lithography.LithographyActivity
 
@@ -25,6 +26,10 @@ object DataModels {
       DemoListDataModel(
           name = "Lithography",
           klass = LithographyActivity::class.java
+      ),
+      DemoListDataModel(
+          name = "Border effects",
+          klass = BorderEffectsActivity::class.java
       ),
       DemoListDataModel(
           name = "Error boundaries",


### PR DESCRIPTION
* Like previous PRs this one is porting 'bordereffects' to 'sample-kotlin' as well.