### PR TITLE
[circle] Fix broken apt cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,11 +30,11 @@ aliases:
   # Build dependencies Cache aliases
   - &restore-cache-apt
     keys:
-      - v2-apt-{{ arch }}-{{ .Branch }}-{{ checksum "workspace/repo/scripts/apt-get-android-deps.sh" }}
+      - v3-apt-{{ arch }}-{{ .Branch }}-{{ checksum "workspace/repo/scripts/apt-get-android-deps.sh" }}
   - &save-cache-apt
     paths:
       - ~/vendor/apt
-    key: v2-apt-{{ arch }}-{{ .Branch }}-{{ checksum "workspace/repo/scripts/apt-get-android-deps.sh" }}
+    key: v3-apt-{{ arch }}-{{ .Branch }}-{{ checksum "workspace/repo/scripts/apt-get-android-deps.sh" }}
 
   # Repo Cache aliases
   - &restore-repo-cache


### PR DESCRIPTION
It looks like our cache corrupted. I can install everything fine manually via SSH, so let's just reset the cache.

https://circleci.com/gh/facebook/litho/4863