### PR TITLE
Change LayoutStateFuture to be NonNull

### DIFF
--- a/litho-it/src/test/java/com/facebook/litho/ComponentTreeTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/ComponentTreeTest.java
@@ -22,6 +22,7 @@ import static com.facebook.litho.SizeSpec.EXACTLY;
 import static com.facebook.litho.SizeSpec.makeSizeSpec;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.junit.Assert.assertNotEquals;
@@ -653,18 +654,16 @@ public class ComponentTreeTest {
       e.printStackTrace();
     }
 
-    assertEquals(1, componentTree.getLayoutStateFutures().size());
-    ComponentTree.LayoutStateFuture layoutStateFuture =
-        componentTree.getLayoutStateFutures().get(0);
+    ComponentTree.LayoutStateFuture layoutStateFuture = componentTree.getLayoutStateFuture();
+    assertNotNull(layoutStateFuture);
 
     handler.post(
         new Runnable() {
           @Override
           public void run() {
-            assertEquals(1, layoutStateFuture.getWaitingCount());
+            assertEquals(componentTree.getLayoutStateFuture(), layoutStateFuture);
             layoutStateFuture.runAndGet();
-            assertEquals(0, layoutStateFuture.getWaitingCount());
-            assertEquals(0, componentTree.getLayoutStateFutures().size());
+            assertEquals(componentTree.getLayoutStateFuture(), layoutStateFuture);
           }
         });
   }
@@ -707,7 +706,7 @@ public class ComponentTreeTest {
       e.printStackTrace();
     }
 
-    assertEquals(1, componentTree.getLayoutStateFutures().size());
+    assertNotNull(componentTree.getLayoutStateFuture());
 
     Thread thread =
         new Thread(
@@ -778,7 +777,7 @@ public class ComponentTreeTest {
       e.printStackTrace();
     }
 
-    assertEquals(1, componentTree.getLayoutStateFutures().size());
+    assertNotNull(componentTree.getLayoutStateFuture());
 
     Thread thread =
         new Thread(


### PR DESCRIPTION
This adds a refCount to the LayoutStateFuture, allowing us to guarantee always returning an unreleased LayoutState.

I tried to update/run tests but (#458):
1. robolectric needs to be updated so Looper.getMainLooper() doesn't NPE
2. the tests won't actually fail if the background thread assertions fail