### PR TITLE
Replace usages of Powermock in litho-testing with local replacement

### DIFF
--- a/litho-testing/src/main/java/com/facebook/litho/testing/Whitebox.java
+++ b/litho-testing/src/main/java/com/facebook/litho/testing/Whitebox.java
@@ -1,0 +1,108 @@
+package com.facebook.litho.testing;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+/** Internal copy of Whitebox implementation of Powermock. */
+public class Whitebox {
+
+  @SuppressWarnings("unchecked")
+  public static <T> T getInternalState(Object object, String fieldName) {
+    Field foundField = findFieldInHierarchy(object.getClass(), fieldName);
+    try {
+      return (T) foundField.get(object);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(
+          "Internal error: Failed to get field in method getInternalState.", e);
+    }
+  }
+
+  public static void setInternalState(Object object, String fieldName, Object value) {
+    Field foundField = findFieldInHierarchy(object.getClass(), fieldName);
+    try {
+      foundField.set(object, value);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(
+          "Internal error: Failed to get field in method getInternalState.", e);
+    }
+  }
+
+  private static Field findFieldInHierarchy(Class<?> startClass, String fieldName) {
+    Field foundField = null;
+    Class<?> currentClass = startClass;
+    while (currentClass != null) {
+      final Field[] declaredFields = currentClass.getDeclaredFields();
+
+      for (Field field : declaredFields) {
+        if (field.getName().equals(fieldName)) {
+          if (foundField != null) {
+            throw new IllegalArgumentException(
+                "Two or more fields matching " + fieldName + " in " + startClass + ".");
+          }
+
+          foundField = field;
+        }
+      }
+      if (foundField != null) {
+        break;
+      }
+      currentClass = currentClass.getSuperclass();
+    }
+    if (foundField == null) {
+      throw new IllegalArgumentException(
+          "No fields matching " + fieldName + " in " + startClass + ".");
+    }
+    foundField.setAccessible(true);
+    return foundField;
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <T> T invokeMethod(Object object, String methodName, Object... arguments) {
+    Method foundMethod = findMethodInHierarchy(object.getClass(), methodName);
+    try {
+      return (T) foundMethod.invoke(object, arguments);
+    } catch (Exception e) {
+      throw new RuntimeException("Internal error: Failed to invoked method.", e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <T> T invokeMethod(Class<?> clazz, String methodName, Object... arguments) {
+    Method foundMethod = findMethodInHierarchy(clazz, methodName);
+    try {
+      return (T) foundMethod.invoke(clazz, arguments);
+    } catch (Exception e) {
+      throw new RuntimeException("Internal error: Failed to invoked method.", e);
+    }
+  }
+
+  private static Method findMethodInHierarchy(Class<?> startClass, String methodName) {
+    Method foundMethod = null;
+    Class<?> currentClass = startClass;
+
+    while (currentClass != null) {
+      final Method[] declaredMethods = currentClass.getDeclaredMethods();
+
+      for (Method method : declaredMethods) {
+        if (method.getName().equals(methodName)) {
+          if (foundMethod != null) {
+            throw new IllegalArgumentException(
+                "Two or more methods matching " + methodName + " in " + startClass + ".");
+          }
+
+          foundMethod = method;
+        }
+      }
+      if (foundMethod != null) {
+        break;
+      }
+      currentClass = currentClass.getSuperclass();
+    }
+    if (foundMethod == null) {
+      throw new IllegalArgumentException(
+          "No methods matching " + methodName + " in " + startClass + ".");
+    }
+    foundMethod.setAccessible(true);
+    return foundMethod;
+  }
+}

--- a/litho-testing/src/main/java/com/facebook/litho/testing/assertj/ComponentAssert.java
+++ b/litho-testing/src/main/java/com/facebook/litho/testing/assertj/ComponentAssert.java
@@ -21,6 +21,7 @@ import android.support.annotation.DrawableRes;
 import com.facebook.litho.Component;
 import com.facebook.litho.ComponentContext;
 import com.facebook.litho.LithoView;
+import com.facebook.litho.testing.Whitebox;
 import com.facebook.litho.testing.helper.ComponentTestHelper;
 import com.facebook.litho.testing.state.StateUpdatesTestHelper;
 import com.facebook.litho.testing.subcomponents.InspectableComponent;
@@ -31,7 +32,6 @@ import org.assertj.core.api.Java6Assertions;
 import org.assertj.core.api.ListAssert;
 import org.assertj.core.api.iterable.Extractor;
 import org.assertj.core.util.CheckReturnValue;
-import org.powermock.reflect.Whitebox;
 
 /**
  * Assertion methods for {@link Component}s.

--- a/litho-testing/src/main/java/com/facebook/litho/testing/helper/ComponentTestHelper.java
+++ b/litho-testing/src/main/java/com/facebook/litho/testing/helper/ComponentTestHelper.java
@@ -36,10 +36,10 @@ import com.facebook.litho.LithoView;
 import com.facebook.litho.TestComponentTree;
 import com.facebook.litho.TreeProps;
 import com.facebook.litho.VisibleEvent;
+import com.facebook.litho.testing.Whitebox;
 import com.facebook.litho.testing.subcomponents.SubComponent;
 import java.util.ArrayList;
 import java.util.List;
-import org.powermock.reflect.Whitebox;
 import org.robolectric.shadows.ShadowLooper;
 
 /**

--- a/litho-testing/src/main/java/com/facebook/litho/testing/state/StateUpdatesTestHelper.java
+++ b/litho-testing/src/main/java/com/facebook/litho/testing/state/StateUpdatesTestHelper.java
@@ -21,8 +21,8 @@ import com.facebook.litho.ComponentContext;
 import com.facebook.litho.ComponentTree;
 import com.facebook.litho.LithoView;
 import com.facebook.litho.LithoViewTestHelper;
+import com.facebook.litho.testing.Whitebox;
 import com.facebook.litho.testing.helper.ComponentTestHelper;
-import org.powermock.reflect.Whitebox;
 import org.robolectric.shadows.ShadowLooper;
 
 /** Helper for writing state update unit tests. */


### PR DESCRIPTION
This allows us to remove the Powermock dependency from litho-testing.

Fixes #490