### PR TITLE
Allow for lazy RenderInfos

### DIFF
--- a/litho-widget/src/main/java/com/facebook/litho/widget/BaseRenderInfo.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/BaseRenderInfo.java
@@ -116,6 +116,11 @@ public abstract class BaseRenderInfo implements RenderInfo {
     throw new UnsupportedOperationException();
   }
 
+  @Override
+  public boolean isLazy() {
+    return false;
+  }
+
   /**
    * @return true, if {@link RenderInfo} was created through {@link ViewRenderInfo#create()}, or
    *     false otherwise. This should be queried before accessing view related methods, such as

--- a/litho-widget/src/main/java/com/facebook/litho/widget/RenderInfo.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/RenderInfo.java
@@ -43,6 +43,8 @@ public interface RenderInfo {
   @Nullable
   EventHandler<RenderCompleteEvent> getRenderCompleteEventHandler();
 
+  boolean isLazy();
+
   boolean rendersView();
 
   ViewBinder getViewBinder();

--- a/litho-widget/src/main/java/com/facebook/litho/widget/RenderInfoViewCreatorController.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/RenderInfoViewCreatorController.java
@@ -46,7 +46,7 @@ public class RenderInfoViewCreatorController {
 
   @UiThread
   public void maybeTrackViewCreator(RenderInfo renderInfo) {
-    if (!renderInfo.rendersView()) {
+    if (renderInfo.isLazy() || !renderInfo.rendersView()) {
       return;
     }
 

--- a/litho-widget/src/main/java/com/facebook/litho/widget/TreePropsWrappedRenderInfo.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/TreePropsWrappedRenderInfo.java
@@ -49,6 +49,11 @@ public class TreePropsWrappedRenderInfo implements RenderInfo {
   }
 
   @Override
+  public boolean isLazy() {
+    return false;
+  }
+
+  @Override
   public boolean rendersComponent() {
     return mRenderInfo.rendersComponent();
   }


### PR DESCRIPTION
This allows for advanced integrations to have custom implementations of `RenderInfo` that lazily compute `rendersComponent()` `getComponent()` and `rendersView()` internally without needing to create all the `Component`s, `ViewCreator`s, and `ViewBinder`s ahead of time.

This *should* work, but may be incomplete since we're hardcoding `initRange` ourselves, and also an AdapterProxy that I have yet to submit a PR for... I'm mostly submitting this so upstream changes don't diverge too much from our branch, as you can imagine this lazy behavior is somewhat fragile.

The main change is in the logic in `computeRangeLayoutAt`, which had some tricky synchronization to work around.

I'll see if I can come up with some way to test this to make sure the default implementation doesn't regress.