### PR TITLE
Expose incremental mount option in RecyclerBinder configuration builder

### DIFF
--- a/litho-it/src/test/java/com/facebook/litho/widget/RecyclerBinderTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/widget/RecyclerBinderTest.java
@@ -159,6 +159,7 @@ public class RecyclerBinderTest {
               RenderInfo renderInfo,
               LayoutHandler layoutHandler,
               boolean useSharedLayoutStateFuture,
+              boolean useIncrementalMount,
               ComponentTreeMeasureListenerFactory componentTreeMeasureListenerFactory,
               String splitLayoutTag) {
             final TestComponentTreeHolder holder = new TestComponentTreeHolder(renderInfo);

--- a/litho-widget/src/main/java/com/facebook/litho/widget/ComponentTreeHolder.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/ComponentTreeHolder.java
@@ -30,7 +30,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
-import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * A class used to store the data backing a {@link RecyclerBinder}. For each item the
@@ -86,6 +85,7 @@ public class ComponentTreeHolder {
   private boolean mCanPreallocateOnDefaultHandler;
   private boolean mShouldPreallocatePerMountSpec;
   private boolean mUseSharedLayoutStateFuture;
+  private boolean mUseIncrementalMount;
   private String mSplitLayoutTag;
   private boolean mIsInserted = true;
   private boolean mHasMounted = false;
@@ -108,6 +108,7 @@ public class ComponentTreeHolder {
     private boolean canPreallocateOnDefaultHandler;
     private boolean shouldPreallocatePerMountSpec;
     private boolean useSharedLayoutStateFuture;
+    private boolean useIncrementalMount = true;
 
     private Builder() {}
 
@@ -153,6 +154,11 @@ public class ComponentTreeHolder {
       return this;
     }
 
+    public Builder useIncrementalMount(boolean useIncrementalMount) {
+      this.useIncrementalMount = useIncrementalMount;
+      return this;
+    }
+
     public ComponentTreeHolder build() {
       ensureMandatoryParams();
 
@@ -167,6 +173,7 @@ public class ComponentTreeHolder {
       componentTreeHolder.mCanPreallocateOnDefaultHandler = canPreallocateOnDefaultHandler;
       componentTreeHolder.mShouldPreallocatePerMountSpec = shouldPreallocatePerMountSpec;
       componentTreeHolder.mUseSharedLayoutStateFuture = useSharedLayoutStateFuture;
+      componentTreeHolder.mUseIncrementalMount = useIncrementalMount;
       componentTreeHolder.mComponentTreeMeasureListenerFactory =
           componentTreeMeasureListenerFactory;
       componentTreeHolder.mSplitLayoutTag = splitLayoutTag;
@@ -435,6 +442,7 @@ public class ComponentTreeHolder {
                       : mComponentTreeMeasureListenerFactory.create(this))
               .splitLayoutTag(mSplitLayoutTag)
               .hasMounted(mHasMounted)
+              .incrementalMount(mUseIncrementalMount)
               .build();
       if (mPendingNewLayoutListener != null) {
         mComponentTree.setNewLayoutStateReadyListener(mPendingNewLayoutListener);

--- a/litho-widget/src/main/java/com/facebook/litho/widget/ComponentTreeHolder.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/ComponentTreeHolder.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * A class used to store the data backing a {@link RecyclerBinder}. For each item the

--- a/litho-widget/src/main/java/com/facebook/litho/widget/RecyclerBinder.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/RecyclerBinder.java
@@ -250,6 +250,7 @@ public class RecyclerBinder
   private final boolean mUseSharedLayoutStateFuture;
   private final @Nullable LayoutHandler mThreadPoolHandler;
   private final @Nullable LayoutThreadPoolConfiguration mThreadPoolConfig;
+  private final boolean mUseIncrementalMount;
   private EventHandler<ReMeasureEvent> mReMeasureEventEventHandler;
   private volatile boolean mHasAsyncOperations = false;
   private boolean mIsInitMounted = false; // Set to true when the first mount() is called.
@@ -341,6 +342,7 @@ public class RecyclerBinder
         RenderInfo renderInfo,
         LayoutHandler layoutHandler,
         boolean useSharedLayoutStateFuture,
+        boolean useIncrementalMount,
         ComponentTreeMeasureListenerFactory measureListenerFactory,
         String splitLayoutTag);
   }
@@ -352,6 +354,7 @@ public class RecyclerBinder
             RenderInfo renderInfo,
             LayoutHandler layoutHandler,
             boolean useSharedLayoutStateFuture,
+            boolean useIncrementalMount,
             ComponentTreeMeasureListenerFactory measureListenerFactory,
             String splitLayoutTag) {
           return ComponentTreeHolder.create()
@@ -360,6 +363,7 @@ public class RecyclerBinder
               .useSharedLayoutStateFuture(useSharedLayoutStateFuture)
               .componentTreeMeasureListenerFactory(measureListenerFactory)
               .splitLayoutTag(splitLayoutTag)
+              .useIncrementalMount(useIncrementalMount)
               .build();
         }
       };
@@ -391,6 +395,7 @@ public class RecyclerBinder
     private boolean canMeasure;
     private boolean hscrollAsyncMode = false;
     private boolean singleThreadPool = ComponentsConfiguration.useSingleThreadPool;
+    private boolean useIncrementalMount = true;
 
     /**
      * @param rangeRatio specifies how big a range this binder should try to compute. The range is
@@ -597,6 +602,12 @@ public class RecyclerBinder
       return this;
     }
 
+    /** Toggle whether new ComponentTree instance will enable incremental mount or not */
+    public Builder useIncrementalMount(boolean useIncrementalMount) {
+      this.useIncrementalMount = useIncrementalMount;
+      return this;
+    }
+
     /** @param c The {@link ComponentContext} the RecyclerBinder will use. */
     public RecyclerBinder build(ComponentContext c) {
       componentContext =
@@ -750,6 +761,8 @@ public class RecyclerBinder
     mAsyncInitRange = builder.asyncInitRange;
     mBgScheduleAllInitRange = builder.bgScheduleAllInitRange;
     mHScrollAsyncMode = builder.hscrollAsyncMode;
+
+    mUseIncrementalMount = builder.useIncrementalMount;
   }
 
   /**
@@ -3122,6 +3135,7 @@ public class RecyclerBinder
         renderInfo,
         layoutHandler,
         mUseSharedLayoutStateFuture,
+        mUseIncrementalMount,
         mComponentTreeMeasureListenerFactory,
         mSplitLayoutTag);
   }


### PR DESCRIPTION
This allows a RecyclerBinder to be built with the flexibility of toggling incremental mount for its children Litho views.

We have encountered "animated parent view" bugs, which needed this option as a fix. When a Litho view is used as a child inside an animated parent view, the Litho view does not render properly and could show up as blank when incremental mount is enabled, because incremental mount doesn't get triggered during animation and the parent view does not propagate setHasTransientState(boolean) calls to the contained Litho view. When this happens, disabling incremental mount on the Litho view is a fix.

This works until a RecyclerCollectionComponent is used in the Litho view. As there is no way to disable incremental mount in the RecyclerCollectionComponent's underlying RecyclerBinder, the blank rendering bug would still manifest for children inside the RecyclerBinder.

With this change, we can disable incremental mount using RecyclerBinderConfiguration:

```
RecyclerCollectionComponent.create(c)
    .recyclerConfiguration(
        ListRecyclerConfiguration.create()
            .recyclerBinderConfiguration(
                RecyclerBinderConfiguration.create()
                    .useIncrementalMount(true/false)
                    .build())
            .build())
    .build()
```

cc @vinc3m1 