### PR TITLE
Fix some tests to work with Robolectric upgrade

### DIFF
--- a/litho-it/src/test/java/com/facebook/litho/ComponentHostTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/ComponentHostTest.java
@@ -924,7 +924,7 @@ public class ComponentHostTest {
     assertThat(drawables).hasSize(1);
     assertThat(drawables).contains(d3);
 
-    unmount(2, mountItem2);
+    unmount(1, mountItem2);
 
     drawables = mHost.getDrawables();
     assertThat(drawables).hasSize(1);

--- a/litho-it/src/test/java/com/facebook/litho/ResolveAttributeTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/ResolveAttributeTest.java
@@ -27,6 +27,7 @@ import static com.facebook.litho.it.R.drawable.test_bg;
 import static com.facebook.litho.reference.Reference.acquire;
 import static com.facebook.yoga.YogaEdge.LEFT;
 import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.robolectric.Shadows.shadowOf;
 
 import android.graphics.drawable.Drawable;
 import android.view.ContextThemeWrapper;
@@ -57,7 +58,8 @@ public class ResolveAttributeTest {
     Drawable d = mContext.getResources().getDrawable(test_bg);
     ComparableDrawableWrapper comparable =
         (ComparableDrawableWrapper) acquire(mContext.getAndroidContext(), node.getBackground());
-    assertThat(comparable.getWrappedDrawable()).isEqualTo(d);
+    assertThat(shadowOf(comparable.getWrappedDrawable()).getCreatedFromResId())
+        .isEqualTo(shadowOf(d).getCreatedFromResId());
   }
 
   @Test
@@ -81,7 +83,8 @@ public class ResolveAttributeTest {
     Drawable d = mContext.getResources().getDrawable(test_bg);
     ComparableDrawableWrapper comparable =
         (ComparableDrawableWrapper) acquire(mContext.getAndroidContext(), node.getBackground());
-    assertThat(comparable.getWrappedDrawable()).isEqualTo(d);
+    assertThat(shadowOf(comparable.getWrappedDrawable()).getCreatedFromResId())
+        .isEqualTo(shadowOf(d).getCreatedFromResId());
   }
 
   @Test

--- a/litho-it/src/test/java/com/facebook/litho/reference/DrawableResourcesCacheTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/reference/DrawableResourcesCacheTest.java
@@ -76,9 +76,9 @@ public class DrawableResourcesCacheTest {
     mCache.release(drawable2, 1);
     mCache.release(drawable3, 1);
 
-    assertThat(mCache.get(1, resources)).isEqualTo(drawable);
-    assertThat(mCache.get(1, resources)).isEqualTo(drawable2);
-    assertThat(mCache.get(1, resources)).isEqualTo(drawable3);
+    assertThat(mCache.get(1, resources)).isSameAs(drawable3);
+    assertThat(mCache.get(1, resources)).isSameAs(drawable2);
+    assertThat(mCache.get(1, resources)).isSameAs(drawable);
   }
 
 }


### PR DESCRIPTION
Robolectric 4 is stricter with Drawable.equals, and one of these tests was just wrong...