### PR TITLE
Unify build depepdencies

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -12,4 +12,4 @@
 
 [android]
   target = android-26
-  build_tools_version = 26.0.2
+  build_tools_version = 27.0.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,11 +12,11 @@ aliases:
   # SDK Cache aliases
   - &restore-cache-android-packages
     keys:
-      - v3-android-sdkmanager-packages-{{ arch }}-api-27-alpha-{{ checksum "workspace/repo/scripts/circle-ci-android-setup.sh" }}
+      - v4-android-sdkmanager-packages-{{ arch }}-api-27-alpha-{{ checksum "workspace/repo/scripts/circle-ci-android-setup.sh" }}
   - &save-cache-android-packages
     paths:
       - /opt/android/sdk
-    key: v3-android-sdkmanager-packages-{{ arch }}-api-27-alpha-{{ checksum "workspace/repo/scripts/circle-ci-android-setup.sh" }}
+    key: v4-android-sdkmanager-packages-{{ arch }}-api-27-alpha-{{ checksum "workspace/repo/scripts/circle-ci-android-setup.sh" }}
 
   # BUCK Cache aliases
   - &restore-cache-buck

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@ We want to make contributing to this project as easy and transparent as possible
 1. Clone the repo.
 2. Ensure your Android SDK has the right dependencies.  To build Litho you need:
    - [The Android NDK and build tools](https://developer.android.com/studio/projects/add-native-code.html) (NDK, CMake, LLDB)
-   - The Android 7.1.1 (API 25) SDK
-   - Version 26.0.2 of the The Android SDK Build tools.
+   - The Android 8.0 (API 26) SDK
+   - Version 27.0.3 of the The Android SDK Build tools.
 3. Import the project by selecting the repo's root directory. You should be able to successfully sync the gradle project now!
 
 ## Our Development Process

--- a/scripts/circle-ci-android-setup.sh
+++ b/scripts/circle-ci-android-setup.sh
@@ -56,5 +56,5 @@ function installAndroidSDK {
   echo > "$ANDROID_HOME/licenses/android-sdk-license"
   echo -n d56f5187479451eabf01fb78af6dfcb131a6481e > "$ANDROID_HOME/licenses/android-sdk-license"
 
-  installsdk 'build-tools;25.0.3' 'build-tools;26.0.2' 'platforms;android-25' 'platforms;android-26' 'extras;android;m2repository'
+  installsdk 'build-tools;27.0.3' 'platforms;android-26' 'extras;android;m2repository'
 }


### PR DESCRIPTION
Summary:
Use the same SDK and build-tools for Buck and Gradle
which reduces the download and hopefully CircleCI flakiness.

Differential Revision: D9262436
