### PR TITLE
Update soloader version in docs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -37,6 +37,7 @@ repository: "facebook/litho"
 # These can be used in documentation with e.g. {{site.litho-version}}
 litho-version: 0.17.0
 litho-snapshot-version: 0.17.1-SNAPSHOT
+soloader-version: 0.5.1
 
 # Use these color settings to determine your colour scheme for the site.
 color:

--- a/docs/_docs/getting-started/gradle-kt.md
+++ b/docs/_docs/getting-started/gradle-kt.md
@@ -31,7 +31,7 @@ dependencies {
   kapt 'com.facebook.litho:litho-processor:{{site.litho-version}}'
 
   // SoLoader
-  implementation 'com.facebook.soloader:soloader:0.2.0'
+  implementation 'com.facebook.soloader:soloader:{{site.soloader-version}}'
 
   // For integration with Fresco
   implementation 'com.facebook.litho:litho-fresco:{{site.litho-version}}'

--- a/docs/_docs/getting-started/gradle.md
+++ b/docs/_docs/getting-started/gradle.md
@@ -22,7 +22,7 @@ dependencies {
   annotationProcessor 'com.facebook.litho:litho-processor:{{site.litho-version}}'
 
   // SoLoader
-  implementation 'com.facebook.soloader:soloader:0.2.0'
+  implementation 'com.facebook.soloader:soloader:{{site.soloader-version}}'
 
   // For integration with Fresco
   implementation 'com.facebook.litho:litho-fresco:{{site.litho-version}}'


### PR DESCRIPTION
Summary:
Soloader has had a backwards-incompatible change and mixing versions
older than 0.5 is gonna cause trouble.

Test Plan:
eyes