### PR TITLE
Add a replaceAll(List<RenderInfo>) method to RecyclerBinder.

### DIFF
--- a/litho-widget/src/main/java/com/facebook/litho/widget/RecyclerBinder.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/RecyclerBinder.java
@@ -1123,6 +1123,25 @@ public class RecyclerBinder
   }
 
   /**
+   * Replaces all items in the {@link RecyclerBinder} with the provided {@link RenderInfo}s.
+   */
+  @UiThread
+  public final void replaceAll(List<RenderInfo> renderInfos) {
+    synchronized (this) {
+      if (mHasAsyncOperations) {
+        throw new RuntimeException(
+            "Trying to do a sync replaceAll when using asynchronous mutations!");
+      }
+      mComponentTreeHolders.clear();
+      for (RenderInfo renderInfo : renderInfos) {
+        mComponentTreeHolders.add(createComponentTreeHolder(renderInfo));
+      }
+    }
+    mInternalAdapter.notifyDataSetChanged();
+    mViewportManager.setShouldUpdate(true);
+  }
+
+  /**
    * See {@link RecyclerBinder#appendItem(RenderInfo)}.
    */
   @UiThread


### PR DESCRIPTION
For compatibility reasons, there's currently no way to hook up
RecyclerView.notifyDatasetChanged() calls to RecyclerBinder without
potentially triggering transition animations. This opens up an API to
support the equivalent of replacing all the items in a RecyclerBinder
and calling notifyDatasetChanged().