### PR TITLE
Add missing dependency to :litho-widget

### DIFF
--- a/litho-sections-debug/build.gradle
+++ b/litho-sections-debug/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     // Project dependencies
     implementation project(':litho-sections-core')
     implementation project(':litho-core')
+    implementation project(':litho-widget')
 
     // compileOnly dependencies
     compileOnly deps.jsr305


### PR DESCRIPTION
Summary:

Caused `:litho-sections-debug` to fail building.

Test Plan:

```
./gradlew :sample:assembleDebug
./gradlew :litho-it:testDebugUnitTest
```