### PR TITLE
Throw when using 'isFullSpan()' in ViewRenderInfo.Builder

### DIFF
--- a/litho-it/src/test/java/com/facebook/litho/widget/ViewRenderInfoTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/widget/ViewRenderInfoTest.java
@@ -1,0 +1,35 @@
+package com.facebook.litho.widget;
+
+import android.content.Context;
+import android.view.View;
+import android.view.ViewGroup;
+import com.facebook.litho.testing.testrunner.ComponentsTestRunner;
+import com.facebook.litho.viewcompat.SimpleViewBinder;
+import com.facebook.litho.viewcompat.ViewCreator;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.mockito.Mockito.mock;
+
+@RunWith(ComponentsTestRunner.class)
+public class ViewRenderInfoTest {
+
+  private static final ViewCreator VIEW_CREATOR_1 =
+      new ViewCreator() {
+        @Override
+        public View createView(Context c, ViewGroup parent) {
+          return mock(View.class);
+        }
+      };
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testThrowWhenUsingIsFullSpan() {
+    ViewRenderInfo viewRenderInfo = ViewRenderInfo
+        .create()
+        .viewBinder(new SimpleViewBinder())
+        .viewCreator(VIEW_CREATOR_1)
+        .isFullSpan(true /* actual value does not matter */)
+        .build();
+  }
+
+}

--- a/litho-widget/src/main/java/com/facebook/litho/widget/ViewRenderInfo.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/ViewRenderInfo.java
@@ -135,6 +135,11 @@ public class ViewRenderInfo extends BaseRenderInfo {
     }
 
     @Override
+    public Builder isFullSpan(boolean isFullSpan) {
+      throw new UnsupportedOperationException("ViewRenderInfo does not support isFullSpan.");
+    }
+
+    @Override
     void release() {
       super.release();
       viewBinder = null;


### PR DESCRIPTION
* Since `ViewRenderInfo.Builder` extends `BaseRenderInfo.Builder` it provides access to `builder.isFullSpan(boolean)`, which does not have any effect for `ViewRenderInfo`.

* See #312 for more details.