### PR TITLE
Add a onComponentTreeReleased method to RenderInfo.

### DIFF
--- a/litho-widget/src/main/java/com/facebook/litho/widget/BaseRenderInfo.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/BaseRenderInfo.java
@@ -188,6 +188,11 @@ public abstract class BaseRenderInfo implements RenderInfo {
     return mDebugInfo.get(key);
   }
 
+  @Override
+  public void onComponentTreeReleased() {
+    // No default implementation.
+  }
+
   /**
    * Set viewType of current {@link RenderInfo} if it was created through {@link
    * ViewRenderInfo#create()} and a custom viewType was not set, or otherwise it will throw {@link

--- a/litho-widget/src/main/java/com/facebook/litho/widget/ComponentTreeHolder.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/ComponentTreeHolder.java
@@ -457,6 +457,7 @@ public class ComponentTreeHolder {
     if (mComponentTree != null) {
       mComponentTree.release();
       mComponentTree = null;
+      mRenderInfo.onComponentTreeReleased();
     }
 
     mIsTreeValid = false;

--- a/litho-widget/src/main/java/com/facebook/litho/widget/RecyclerBinder.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/RecyclerBinder.java
@@ -2425,6 +2425,13 @@ public class RecyclerBinder
 
     mViewportManager.removeViewportChangedListener(mViewportChangedListener);
 
+    synchronized (this) {
+      int treeHoldersSize = mComponentTreeHolders.size();
+      for (int i = treeHoldersSize - 1; i >= 0; i--) {
+        mComponentTreeHolders.remove(i).release();
+      }
+    }
+
     // We might have already unmounted this view when calling mount with a different view. In this
     // case we can just return here.
     if (mMountedView != view) {

--- a/litho-widget/src/main/java/com/facebook/litho/widget/RenderInfo.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/RenderInfo.java
@@ -64,4 +64,13 @@ public interface RenderInfo {
    * UnsupportedOperationException}.
    */
   void setViewType(int viewType);
+
+  /**
+   * Perform any cleanup necessary when the ComponentTree gets released. The ComponentTree holds the
+   * layout state, so it is the object that RecyclerBinder holds onto when an item is within the
+   * concurrent layout range. This callback is called when RecyclerBinder releases the ComponentTree
+   * (and thus any associated layout state). Note that this is shorter lived than @State, which is
+   * held onto even if the ComponentTree is released.
+   */
+  void onComponentTreeReleased();
 }

--- a/litho-widget/src/main/java/com/facebook/litho/widget/TreePropsWrappedRenderInfo.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/TreePropsWrappedRenderInfo.java
@@ -143,6 +143,11 @@ public class TreePropsWrappedRenderInfo implements RenderInfo {
     return mRenderInfo.getDebugInfo(key);
   }
 
+  @Override
+  public void onComponentTreeReleased() {
+    // No default implementation.
+  }
+
   /**
    * Set viewType of current {@link RenderInfo} if it was created through {@link
    * ViewRenderInfo#create()} and a custom viewType was not set, or otherwise it will throw {@link


### PR DESCRIPTION
This allows for cleanup when RecyclerBinder disposes of the ComponentTree.