### PR TITLE
[gradle] Add retries with backoff for HTTP downloads

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -35,3 +35,7 @@ KOTLIN_VERSION=1.3.11
 # Deps for publishing
 GRADLE_BINTRAY_PLUGIN_VERSION=1.8.0
 ANDROID_MAVEN_GRADLE_PLUGIN_VERSION=2.1
+
+# Gradle internals
+org.gradle.internal.repository.max.retries=10
+org.gradle.internal.repository.initial.backoff=1250

--- a/scripts/circle-ci-android-setup.sh
+++ b/scripts/circle-ci-android-setup.sh
@@ -54,7 +54,7 @@ function installAndroidSDK {
 
   mkdir -p "$ANDROID_HOME/licenses/"
   echo > "$ANDROID_HOME/licenses/android-sdk-license"
-  echo -n d56f5187479451eabf01fb78af6dfcb131a6481e > "$ANDROID_HOME/licenses/android-sdk-license"
+  echo -n 24333f8a63b6825ea9c5514f83c2829b004d1fee > "$ANDROID_HOME/licenses/android-sdk-license"
 
   installsdk 'platforms;android-28' 'cmake;3.6.4111459'
 }


### PR DESCRIPTION
Summary:
Gradle 5 has some neat new features that allow for automatic retries if
an HTTP download fails. Not that this would ever happen on our infra
*caugh* *caugh*. We've been using this on the Flipper side for a while
and it helps a lot with flakiness.

Test Plan:
./gradlew :litho-it:testDUT