### PR TITLE
Pin cmake version

### DIFF
--- a/lib/yogajni/build.gradle
+++ b/lib/yogajni/build.gradle
@@ -22,6 +22,7 @@ android {
     externalNativeBuild {
         cmake {
             path 'src/main/cpp/CMakeLists.txt'
+            version '3.6.0-rc2'
         }
     }
 

--- a/scripts/circle-ci-android-setup.sh
+++ b/scripts/circle-ci-android-setup.sh
@@ -56,5 +56,5 @@ function installAndroidSDK {
   echo > "$ANDROID_HOME/licenses/android-sdk-license"
   echo -n d56f5187479451eabf01fb78af6dfcb131a6481e > "$ANDROID_HOME/licenses/android-sdk-license"
 
-  installsdk 'platforms;android-28'
+  installsdk 'platforms;android-28' 'cmake;3.6.4111459'
 }


### PR DESCRIPTION
Summary:
The cmake version appears to be the culprit. Not sure where the 3.10 release comes from on the Circle instance. Will try deleting it if this doesn't suffice.

Test Plan:
Circle on CI in https://github.com/facebook/litho/pull/475 is green except for flaky layout tests. :/