### PR TITLE
Update Yoga SNAPSHOT version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ ext.deps = [
 // For releases, we want to depend on a stable version of Yoga.
 ext.deps.yoga =
     isSnapshot()
-        ? 'com.facebook.yoga:yoga:1.10.1-SNAPSHOT'
+        ? 'com.facebook.yoga:yoga:1.10.0-SNAPSHOT'
         : 'com.facebook.yoga:yoga:1.10.0'
 
 // This should hopefully only serve as a temporary measure until


### PR DESCRIPTION
Yoga has only released a 1.10.0-SNAPSHOT version and not a 1.10.1, which breaks the `Publish snapshot` job of the CircleCI workflow.

https://oss.sonatype.org/content/repositories/snapshots/com/facebook/yoga/yoga/