### PR TITLE
Upgrade Roboletric

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ ext.deps = [
         inferAnnotations   : 'com.facebook.infer.annotation:infer-annotation:0.11.2',
         // Debugging and testing
         guava              : 'com.google.guava:guava:20.0',
-        robolectric        : 'org.robolectric:robolectric:3.0',
+        robolectric        : 'org.robolectric:robolectric:3.3',
         junit              : 'junit:junit:4.12',
         hamcrestLibrary    : 'org.hamcrest:hamcrest-library:1.3',
         powermockReflect   : 'org.powermock:powermock-reflect:1.5.6',

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ ext.deps = [
         inferAnnotations   : 'com.facebook.infer.annotation:infer-annotation:0.11.2',
         // Debugging and testing
         guava              : 'com.google.guava:guava:20.0',
-        robolectric        : 'org.robolectric:robolectric:3.3',
+        robolectric        : 'org.robolectric:robolectric:3.8',
         junit              : 'junit:junit:4.12',
         hamcrestLibrary    : 'org.hamcrest:hamcrest-library:1.3',
         powermockReflect   : 'org.powermock:powermock-reflect:1.5.6',

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ subprojects {
 ext {
     minSdkVersion = 15
     targetSdkVersion = 25
-    compileSdkVersion = 26
+    compileSdkVersion = 28
     buildToolsVersion = '27.0.3'
     sourceCompatibilityVersion = JavaVersion.VERSION_1_7
     targetCompatibilityVersion = JavaVersion.VERSION_1_7
@@ -71,7 +71,7 @@ ext.deps = [
         inferAnnotations   : 'com.facebook.infer.annotation:infer-annotation:0.11.2',
         // Debugging and testing
         guava              : 'com.google.guava:guava:20.0',
-        robolectric        : 'org.robolectric:robolectric:3.8',
+        robolectric        : 'org.robolectric:robolectric:4.0.1',
         junit              : 'junit:junit:4.12',
         hamcrestLibrary    : 'org.hamcrest:hamcrest-library:1.3',
         powermockReflect   : 'org.powermock:powermock-reflect:1.5.6',

--- a/litho-it/src/test/java/com/facebook/litho/ComponentsPoolsTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/ComponentsPoolsTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.util.ActivityController;
+import org.robolectric.android.controller.ActivityController;
 
 @RunWith(ComponentsTestRunner.class)
 public class ComponentsPoolsTest {

--- a/litho-testing/src/main/java/com/facebook/litho/testing/shadows/ColorDrawableShadow.java
+++ b/litho-testing/src/main/java/com/facebook/litho/testing/shadows/ColorDrawableShadow.java
@@ -16,7 +16,7 @@
 
 package com.facebook.litho.testing.shadows;
 
-import static org.robolectric.internal.Shadow.directlyOn;
+import static org.robolectric.shadow.api.Shadow.directlyOn;
 
 import android.graphics.Canvas;
 import android.graphics.ColorFilter;

--- a/litho-testing/src/main/java/com/facebook/litho/testing/testrunner/ComponentsTestRunner.java
+++ b/litho-testing/src/main/java/com/facebook/litho/testing/testrunner/ComponentsTestRunner.java
@@ -77,16 +77,22 @@ public class ComponentsTestRunner extends RobolectricTestRunner {
     final Config config = super.getConfig(method);
     // We are hard-coding the path here instead of relying on BUCK internals
     // to allow for building with gradle in the Open Source version.
-    return new Config.Implementation(config, new Config.Implementation(
-        new int[]{},
+    return new Config.Implementation(
+        config.sdk(),
+        config.minSdk(),
+        config.maxSdk(),
         getResPrefix() + "AndroidManifest.xml",
         "",
         "",
+        config.abiSplit(),
         "res",
         "assets",
+        config.buildDir(),
         new Class[]{},
+        config.instrumentedPackages(),
         Application.class,
         new String[0],
-        null));
+        null
+    );
   }
 }

--- a/litho-testing/src/main/java/com/facebook/litho/testing/testrunner/ComponentsTestRunner.java
+++ b/litho-testing/src/main/java/com/facebook/litho/testing/testrunner/ComponentsTestRunner.java
@@ -84,15 +84,12 @@ public class ComponentsTestRunner extends RobolectricTestRunner {
         getResPrefix() + "AndroidManifest.xml",
         "",
         "",
-        config.abiSplit(),
         "res",
         "assets",
-        config.buildDir(),
         new Class[]{},
         config.instrumentedPackages(),
         Application.class,
-        new String[0],
-        null
+        new String[0]
     );
   }
 }


### PR DESCRIPTION
There are 3 commits that upgrade robolectric to higher and higher versions depending on what is possible.

At minimum we should upgrade to 3.3 to deal with `ShadowLooper.getMainLooper()` (https://github.com/robolectric/robolectric/issues/2876) but there are no code changes between 3.8 and 3.8, so we could just go directly to 3.8.

There are also minimal changes to go directly to 4.0.1 too.