### PR TITLE
Move targetSdk configuration from AndroidManifest to build.gradle. Fix running Unit test from Gradle

### DIFF
--- a/litho-it-powermock/build.gradle
+++ b/litho-it-powermock/build.gradle
@@ -24,6 +24,7 @@ android {
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.targetSdkVersion
     }
 
     testOptions {

--- a/litho-it-powermock/src/main/AndroidManifest.xml
+++ b/litho-it-powermock/src/main/AndroidManifest.xml
@@ -16,14 +16,6 @@
   ~ limitations under the License.
   -->
 
-<manifest
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.facebook.litho.itpowermock"
-    android:versionCode="1"
-    android:versionName="1.0">
-
-  <uses-sdk
-      android:minSdkVersion="16"
-      android:targetSdkVersion="16"/>
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.facebook.litho.itpowermock">
 </manifest>

--- a/litho-it/build.gradle
+++ b/litho-it/build.gradle
@@ -26,6 +26,7 @@ android {
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.targetSdkVersion
 
         javaCompileOptions {
             annotationProcessorOptions {

--- a/litho-it/src/main/AndroidManifest.xml
+++ b/litho-it/src/main/AndroidManifest.xml
@@ -16,14 +16,6 @@
   ~ limitations under the License.
   -->
 
-<manifest
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.facebook.litho.it"
-    android:versionCode="1"
-    android:versionName="1.0">
-
-  <uses-sdk
-      android:minSdkVersion="16"
-      android:targetSdkVersion="16"/>
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.facebook.litho.it">
 </manifest>

--- a/sample-barebones-kotlin/build.gradle
+++ b/sample-barebones-kotlin/build.gradle
@@ -23,6 +23,7 @@ android {
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.targetSdkVersion
     }
 
     // TODO(#62): Re-enable abort on error.

--- a/sample-barebones-kotlin/src/main/AndroidManifest.xml
+++ b/sample-barebones-kotlin/src/main/AndroidManifest.xml
@@ -15,8 +15,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.facebook.samples.lithoktbarebones">
 
-  <uses-sdk android:targetSdkVersion="23"/>
-
   <application
       android:name="com.facebook.samples.lithoktbarebones.SampleApplication"
       android:label="Litho Kotlin Barebones"

--- a/sample-barebones/build.gradle
+++ b/sample-barebones/build.gradle
@@ -21,6 +21,7 @@ android {
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.targetSdkVersion
     }
 
     // TODO(#62): Re-enable abort on error.

--- a/sample-barebones/src/main/AndroidManifest.xml
+++ b/sample-barebones/src/main/AndroidManifest.xml
@@ -15,8 +15,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.facebook.samples.lithobarebones">
 
-  <uses-sdk android:targetSdkVersion="23"/>
-
   <application
       android:name="com.facebook.samples.lithobarebones.SampleApplication"
       android:label="Litho Barebones"

--- a/sample-codelab/src/main/AndroidManifest.xml
+++ b/sample-codelab/src/main/AndroidManifest.xml
@@ -16,10 +16,6 @@
           xmlns:tools="http://schemas.android.com/tools"
           package="com.facebook.samples.lithocodelab" >
 
-    <uses-sdk
-        android:minSdkVersion="15"
-        android:targetSdkVersion="26"
-        tools:ignore="GradleOverrides"/>
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application

--- a/sample-kotlin/build.gradle
+++ b/sample-kotlin/build.gradle
@@ -23,6 +23,7 @@ android {
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.targetSdkVersion
     }
 }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -22,10 +22,11 @@ android {
     sourceCompatibility = sourceCompatibilityVersion
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.targetSdkVersion
+
         multiDexEnabled true
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
-        targetSdkVersion rootProject.targetSdkVersion
     }
 
     // TODO(#62): Re-enable abort on error.

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -19,17 +19,11 @@
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
-  <uses-sdk
-      android:minSdkVersion="15"
-      android:targetSdkVersion="19"
-      />
-
   <application
       android:name=".LithoSampleApplication"
       android:label="@string/app_name"
       android:icon="@drawable/ic_launcher"
       android:allowBackup="false"
-      android:debuggable="true"
       android:theme="@style/NoTitleBarWhiteBG">
     <activity android:name=".DemoListActivity">
       <intent-filter>


### PR DESCRIPTION
Summary:
Gradle sync is broken, because build config doesn't support setting `minSdkVersion` and `targetSdkVersion` in
AndroidManifest for a long time. We need to move these config params to `build.gradle`, but this will break our
Unit test execution, because of the old Robolectric version which relies on AndroidManifest. Fix TestRunner
accordingly. Closes #515

Differential Revision: D14853883
