### PR TITLE
Add a getter for ComponentContext on Component.Builder

### DIFF
--- a/litho-core/src/main/java/com/facebook/litho/Component.java
+++ b/litho-core/src/main/java/com/facebook/litho/Component.java
@@ -690,6 +690,13 @@ public abstract class Component extends ComponentLifecycle
       }
     }
 
+    /**
+     * @return the {@link ComponentContext} for this {@link Builder}, useful for Kotlin DSL.
+     */
+    public ComponentContext getContext() {
+      return mContext;
+    }
+
     public abstract T getThis();
 
     /** Set a key on the component that is local to its parent. */


### PR DESCRIPTION
This allows the Kotlin DSL to build out children without needing to pass in a ComponentContext to each of the child components' DSL methods. Only the root element needs the initial ComponentContext passed in.

old:
```
column(c) {
    paddingDip(ALL, 16f)
    backgroundColor(color)
    children {
      text(c) {
        text(title)
        textSizeSp(40f)
      }
      text(c) {
        text(subtitle)
        textSizeSp(20f)
      }
    }
  }
```
new:
```
column(c) {
    paddingDip(ALL, 16f)
    backgroundColor(color)
    children {
      text {
        text(title)
        textSizeSp(40f)
      }
      text {
        text(subtitle)
        textSizeSp(20f)
      }
    }
  }
```

See https://github.com/vinc3m1/litho/commit/4b33086cc807715ab6714dc6a41176ba99b362a2 for a full example.