### PR TITLE
Update kotlin-stdlib-jre7 to kotlin-stdlib-jdk7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ ext.deps = [
         // Misc
         khronos            : 'org.khronos:opengl-api:gl1.1-android-2.1_r1',
         // Kotlin
-        kotlinStandardLib  : "org.jetbrains.kotlin:kotlin-stdlib-jre7:${KOTLIN_VERSION}"
+        kotlinStandardLib  : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${KOTLIN_VERSION}"
 ]
 
 // For releases, we want to depend on a stable version of Yoga.


### PR DESCRIPTION
* Kotlin JRE7 dependency has been deprecated and replaced with JDK7 version.