### PR TITLE
Bump the support libraries version to v28

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,9 +37,9 @@ subprojects {
 
 ext {
     minSdkVersion = 15
-    targetSdkVersion = 25
-    compileSdkVersion = 26
-    buildToolsVersion = '27.0.3'
+    targetSdkVersion = 28
+    compileSdkVersion = 28
+    buildToolsVersion = '28.0.3'
     sourceCompatibilityVersion = JavaVersion.VERSION_1_7
     targetCompatibilityVersion = JavaVersion.VERSION_1_7
 }
@@ -49,10 +49,10 @@ ext.isSnapshot = { VERSION_NAME.endsWith('-SNAPSHOT') }
 
 ext.deps = [
         // Android support
-        supportAnnotations : 'com.android.support:support-annotations:27.1.1',
-        supportAppCompat   : 'com.android.support:appcompat-v7:27.1.1',
-        supportCoreUi      : 'com.android.support:support-core-ui:27.1.1',
-        supportRecyclerView: 'com.android.support:recyclerview-v7:27.1.1',
+        supportAnnotations : 'com.android.support:support-annotations:28.0.0',
+        supportAppCompat   : 'com.android.support:appcompat-v7:28.0.0',
+        supportCoreUi      : 'com.android.support:support-core-ui:28.0.0',
+        supportRecyclerView: 'com.android.support:recyclerview-v7:28.0.0',
         supportEspresso    : 'com.android.support.test.espresso:espresso-core:3.0.2',
         supportEspressoIntents : 'com.android.support.test.espresso:espresso-intents:3.0.2',
         supportTestRunner  : 'com.android.support.test:runner:1.0.2',


### PR DESCRIPTION
Summary: This is prerequisite before moving to AndroidX

Reviewed By: passy

Differential Revision: D14124346
