### PR TITLE
Migrate to CircleCI 2.1 configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,17 +126,18 @@ aliases:
       find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/litho-working-dir/workspace/junit/ \;
     when: always
 
-circle_ci_android_container_config: &circle_ci_android_container_config
-  docker:
-    - image: circleci/android:api-28-ndk-r17b
-  working_directory: ~/litho-working-dir
-  environment:
-    # Borrowed from https://github.com/chrisbanes/tivi/blob/master/.circleci/config.yml
-    # Sometimes gradle_tests_run job would fail with OOM error from CI. This is an attempt to fix it!
-    _JAVA_OPTIONS: "-Xmx1500m -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -XX:ParallelGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2"
-    TERM: 'dumb'
-    ANDROID_NDK_REPOSITORY: '/opt/ndk'
-    ANDROID_NDK_HOME: '/opt/ndk/android-ndk-r15c/'
+executors:
+  litho_executor:
+    docker:
+      - image: circleci/android:api-28-ndk-r17b
+    working_directory: ~/litho-working-dir
+    environment:
+      # Borrowed from https://github.com/chrisbanes/tivi/blob/master/.circleci/config.yml
+      # Sometimes gradle_tests_run job would fail with OOM error from CI. This is an attempt to fix it!
+      _JAVA_OPTIONS: "-Xmx1500m -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -XX:ParallelGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2"
+      TERM: 'dumb'
+      ANDROID_NDK_REPOSITORY: '/opt/ndk'
+      ANDROID_NDK_HOME: '/opt/ndk/android-ndk-r15c/'
 
 attach_workspace: &attach_workspace
   attach_workspace:
@@ -152,7 +153,7 @@ store_litho_artifacts: &store_litho_artifacts
 
 jobs:
   checkout_code:
-    <<: *circle_ci_android_container_config
+    executor: litho_executor
     steps:
       # Create folders needed
       - run: mkdir -p workspace
@@ -190,7 +191,7 @@ jobs:
             - repo
 
   build:
-    <<: *circle_ci_android_container_config
+    executor: litho_executor
     steps:
       - *attach_workspace
       - run: *create-android-ndk-dir
@@ -204,7 +205,7 @@ jobs:
       - save_cache: *save-repo-cache
 
   buck_sample_build:
-    <<: *circle_ci_android_container_config
+    executor: litho_executor
     steps:
       - *attach_workspace
       - run: *create-android-ndk-dir
@@ -221,7 +222,7 @@ jobs:
             buck build sample --num-threads=4
 
   buck_sample_barebones_build:
-    <<: *circle_ci_android_container_config
+    executor: litho_executor
     steps:
       - *attach_workspace
       - run: *create-android-ndk-dir
@@ -238,7 +239,7 @@ jobs:
             buck build sample-barebones --num-threads=4
 
   buck_sample_codelab_build:
-    <<: *circle_ci_android_container_config
+    executor: litho_executor
     steps:
       - *attach_workspace
       - run: *create-android-ndk-dir
@@ -255,7 +256,7 @@ jobs:
             buck build sample-codelab --num-threads=4
 
   gradle_sample_kotlin_build:
-    <<: *circle_ci_android_container_config
+    executor: litho_executor
     steps:
       - *attach_workspace
       - run: *create-android-ndk-dir
@@ -271,7 +272,7 @@ jobs:
             ./gradlew :sample-kotlin:assembleDebug --no-daemon --max-workers 2
 
   buck_litho_it_tests_run:
-    <<: *circle_ci_android_container_config
+    executor: litho_executor
     steps:
       - *attach_workspace
       - run: *create-android-ndk-dir
@@ -291,7 +292,7 @@ jobs:
       - *store_litho_artifacts
 
   buck_litho_it_powermock_tests_run:
-    <<: *circle_ci_android_container_config
+    executor: litho_executor
     steps:
       - *attach_workspace
       - run: *create-android-ndk-dir
@@ -311,7 +312,7 @@ jobs:
       - *store_litho_artifacts
 
   gradle_tests_run:
-    <<: *circle_ci_android_container_config
+    executor: litho_executor
     steps:
       - *attach_workspace
       - run: *create-android-ndk-dir
@@ -330,7 +331,7 @@ jobs:
       - *store_litho_artifacts
 
   publish_snapshot:
-    <<: *circle_ci_android_container_config
+    executor: litho_executor
     steps:
       - *attach_workspace
       - run: *create-android-ndk-dir

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 2.1
 aliases:
   # NDK Cache aliases
   - &restore-cache-ndk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ store_litho_artifacts: &store_litho_artifacts
     path: ~/litho-working-dir/workspace/junit
 
 executors:
-  litho_executor:
+  litho-executor:
     docker:
       - image: circleci/android:api-28-ndk-r17b
     working_directory: ~/litho-working-dir
@@ -209,7 +209,7 @@ commands:
 
 jobs:
   checkout_code:
-    executor: litho_executor
+    executor: litho-executor
     steps:
       # Create folders needed
       - run: mkdir -p workspace
@@ -247,7 +247,7 @@ jobs:
             - repo
 
   build:
-    executor: litho_executor
+    executor: litho-executor
     steps:
       - attach_restore_setup_buck
       - run: *download-buck-dependencies
@@ -255,43 +255,43 @@ jobs:
       - save_cache: *save-repo-cache
 
   buck_sample_build:
-    executor: litho_executor
+    executor: litho-executor
     steps:
       - buck_build:
           module_name: "sample"
 
   buck_sample_barebones_build:
-    executor: litho_executor
+    executor: litho-executor
     steps:
       - buck_build:
           module_name: "sample-barebones"
 
   buck_sample_codelab_build:
-    executor: litho_executor
+    executor: litho-executor
     steps:
       - buck_build:
           module_name: "sample-codelab"
 
   gradle_sample_kotlin_build:
-    executor: litho_executor
+    executor: litho-executor
     steps:
       - gradle_build:
           module_name: "sample-kotlin"
   
   buck_litho_it_tests_run:
-    executor: litho_executor
+    executor: litho-executor
     steps:
       - buck_tests:
           module_name: "litho-it"
 
   buck_litho_it_powermock_tests_run:
-    executor: litho_executor
+    executor: litho-executor
     steps:
       - buck_tests:
           module_name: "litho-it-powermock"
 
   gradle_tests_run:
-    executor: litho_executor
+    executor: litho-executor
     steps:
       - attach_restore_setup_buck
       - run:
@@ -304,7 +304,7 @@ jobs:
       - *store_litho_artifacts
 
   publish_snapshot:
-    executor: litho_executor
+    executor: litho-executor
     steps:
       - attach_restore_setup_buck
       - run: *setup-keys

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,10 +157,10 @@ commands:
     steps:
       - *attach_workspace
       - run: *create-android-ndk-dir
-      - restore-cache: *restore-cache-ndk
-      - restore-cache: *restore-cache-buck
-      - restore-cache: *restore-repo-cache
-      - restore-cache: *restore-cache-android-packages
+      - restore_cache: *restore-cache-ndk
+      - restore_cache: *restore-cache-buck
+      - restore_cache: *restore-repo-cache
+      - restore_cache: *restore-cache-android-packages
       - run: *setup-buck
 
   buck_build:
@@ -221,24 +221,24 @@ jobs:
 
       # Manage Android NDK caches
       - run: *create-android-ndk-dir
-      - restore-cache: *restore-cache-ndk
+      - restore_cache: *restore-cache-ndk
       - run: *install-ndk
-      - save-cache: *save-cache-ndk
+      - save_cache: *save-cache-ndk
 
       # Manage Android build depencies caches
-      - restore-cache: *restore-cache-apt
+      - restore_cache: *restore-cache-apt
       - run: *install-android-build-dependencies
-      - save-cache: *save-cache-apt
+      - save_cache: *save-cache-apt
 
       # Manage Android SDK caches
-      - restore-cache: *restore-cache-android-packages
+      - restore_cache: *restore-cache-android-packages
       - run: *install-android-packages
-      - save-cache: *save-cache-android-packages
+      - save_cache: *save-cache-android-packages
 
       # Manage BUCK caches
-      - restore-cache: *restore-cache-buck
+      - restore_cache: *restore-cache-buck
       - run: *download-buck
-      - save-cache: *save-cache-buck
+      - save_cache: *save-cache-buck
 
       # Persist repo code
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ aliases:
       cd workspace
       mkdir -p junit
       cd repo
-      find . -type f -name "litho_it_*tests*.xml" -exec cp {} ~/litho-working-dir/workspace/junit/ \;
+      find . -type f -name "litho-it*tests*.xml" -exec cp {} ~/litho-working-dir/workspace/junit/ \;
     when: always
 
   # Save Litho Gradle test results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,6 +126,18 @@ aliases:
       find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/litho-working-dir/workspace/junit/ \;
     when: always
 
+attach_workspace: &attach_workspace
+  attach_workspace:
+    at: ~/litho-working-dir/workspace
+
+store_litho_tests_results: &store_litho_tests_results
+  store_test_results:
+    path: ~/litho-working-dir/workspace/junit
+
+store_litho_artifacts: &store_litho_artifacts
+  store_artifacts:
+    path: ~/litho-working-dir/workspace/junit
+
 executors:
   litho_executor:
     docker:
@@ -139,17 +151,61 @@ executors:
       ANDROID_NDK_REPOSITORY: '/opt/ndk'
       ANDROID_NDK_HOME: '/opt/ndk/android-ndk-r15c/'
 
-attach_workspace: &attach_workspace
-  attach_workspace:
-    at: ~/litho-working-dir/workspace
+commands:
+  attach_restore_setup_buck:
+    description: "A command that attaches to workspace, restores caches and setups BUCK"
+    steps:
+      - *attach_workspace
+      - run: *create-android-ndk-dir
+      - restore-cache: *restore-cache-ndk
+      - restore-cache: *restore-cache-buck
+      - restore-cache: *restore-repo-cache
+      - restore-cache: *restore-cache-android-packages
+      - run: *setup-buck
 
-store_litho_tests_results: &store_litho_tests_results
-  store_test_results:
-    path: ~/litho-working-dir/workspace/junit
+  buck_build:
+    description: "A command that uses BUCK for builds"
+    parameters:
+      module_name:
+        type: string
+    steps:
+      - attach_restore_setup_buck
+      - run:
+          name: Build <<parameters.module_name>> with BUCK
+          command: |
+            cd workspace/repo
+            buck fetch //...
+            buck build <<parameters.module_name>> --num-threads=4
+  
+  gradle_build:
+    description: "A command that uses Gradle for builds"
+    parameters:
+      module_name:
+        type: string
+    steps:
+      - attach_restore_setup_buck
+      - run:
+          name: Build <<parameters.module_name>> with Gradle
+          command: |
+            cd workspace/repo
+            ./gradlew :<<parameters.module_name>>:assembleDebug --no-daemon --max-workers 2
 
-store_litho_artifacts: &store_litho_artifacts
-  store_artifacts:
-    path: ~/litho-working-dir/workspace/junit
+  buck_tests:
+    description: "A command that runs tests using BUCK"
+    parameters:
+      module_name:
+        type: string
+    steps:
+      - attach_restore_setup_buck
+      - run:
+          name: Run <<parameters.module_name>> tests with BUCK
+          command: |
+            cd workspace/repo
+            buck fetch //...
+            buck test <<parameters.module_name>>/src/test/... --num-threads=4 --xml <<parameters.module_name>>_tests.xml
+      - run: *save-litho-buck-tests-results
+      - *store_litho_tests_results
+      - *store_litho_artifacts
 
 jobs:
   checkout_code:
@@ -193,13 +249,7 @@ jobs:
   build:
     executor: litho_executor
     steps:
-      - *attach_workspace
-      - run: *create-android-ndk-dir
-      - restore-cache: *restore-cache-ndk
-      - restore-cache: *restore-cache-buck
-      - restore_cache: *restore-repo-cache
-      - restore-cache: *restore-cache-android-packages
-      - run: *setup-buck
+      - attach_restore_setup_buck
       - run: *download-buck-dependencies
       - run: *download-gradle-dependencies
       - save_cache: *save-repo-cache
@@ -207,120 +257,43 @@ jobs:
   buck_sample_build:
     executor: litho_executor
     steps:
-      - *attach_workspace
-      - run: *create-android-ndk-dir
-      - restore_cache: *restore-repo-cache
-      - restore-cache: *restore-cache-ndk
-      - restore-cache: *restore-cache-buck
-      - restore-cache: *restore-cache-android-packages
-      - run: *setup-buck
-      - run:
-          name: Build sample with BUCK
-          command: |
-            cd workspace/repo
-            buck fetch //...
-            buck build sample --num-threads=4
+      - buck_build:
+          module_name: "sample"
 
   buck_sample_barebones_build:
     executor: litho_executor
     steps:
-      - *attach_workspace
-      - run: *create-android-ndk-dir
-      - restore_cache: *restore-repo-cache
-      - restore-cache: *restore-cache-ndk
-      - restore-cache: *restore-cache-buck
-      - restore-cache: *restore-cache-android-packages
-      - run: *setup-buck
-      - run:
-          name: Build sample-barebones with BUCK
-          command: |
-            cd workspace/repo
-            buck fetch //...
-            buck build sample-barebones --num-threads=4
+      - buck_build:
+          module_name: "sample-barebones"
 
   buck_sample_codelab_build:
     executor: litho_executor
     steps:
-      - *attach_workspace
-      - run: *create-android-ndk-dir
-      - restore_cache: *restore-repo-cache
-      - restore-cache: *restore-cache-ndk
-      - restore-cache: *restore-cache-buck
-      - restore-cache: *restore-cache-android-packages
-      - run: *setup-buck
-      - run:
-          name: Build sample-codelab with BUCK
-          command: |
-            cd workspace/repo
-            buck fetch //...
-            buck build sample-codelab --num-threads=4
+      - buck_build:
+          module_name: "sample-codelab"
 
   gradle_sample_kotlin_build:
     executor: litho_executor
     steps:
-      - *attach_workspace
-      - run: *create-android-ndk-dir
-      - restore_cache: *restore-repo-cache
-      - restore-cache: *restore-cache-ndk
-      - restore-cache: *restore-cache-buck
-      - restore-cache: *restore-cache-android-packages
-      - run: *setup-buck
-      - run:
-          name: Build sample-kotlin with Gradle
-          command: |
-            cd workspace/repo
-            ./gradlew :sample-kotlin:assembleDebug --no-daemon --max-workers 2
-
+      - gradle_build:
+          module_name: "sample-kotlin"
+  
   buck_litho_it_tests_run:
     executor: litho_executor
     steps:
-      - *attach_workspace
-      - run: *create-android-ndk-dir
-      - restore_cache: *restore-repo-cache
-      - restore-cache: *restore-cache-ndk
-      - restore-cache: *restore-cache-buck
-      - restore-cache: *restore-cache-android-packages
-      - run: *setup-buck
-      - run:
-          name: Run litho-it tests with BUCK
-          command: |
-            cd workspace/repo
-            buck fetch //...
-            buck test litho-it/src/test/... --num-threads=4 --xml litho_it_tests.xml
-      - run: *save-litho-buck-tests-results
-      - *store_litho_tests_results
-      - *store_litho_artifacts
+      - buck_tests:
+          module_name: "litho-it"
 
   buck_litho_it_powermock_tests_run:
     executor: litho_executor
     steps:
-      - *attach_workspace
-      - run: *create-android-ndk-dir
-      - restore_cache: *restore-repo-cache
-      - restore-cache: *restore-cache-ndk
-      - restore-cache: *restore-cache-buck
-      - restore-cache: *restore-cache-android-packages
-      - run: *setup-buck
-      - run:
-          name: Run lith-it-powermock tests with BUCK
-          command: |
-            cd workspace/repo
-            buck fetch //...
-            buck test litho-it-powermock/src/test/... --num-threads=4 --xml litho_it_powermock_tests.xml
-      - run: *save-litho-buck-tests-results
-      - *store_litho_tests_results
-      - *store_litho_artifacts
+      - buck_tests:
+          module_name: "litho-it-powermock"
 
   gradle_tests_run:
     executor: litho_executor
     steps:
-      - *attach_workspace
-      - run: *create-android-ndk-dir
-      - restore_cache: *restore-repo-cache
-      - restore-cache: *restore-cache-ndk
-      - restore-cache: *restore-cache-buck
-      - restore-cache: *restore-cache-android-packages
-      - run: *setup-buck
+      - attach_restore_setup_buck
       - run:
           name: Run tests with Gradle
           command: |
@@ -333,14 +306,8 @@ jobs:
   publish_snapshot:
     executor: litho_executor
     steps:
-      - *attach_workspace
-      - run: *create-android-ndk-dir
-      - restore_cache: *restore-repo-cache
-      - restore-cache: *restore-cache-ndk
-      - restore-cache: *restore-cache-buck
-      - restore-cache: *restore-cache-android-packages
+      - attach_restore_setup_buck
       - run: *setup-keys
-      - run: *setup-buck
       - run:
           name: Publish Snapshot
           command: |


### PR DESCRIPTION
Hey all 😄 In light of Hacktoberfest and recent CircleCI updates here is a PR to review at your disposal :)

### What this PR includes

* Updates CircleCI config to 2.1
* Fixes several issues in CircleCI current configuration

### What is needed for this PR to be merged

* The owner of the project needs to follow some simple steps in order to enable `Build processing` feature needed for config 2.1. Go to CircleCI website -> Project: `litho` -> Click on settings icon -> `Advanced Settings` -> Scroll to bottom -> Toggle `Enable build processing` to `on`. 

* Until the above is enabled the build will fail :/ The file itself is validated using `circleci config validate .circleci/config.yml` and you can find an execution using the new configuration here: https://circleci.com/workflow-run/c51dad46-9606-4001-9077-0eecc112bf89

### CircleCI config 2.1 

CircleCI config 2.1 introduces a more formal way of re-using several parts in the project's configuration, such as executors & commands. This lets us minimize the bloat of the config by re-using commands (with params when needed). More on this can be found here: https://circleci.com/docs/2.0/reusing-config/
