### PR TITLE
Upgrade Flipper and Fresco deps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,6 @@ subprojects {
         google()
         jcenter()
         mavenCentral()
-        //T41117446 Remove this once Flipper/Fresco releases their AndroidX versions
-        maven { url 'https://jitpack.io' }
         maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
     }
     afterEvaluate {
@@ -65,11 +63,11 @@ ext.deps = [
         // Arch
         archLifecycle      : 'androidx.lifecycle:lifecycle-extensions:2.0.0-rc01',
         // First-party
-        fresco             : 'com.facebook.fresco:fresco:1.10.0',
+        fresco             : 'com.facebook.fresco:fresco:1.13.0',
         soloader           : 'com.facebook.soloader:soloader:0.6.0',
         textlayoutbuilder  : 'com.facebook.fbui.textlayoutbuilder:textlayoutbuilder:1.5.0',
         screenshot         : 'com.facebook.testing.screenshot:core:0.5.0',
-        flipper            : 'com.facebook.flipper:flipper:0.16.3-SNAPSHOT',
+        flipper            : 'com.facebook.flipper:flipper:0.17.0',
         // Annotations
         jsr305             : 'com.google.code.findbugs:jsr305:3.0.1',
         inferAnnotations   : 'com.facebook.infer.annotation:infer-annotation:0.11.2',

--- a/litho-fresco/build.gradle
+++ b/litho-fresco/build.gradle
@@ -40,8 +40,7 @@ dependencies {
     compileOnly deps.inferAnnotations
 
     // First-party
-    //T41117446 Replace this with proper version after Fresco releases their AndroidX version
-    implementation('com.github.facebook.fresco:fresco:67fd55d341')
+    implementation deps.fresco
 
     // Android Support Library
     compileOnly deps.supportAnnotations

--- a/sample-kotlin/build.gradle
+++ b/sample-kotlin/build.gradle
@@ -42,8 +42,7 @@ dependencies {
     kapt project(':litho-sections-processor')
 
     implementation deps.soloader
-    //T41117446 Replace this with proper version after Fresco releases their AndroidX version
-    implementation('com.github.facebook.fresco:fresco:67fd55d341')
+    implementation deps.fresco
 
     implementation deps.supportRecyclerView
     implementation deps.kotlinStandardLib

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -45,12 +45,8 @@ dependencies {
 
     // First-party
     implementation deps.soloader
-    //T41117446 Replace this with proper version after Fresco releases their AndroidX version
-    implementation('com.github.facebook.fresco:fresco:67fd55d341')
-    implementation(deps.flipper) {
-        exclude group: 'com.facebook.flipper', module: 'fbjni'
-        exclude group: 'com.facebook.litho', module: 'litho-sections-debug'
-    }
+    implementation deps.flipper
+    implementation deps.fresco
     implementation deps.guava
 
     // Annotations


### PR DESCRIPTION
Summary:
All nicely AndroidX-ed and no longer based on snapshots.
Enjoy your releases, Litho!

Reviewed By: oprisnik

Differential Revision: D14324289
