### PR TITLE
Fixed code example in mount-specs.md

### DIFF
--- a/docs/_docs/mount-specs.md
+++ b/docs/_docs/mount-specs.md
@@ -115,7 +115,7 @@ static void onMeasure(
 
   // If height is undefined, use 1.5 aspect ratio.
   if (SizeSpec.getMode(heightSpec) == SizeSpec.UNSPECIFIED) {
-    size.height = width * 1.5;
+    size.height = (int) (size.width * 1.5);
   } else {
     size.height = SizeSpec.getSize(heightSpec);
   }


### PR DESCRIPTION
The code example ( https://fblitho.com/docs/mount-specs ) may confuse readers. Undefined variable "width" should have been "size.width" and cast as an int.