### PR TITLE
Upgrade Gradle plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,20 +3,20 @@ aliases:
   # NDK Cache aliases
   - &restore-cache-ndk
     keys:
-      - v2-android-ndk-{{ arch }}-r15c-{{ checksum "workspace/repo/scripts/circle-ci-android-setup.sh" }}
+      - v3-android-ndk-{{ arch }}-r15c-{{ checksum "workspace/repo/scripts/circle-ci-android-setup.sh" }}
   - &save-cache-ndk
     paths:
       - /opt/ndk
-    key: v2-android-ndk-{{ arch }}-r15c-{{ checksum "workspace/repo/scripts/circle-ci-android-setup.sh" }}
+    key: v3-android-ndk-{{ arch }}-r15c-{{ checksum "workspace/repo/scripts/circle-ci-android-setup.sh" }}
 
   # SDK Cache aliases
   - &restore-cache-android-packages
     keys:
-      - v5-android-sdkmanager-packages-{{ arch }}-api-27-alpha-{{ checksum "workspace/repo/scripts/circle-ci-android-setup.sh" }}
+      - v6-android-sdkmanager-packages-{{ arch }}-api-27-alpha-{{ checksum "workspace/repo/scripts/circle-ci-android-setup.sh" }}
   - &save-cache-android-packages
     paths:
       - /opt/android/sdk
-    key: v5-android-sdkmanager-packages-{{ arch }}-api-27-alpha-{{ checksum "workspace/repo/scripts/circle-ci-android-setup.sh" }}
+    key: v6-android-sdkmanager-packages-{{ arch }}-api-27-alpha-{{ checksum "workspace/repo/scripts/circle-ci-android-setup.sh" }}
 
   # BUCK Cache aliases
   - &restore-cache-buck

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:${GRADLE_BINTRAY_PLUGIN_VERSION}"
         classpath "com.github.dcendents:android-maven-gradle-plugin:${ANDROID_MAVEN_GRADLE_PLUGIN_VERSION}"
         classpath "com.github.ben-manes:gradle-versions-plugin:${GRADLE_VERSIONS_PLUGIN_VERSION}"
@@ -39,7 +39,7 @@ ext {
     minSdkVersion = 15
     targetSdkVersion = 25
     compileSdkVersion = 26
-    buildToolsVersion = '27.0.3'
+    buildToolsVersion = '28.0.3'
     sourceCompatibilityVersion = JavaVersion.VERSION_1_7
     targetCompatibilityVersion = JavaVersion.VERSION_1_7
 }

--- a/lib/yogajni/build.gradle
+++ b/lib/yogajni/build.gradle
@@ -14,7 +14,7 @@ android {
 
         externalNativeBuild {
             cmake {
-                arguments '-DANDROID_TOOLCHAIN=clang', '-DANDROID_STL=gnustl_shared'
+                arguments '-DANDROID_TOOLCHAIN=clang'
             }
         }
     }

--- a/scripts/circle-ci-android-setup.sh
+++ b/scripts/circle-ci-android-setup.sh
@@ -41,7 +41,7 @@ function getAndroidNDK {
     cd $NDK_HOME
     echo "Downloading NDK..."
     TMP=/tmp/ndk$$.zip
-    download https://dl.google.com/android/repository/android-ndk-r15c-linux-x86_64.zip "$TMP"
+    download https://dl.google.com/android/repository/android-ndk-r18b-linux-x86_64.zip "$TMP"
     unzip -qo "$TMP"
     echo "Installed Android NDK at $NDK_HOME"
     touch $DEPS


### PR DESCRIPTION
Summary:
This brings a new build tools requirements and NDK with it.
The `gnustl_shared` version is also no longer supported, but that
only matters for debug builds anyway.

Test Plan:
```
./gradlew :sample:installDebug
```

Also, let's see first if Circle is okay with this.