### PR TITLE
Ignore uninitialized LayoutParams from the RecyclerBinder

### DIFF
--- a/litho-core/src/main/java/com/facebook/litho/LithoView.java
+++ b/litho-core/src/main/java/com/facebook/litho/LithoView.java
@@ -282,8 +282,14 @@ public class LithoView extends ComponentHost {
     if (layoutParams instanceof LayoutManagerOverrideParams) {
       LayoutManagerOverrideParams layoutManagerOverrideParams =
           (LayoutManagerOverrideParams) layoutParams;
-      widthMeasureSpec = layoutManagerOverrideParams.getWidthMeasureSpec();
-      heightMeasureSpec = layoutManagerOverrideParams.getHeightMeasureSpec();
+      final int overrideWidthSpec = layoutManagerOverrideParams.getWidthMeasureSpec();
+      if (overrideWidthSpec != LayoutManagerOverrideParams.UNINITIALIZED) {
+        widthMeasureSpec = overrideWidthSpec;
+      }
+      final int overrideHeightSpec = layoutManagerOverrideParams.getHeightMeasureSpec();
+      if (overrideHeightSpec != LayoutManagerOverrideParams.UNINITIALIZED) {
+        heightMeasureSpec = overrideHeightSpec;
+      }
     }
 
     int width = MeasureSpec.getSize(widthMeasureSpec);
@@ -971,6 +977,9 @@ public class LithoView extends ComponentHost {
    * special values.
    */
   public interface LayoutManagerOverrideParams {
+
+    int UNINITIALIZED = -1;
+
     int getWidthMeasureSpec();
 
     int getHeightMeasureSpec();

--- a/litho-widget/src/main/java/com/facebook/litho/widget/RecyclerBinder.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/RecyclerBinder.java
@@ -50,6 +50,7 @@ import com.facebook.litho.EventHandler;
 import com.facebook.litho.LayoutHandler;
 import com.facebook.litho.LayoutThreadPoolExecutor;
 import com.facebook.litho.LithoView;
+import com.facebook.litho.LithoView.LayoutManagerOverrideParams;
 import com.facebook.litho.MeasureComparisonUtils;
 import com.facebook.litho.RenderCompleteEvent;
 import com.facebook.litho.Size;
@@ -86,7 +87,6 @@ import javax.annotation.concurrent.ThreadSafe;
 public class RecyclerBinder
     implements Binder<RecyclerView>, LayoutInfo.RenderInfoCollection, HasStickyHeader {
 
-  private static final int UNINITIALIZED = -1;
   private static final Size sDummySize = new Size();
   private static final String TAG = RecyclerBinder.class.getSimpleName();
   private static final int POST_UPDATE_VIEWPORT_AND_COMPUTE_RANGE_MAX_ATTEMPTS = 3;
@@ -208,8 +208,8 @@ public class RecyclerBinder
   private final boolean mIsCircular;
   private final boolean mHasDynamicItemHeight;
   private final boolean mWrapContent;
-  private int mLastWidthSpec = UNINITIALIZED;
-  private int mLastHeightSpec = UNINITIALIZED;
+  private int mLastWidthSpec = LayoutManagerOverrideParams.UNINITIALIZED;
+  private int mLastHeightSpec = LayoutManagerOverrideParams.UNINITIALIZED;
   private Size mMeasuredSize;
   private RecyclerView mMountedView;
   @VisibleForTesting int mCurrentFirstVisiblePosition = RecyclerView.NO_POSITION;
@@ -1475,7 +1475,7 @@ public class RecyclerBinder
                 " either OrientationHelper.HORIZONTAL or OrientationHelper.VERTICAL");
     }
 
-    if (mLastWidthSpec != UNINITIALIZED && !mRequiresRemeasure.get()) {
+    if (mLastWidthSpec != LayoutManagerOverrideParams.UNINITIALIZED && !mRequiresRemeasure.get()) {
       switch (scrollDirection) {
         case VERTICAL:
           if (MeasureComparisonUtils.isMeasureSpecCompatible(
@@ -2149,7 +2149,7 @@ public class RecyclerBinder
    */
   @Override
   public synchronized void setSize(int width, int height) {
-    if (mLastWidthSpec == UNINITIALIZED || !isCompatibleSize(
+    if (mLastWidthSpec == LayoutManagerOverrideParams.UNINITIALIZED || !isCompatibleSize(
         SizeSpec.makeSizeSpec(width, SizeSpec.EXACTLY),
         SizeSpec.makeSizeSpec(height, SizeSpec.EXACTLY))) {
       measure(
@@ -2377,7 +2377,7 @@ public class RecyclerBinder
   private boolean isCompatibleSize(int widthSpec, int heightSpec) {
     final int scrollDirection = mLayoutInfo.getScrollDirection();
 
-    if (mLastWidthSpec != UNINITIALIZED) {
+    if (mLastWidthSpec != LayoutManagerOverrideParams.UNINITIALIZED) {
 
       switch (scrollDirection) {
         case HORIZONTAL:


### PR DESCRIPTION
It's possible that RecyclerBinder doesn't have its size set by the time the RecyclerView measures itself (and lays out its children within its measure call). Due to the bitmasking on the measurespec int, the UNINITIALIZED -1 value that is sent in results in the cell being measured with width 0. Since the MeasureSpecs from the View's native onMeasure are still valid, we can just ignore the UNINITIALIZED value from the OverrideParams.