### PR TITLE
Add support for more text_alignment values

### DIFF
--- a/litho-it/src/test/java/com/facebook/litho/widget/BUCK
+++ b/litho-it/src/test/java/com/facebook/litho/widget/BUCK
@@ -3,7 +3,7 @@
 # This source code is licensed under the Apache 2.0 license found in the
 # LICENSE file in the root directory of this source tree.
 
-load("//tools/build_defs/oss:litho_defs.bzl", "LITHO_ANDROIDSUPPORT_RECYCLERVIEW_TARGET", "LITHO_ANDROIDSUPPORT_TARGET", "LITHO_ASSERTJ_TARGET", "LITHO_BUILD_CONFIG_TARGET", "LITHO_JAVA_TARGET", "LITHO_JUNIT_TARGET", "LITHO_MOCKITO_TARGET", "LITHO_ROBOLECTRIC_V3_TARGET", "LITHO_SOLOADER_TARGET", "LITHO_TESTING_V3_TARGET", "LITHO_TESTING_WHITEBOX_TARGET", "LITHO_VIEWCOMPAT_TARGET", "components_robolectric_test", "make_dep_path")
+load("//tools/build_defs/oss:litho_defs.bzl", "LITHO_ANDROIDSUPPORT_RECYCLERVIEW_TARGET", "LITHO_ANDROIDSUPPORT_TARGET", "LITHO_ASSERTJ_TARGET", "LITHO_BUILD_CONFIG_TARGET", "LITHO_JAVA_TARGET", "LITHO_JSR_TARGET", "LITHO_JUNIT_TARGET", "LITHO_MOCKITO_TARGET", "LITHO_ROBOLECTRIC_V3_TARGET", "LITHO_SOLOADER_TARGET", "LITHO_TESTING_V3_TARGET", "LITHO_TESTING_WHITEBOX_TARGET", "LITHO_VIEWCOMPAT_TARGET", "LITHO_YOGA_TARGET", "components_robolectric_test", "make_dep_path")
 
 components_robolectric_test(
     name = "widget",
@@ -19,17 +19,20 @@ components_robolectric_test(
     source = "8",
     target = "8",
     deps = [
+
         LITHO_ANDROIDSUPPORT_RECYCLERVIEW_TARGET,
         LITHO_ANDROIDSUPPORT_TARGET,
         LITHO_ASSERTJ_TARGET,
         LITHO_BUILD_CONFIG_TARGET,
         LITHO_JAVA_TARGET,
+        LITHO_JSR_TARGET,
         LITHO_JUNIT_TARGET,
         LITHO_MOCKITO_TARGET,
         LITHO_TESTING_WHITEBOX_TARGET,
         LITHO_SOLOADER_TARGET,
         LITHO_TESTING_V3_TARGET,
         LITHO_VIEWCOMPAT_TARGET,
+        LITHO_YOGA_TARGET,
         make_dep_path("litho-it/src/main/java/com/facebook/litho/widget:widget"),
         make_dep_path("litho-processor/src/main/java/com/facebook/litho/specmodels/internal:internal"),
         make_dep_path("litho-testing/src/main/java/com/facebook/litho/testing/assertj:assertj"),

--- a/litho-it/src/test/java/com/facebook/litho/widget/TextSpecTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/widget/TextSpecTest.java
@@ -38,10 +38,14 @@ import com.facebook.litho.LithoView;
 import com.facebook.litho.testing.eventhandler.EventHandlerTestHelper;
 import com.facebook.litho.testing.helper.ComponentTestHelper;
 import com.facebook.litho.testing.testrunner.ComponentsTestRunner;
+import com.facebook.yoga.YogaDirection;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
+
+import javax.annotation.Nullable;
 
 /** Tests {@link Text} component. */
 @RunWith(ComponentsTestRunner.class)
@@ -205,6 +209,7 @@ public class TextSpecTest {
     assertThat(drawable.getColor()).isEqualTo(Color.RED);
   }
 
+
   @Test
   public void testColor() {
     TextDrawable drawable = getMountedDrawableForTextWithColors("Some text", Color.RED, null);
@@ -344,5 +349,250 @@ public class TextSpecTest {
     when(layout.getLineRight(anyInt())).thenReturn((float) minimalWidth);
 
     return layout;
+  }
+
+  @Test
+  public void testTextAlignment_textStart() {
+    assertThat(getMountedDrawableLayoutAlignment(
+        "asdf",
+        YogaDirection.LTR,
+        null,
+        TextAlignment.TEXT_START))
+        .isEqualTo(Layout.Alignment.ALIGN_NORMAL);
+
+    assertThat(getMountedDrawableLayoutAlignment(
+        "asdf",
+        YogaDirection.RTL,
+        null,
+        TextAlignment.TEXT_START))
+        .isEqualTo(Layout.Alignment.ALIGN_NORMAL);
+
+    // Layout.Alignment.ALIGN_NORMAL is mapped to TextAlignment.TEXT_START
+    assertThat(getMountedDrawableLayoutAlignment(
+        "asdf",
+        YogaDirection.LTR,
+        Layout.Alignment.ALIGN_NORMAL,
+        null))
+        .isEqualTo(Layout.Alignment.ALIGN_NORMAL);
+
+    assertThat(getMountedDrawableLayoutAlignment(
+        "asdf",
+        YogaDirection.RTL,
+        Layout.Alignment.ALIGN_NORMAL,
+        null))
+        .isEqualTo(Layout.Alignment.ALIGN_NORMAL);
+  }
+
+  @Test
+  public void testTextAlignment_textEnd() {
+    assertThat(getMountedDrawableLayoutAlignment(
+        "asdf",
+        YogaDirection.LTR,
+        null,
+        TextAlignment.TEXT_END))
+        .isEqualTo(Layout.Alignment.ALIGN_OPPOSITE);
+
+    assertThat(getMountedDrawableLayoutAlignment(
+        "asdf",
+        YogaDirection.RTL,
+        null,
+        TextAlignment.TEXT_END))
+        .isEqualTo(Layout.Alignment.ALIGN_OPPOSITE);
+
+    // Layout.Alignment.ALIGN_OPPOSITE is mapped to TextAlignment.TEXT_END
+    assertThat(getMountedDrawableLayoutAlignment(
+        "asdf",
+        YogaDirection.LTR,
+        Layout.Alignment.ALIGN_OPPOSITE,
+        null))
+        .isEqualTo(Layout.Alignment.ALIGN_OPPOSITE);
+
+    assertThat(getMountedDrawableLayoutAlignment(
+        "asdf",
+        YogaDirection.RTL,
+        Layout.Alignment.ALIGN_OPPOSITE,
+        null))
+        .isEqualTo(Layout.Alignment.ALIGN_OPPOSITE);
+  }
+
+  @Test
+  public void testTextAlignment_center() {
+    assertThat(getMountedDrawableLayoutAlignment(
+        "asdf",
+        YogaDirection.LTR,
+        null,
+        TextAlignment.CENTER))
+        .isEqualTo(Layout.Alignment.ALIGN_CENTER);
+
+    assertThat(getMountedDrawableLayoutAlignment(
+        "asdf",
+        YogaDirection.RTL,
+        null,
+        TextAlignment.CENTER))
+        .isEqualTo(Layout.Alignment.ALIGN_CENTER);
+
+    // Layout.Alignment.ALIGN_CENTER is mapped to TextAlignment.CENTER
+    assertThat(getMountedDrawableLayoutAlignment(
+        "asdf",
+        YogaDirection.LTR,
+        Layout.Alignment.ALIGN_CENTER,
+        null))
+        .isEqualTo(Layout.Alignment.ALIGN_CENTER);
+
+    assertThat(getMountedDrawableLayoutAlignment(
+        "asdf",
+        YogaDirection.RTL,
+        Layout.Alignment.ALIGN_CENTER,
+        null))
+        .isEqualTo(Layout.Alignment.ALIGN_CENTER);
+  }
+
+  @Test
+  public void testTextAlignment_layoutStart() {
+    assertThat(getMountedDrawableLayoutAlignment(
+        "asdf",
+        YogaDirection.LTR,
+        null,
+        TextAlignment.LAYOUT_START))
+        .isEqualTo(Layout.Alignment.ALIGN_NORMAL);
+
+    assertThat(getMountedDrawableLayoutAlignment(
+        "asdf",
+        YogaDirection.RTL,
+        null,
+        TextAlignment.LAYOUT_START))
+        .isEqualTo(Layout.Alignment.ALIGN_OPPOSITE);
+
+    assertThat(getMountedDrawableLayoutAlignment(
+        "من اليمين الى اليسار",
+        YogaDirection.LTR,
+        null,
+        TextAlignment.LAYOUT_START))
+        .isEqualTo(Layout.Alignment.ALIGN_OPPOSITE);
+
+    assertThat(getMountedDrawableLayoutAlignment(
+        "من اليمين الى اليسار",
+        YogaDirection.RTL,
+        null,
+        TextAlignment.LAYOUT_START))
+        .isEqualTo(Layout.Alignment.ALIGN_NORMAL);
+  }
+
+  @Test
+  public void testTextAlignment_layoutEnd() {
+    assertThat(getMountedDrawableLayoutAlignment(
+        "asdf",
+        YogaDirection.LTR,
+        null,
+        TextAlignment.LAYOUT_END))
+        .isEqualTo(Layout.Alignment.ALIGN_OPPOSITE);
+
+    assertThat(getMountedDrawableLayoutAlignment(
+        "asdf",
+        YogaDirection.RTL,
+        null,
+        TextAlignment.LAYOUT_END))
+        .isEqualTo(Layout.Alignment.ALIGN_NORMAL);
+
+    assertThat(getMountedDrawableLayoutAlignment(
+        "من اليمين الى اليسار",
+        YogaDirection.LTR,
+        null,
+        TextAlignment.LAYOUT_END))
+        .isEqualTo(Layout.Alignment.ALIGN_NORMAL);
+
+    assertThat(getMountedDrawableLayoutAlignment(
+        "من اليمين الى اليسار",
+        YogaDirection.RTL,
+        null,
+        TextAlignment.LAYOUT_END))
+        .isEqualTo(Layout.Alignment.ALIGN_OPPOSITE);
+  }
+
+  @Test
+  public void testTextAlignment_left() {
+    assertThat(getMountedDrawableLayoutAlignment(
+        "asdf",
+        YogaDirection.LTR,
+        null,
+        TextAlignment.LEFT))
+        .isEqualTo(Layout.Alignment.ALIGN_NORMAL);
+
+    assertThat(getMountedDrawableLayoutAlignment(
+        "asdf",
+        YogaDirection.RTL,
+        null,
+        TextAlignment.LEFT))
+        .isEqualTo(Layout.Alignment.ALIGN_NORMAL);
+
+    assertThat(getMountedDrawableLayoutAlignment(
+        "من اليمين الى اليسار",
+        YogaDirection.LTR,
+        null,
+        TextAlignment.LEFT))
+        .isEqualTo(Layout.Alignment.ALIGN_OPPOSITE);
+
+    assertThat(getMountedDrawableLayoutAlignment(
+        "من اليمين الى اليسار",
+        YogaDirection.RTL,
+        null,
+        TextAlignment.LEFT))
+        .isEqualTo(Layout.Alignment.ALIGN_OPPOSITE);
+  }
+
+  @Test
+  public void testTextAlignment_right() {
+    assertThat(getMountedDrawableLayoutAlignment(
+        "asdf",
+        YogaDirection.LTR,
+        null,
+        TextAlignment.RIGHT))
+        .isEqualTo(Layout.Alignment.ALIGN_OPPOSITE);
+
+    assertThat(getMountedDrawableLayoutAlignment(
+        "asdf",
+        YogaDirection.RTL,
+        null,
+        TextAlignment.RIGHT))
+        .isEqualTo(Layout.Alignment.ALIGN_OPPOSITE);
+
+    assertThat(getMountedDrawableLayoutAlignment(
+        "من اليمين الى اليسار",
+        YogaDirection.LTR,
+        null,
+        TextAlignment.RIGHT))
+        .isEqualTo(Layout.Alignment.ALIGN_NORMAL);
+
+    assertThat(getMountedDrawableLayoutAlignment(
+        "من اليمين الى اليسار",
+        YogaDirection.RTL,
+        null,
+        TextAlignment.RIGHT))
+        .isEqualTo(Layout.Alignment.ALIGN_NORMAL);
+  }
+
+  private Layout.Alignment getMountedDrawableLayoutAlignment(
+      String text,
+      @Nullable YogaDirection layoutDirection,
+      @Nullable Layout.Alignment deprecatedTextAlignment,
+      @Nullable TextAlignment textAlignment) {
+
+    Text.Builder builder = Text.create(mContext).text(text);
+
+    if (layoutDirection != null) {
+      builder.layoutDirection(layoutDirection);
+    }
+
+    if (deprecatedTextAlignment != null) {
+      builder.textAlignment(deprecatedTextAlignment);
+    }
+
+    if (textAlignment != null) {
+      builder.alignment(textAlignment);
+    }
+
+    return ((TextDrawable) ComponentTestHelper.mountComponent(mContext, builder.build())
+        .getDrawables().get(0))
+        .getLayoutAlignment();
   }
 }

--- a/litho-widget/src/main/java/com/facebook/litho/widget/TextAlignment.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/TextAlignment.java
@@ -1,0 +1,44 @@
+package com.facebook.litho.widget;
+
+/**
+ * Enumeration of text alignment values. These values differ from {@link
+ * android.text.Layout.Alignment} and View.TEXT_ALIGNMENT_* because this full list of values is not
+ * supported by either implementation.
+ */
+public enum TextAlignment {
+
+  /**
+   * Align the text to the start of the paragraph i.e. {@link
+   * android.view.View#TEXT_ALIGNMENT_TEXT_START} or {@link
+   * android.text.Layout.Alignment#ALIGN_NORMAL}.
+   */
+  TEXT_START,
+
+  /**
+   * Align the text to the end of the paragraph i.e. {@link
+   * android.view.View#TEXT_ALIGNMENT_TEXT_END} or {@link
+   * android.text.Layout.Alignment#ALIGN_OPPOSITE}/.
+   */
+  TEXT_END,
+
+  /** Align the text to the center. */
+  CENTER,
+
+  /**
+   * Align the text to the start of the view i.e. {@link
+   * android.view.View#TEXT_ALIGNMENT_VIEW_START}.
+   */
+  LAYOUT_START,
+
+  /**
+   * Align the text to the start of the view i.e. {@link
+   * android.view.View#TEXT_ALIGNMENT_VIEW_END}.
+   */
+  LAYOUT_END,
+
+  /** Align the text to the left, ignoring the text or locale preferences for LTR/RTL. */
+  LEFT,
+
+  /** Align the text to the right, ignoring the text or locale preferences for LTR/RTL. */
+  RIGHT,
+}

--- a/litho-widget/src/main/java/com/facebook/litho/widget/TextDrawable.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/TextDrawable.java
@@ -39,6 +39,9 @@ import android.text.style.ImageSpan;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewConfiguration;
+
+import androidx.annotation.VisibleForTesting;
+
 import com.facebook.fbui.textlayoutbuilder.util.LayoutMeasureUtil;
 import com.facebook.litho.TextContent;
 import com.facebook.litho.Touchable;
@@ -536,6 +539,12 @@ public class TextDrawable extends Drawable implements Touchable, TextContent, Dr
       // https://android.googlesource.com/platform/frameworks/base/+/821e9bd5cc2be4b3210cb0226e40ba0f42b51aed
       return -1;
     }
+  }
+
+  @VisibleForTesting
+  @Nullable
+  Layout.Alignment getLayoutAlignment() {
+    return mLayout == null ? null : mLayout.getAlignment();
   }
 
   /**

--- a/litho-widget/src/main/java/com/facebook/litho/widget/TextStylesHelper.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/TextStylesHelper.java
@@ -15,27 +15,23 @@
  */
 package com.facebook.litho.widget;
 
-import static android.text.Layout.Alignment.ALIGN_CENTER;
-import static android.text.Layout.Alignment.ALIGN_NORMAL;
-import static android.text.Layout.Alignment.ALIGN_OPPOSITE;
-import static com.facebook.litho.widget.VerticalGravity.BOTTOM;
-import static com.facebook.litho.widget.VerticalGravity.CENTER;
-import static com.facebook.litho.widget.VerticalGravity.TOP;
-
 import android.content.res.ColorStateList;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.graphics.Typeface;
 import android.os.Build;
-import android.text.Layout;
-import android.text.Layout.Alignment;
 import android.text.TextUtils.TruncateAt;
 import android.view.Gravity;
 import android.view.View;
+
 import com.facebook.litho.ComponentContext;
 import com.facebook.litho.Output;
 import com.facebook.litho.R;
 import com.facebook.litho.config.ComponentsConfiguration;
+
+import static com.facebook.litho.widget.VerticalGravity.BOTTOM;
+import static com.facebook.litho.widget.VerticalGravity.CENTER;
+import static com.facebook.litho.widget.VerticalGravity.TOP;
 
 public final class TextStylesHelper {
   static {
@@ -54,7 +50,7 @@ public final class TextStylesHelper {
   // JUSTIFICATION_MODE_NONE (AOSP Default)
   public static final int DEFAULT_JUSTIFICATION_MODE = 0;
 
-  public static final Alignment textAlignmentDefault = ALIGN_NORMAL;
+  public static final TextAlignment textAlignmentDefault = TextAlignment.TEXT_START;
 
   public static void onLoadStyle(
       ComponentContext c,
@@ -74,7 +70,7 @@ public final class TextStylesHelper {
       Output<Integer> linkColor,
       Output<Integer> highlightColor,
       Output<Integer> textSize,
-      Output<Layout.Alignment> textAlignment,
+      Output<TextAlignment> textAlignment,
       Output<Integer> breakStrategy,
       Output<Integer> hyphenationFrequency,
       Output<Integer> justificationMode,
@@ -203,7 +199,7 @@ public final class TextStylesHelper {
       Output<Integer> linkColor,
       Output<Integer> highlightColor,
       Output<Integer> textSize,
-      Output<Layout.Alignment> textAlignment,
+      Output<TextAlignment> textAlignment,
       Output<Integer> breakStrategy,
       Output<Integer> hyphenationFrequency,
       Output<Integer> justificationMode,
@@ -235,11 +231,11 @@ public final class TextStylesHelper {
       } else if (attr == R.styleable.Text_android_textAlignment) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
           viewTextAlignment = a.getInt(attr, -1);
-          textAlignment.set(getAlignment(viewTextAlignment, gravity));
+          textAlignment.set(getTextAlignment(viewTextAlignment, gravity));
         }
       } else if (attr == R.styleable.Text_android_gravity) {
         gravity = a.getInt(attr, -1);
-        textAlignment.set(getAlignment(viewTextAlignment, gravity));
+        textAlignment.set(getTextAlignment(viewTextAlignment, gravity));
         verticalGravity.set(getVerticalGravity(gravity));
       } else if (attr == R.styleable.Text_android_includeFontPadding) {
         shouldIncludeFontPadding.set(a.getBoolean(attr, false));
@@ -298,29 +294,27 @@ public final class TextStylesHelper {
     }
   }
 
-  private static Alignment getAlignment(int viewTextAlignment, int gravity) {
-    final Alignment alignment;
+  private static TextAlignment getTextAlignment(int viewTextAlignment, int gravity) {
+    final TextAlignment alignment;
     switch (viewTextAlignment) {
-      case View.TEXT_ALIGNMENT_GRAVITY:
-        alignment = getAlignment(gravity);
-        break;
       case View.TEXT_ALIGNMENT_TEXT_START:
-        alignment = ALIGN_NORMAL;
+        alignment = TextAlignment.TEXT_START;
         break;
       case View.TEXT_ALIGNMENT_TEXT_END:
-        alignment = ALIGN_OPPOSITE;
+        alignment = TextAlignment.TEXT_END;
         break;
       case View.TEXT_ALIGNMENT_CENTER:
-        alignment = ALIGN_CENTER;
+        alignment = TextAlignment.CENTER;
         break;
-      case View.TEXT_ALIGNMENT_VIEW_START: // unsupported, default to normal
-        alignment = ALIGN_NORMAL;
+      case View.TEXT_ALIGNMENT_VIEW_START:
+        alignment = TextAlignment.LAYOUT_START;
         break;
-      case View.TEXT_ALIGNMENT_VIEW_END: // unsupported, default to opposite
-        alignment = ALIGN_OPPOSITE;
+      case View.TEXT_ALIGNMENT_VIEW_END:
+        alignment = TextAlignment.LAYOUT_END;
         break;
       case View.TEXT_ALIGNMENT_INHERIT: // unsupported, default to gravity
-        alignment = getAlignment(gravity);
+      case View.TEXT_ALIGNMENT_GRAVITY:
+        alignment = getTextAlignment(gravity);
         break;
       default:
         alignment = textAlignmentDefault;
@@ -329,23 +323,23 @@ public final class TextStylesHelper {
     return alignment;
   }
 
-  private static Alignment getAlignment(int gravity) {
-    final Alignment alignment;
+  private static TextAlignment getTextAlignment(int gravity) {
+    final TextAlignment alignment;
     switch (gravity & Gravity.RELATIVE_HORIZONTAL_GRAVITY_MASK) {
       case Gravity.START:
-        alignment = ALIGN_NORMAL;
+        alignment = TextAlignment.LAYOUT_START;
         break;
       case Gravity.END:
-        alignment = ALIGN_OPPOSITE;
+        alignment = TextAlignment.LAYOUT_END;
         break;
-      case Gravity.LEFT: // unsupported, default to normal
-        alignment = ALIGN_NORMAL;
+      case Gravity.LEFT:
+        alignment = TextAlignment.LEFT;
         break;
-      case Gravity.RIGHT: // unsupported, default to opposite
-        alignment = ALIGN_OPPOSITE;
+      case Gravity.RIGHT:
+        alignment = TextAlignment.RIGHT;
         break;
       case Gravity.CENTER_HORIZONTAL:
-        alignment = ALIGN_CENTER;
+        alignment = TextAlignment.CENTER;
         break;
       default:
         alignment = textAlignmentDefault;

--- a/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/expandableelement/ExpandableElementRootComponentSpec.kt
+++ b/sample-kotlin/src/main/java/com/fblitho/lithoktsample/animations/expandableelement/ExpandableElementRootComponentSpec.kt
@@ -13,7 +13,6 @@
 package com.fblitho.lithoktsample.animations.expandableelement
 
 import android.graphics.Color
-import android.text.Layout
 import com.facebook.litho.ClickEvent
 import com.facebook.litho.Column
 import com.facebook.litho.Component
@@ -36,6 +35,7 @@ import com.facebook.litho.sections.widget.NotAnimatedItemAnimator
 import com.facebook.litho.sections.widget.RecyclerCollectionComponent
 import com.facebook.litho.widget.RenderInfo
 import com.facebook.litho.widget.Text
+import com.facebook.litho.widget.TextAlignment
 import com.facebook.yoga.YogaAlign
 import com.facebook.yoga.YogaEdge
 import com.fblitho.lithoktsample.animations.messages.Message
@@ -72,7 +72,7 @@ object ExpandableElementRootComponentSpec {
                       .flexGrow(1f)
                       .alignSelf(YogaAlign.CENTER)
                       .testKey("INSERT")
-                      .textAlignment(Layout.Alignment.ALIGN_CENTER)
+                      .alignment(TextAlignment.CENTER)
                       .clickHandler(ExpandableElementRootComponent.onClick(c, true)))
               .child(
                   Text.create(c)
@@ -81,7 +81,7 @@ object ExpandableElementRootComponentSpec {
                       .textSizeSp(20f)
                       .flexGrow(1f)
                       .alignSelf(YogaAlign.CENTER)
-                      .textAlignment(Layout.Alignment.ALIGN_CENTER)
+                      .alignment(TextAlignment.CENTER)
                       .clickHandler(ExpandableElementRootComponent.onClick(c, false))))
       .child(
           RecyclerCollectionComponent.create(c)

--- a/sample/src/main/java/com/facebook/samples/litho/animations/expandableelement/ExpandableElementRootComponentSpec.java
+++ b/sample/src/main/java/com/facebook/samples/litho/animations/expandableelement/ExpandableElementRootComponentSpec.java
@@ -13,7 +13,6 @@
 package com.facebook.samples.litho.animations.expandableelement;
 
 import android.graphics.Color;
-import android.text.Layout;
 import com.facebook.litho.ClickEvent;
 import com.facebook.litho.Column;
 import com.facebook.litho.Component;
@@ -36,6 +35,7 @@ import com.facebook.litho.sections.widget.NotAnimatedItemAnimator;
 import com.facebook.litho.sections.widget.RecyclerCollectionComponent;
 import com.facebook.litho.widget.RenderInfo;
 import com.facebook.litho.widget.Text;
+import com.facebook.litho.widget.TextAlignment;
 import com.facebook.yoga.YogaAlign;
 import com.facebook.yoga.YogaEdge;
 import java.util.ArrayList;
@@ -69,7 +69,7 @@ public class ExpandableElementRootComponentSpec {
                         .flexGrow(1)
                         .alignSelf(YogaAlign.CENTER)
                         .testKey("INSERT")
-                        .textAlignment(Layout.Alignment.ALIGN_CENTER)
+                        .alignment(TextAlignment.CENTER)
                         .clickHandler(ExpandableElementRootComponent.onClick(c, true)))
                 .child(
                     Text.create(c)
@@ -78,7 +78,7 @@ public class ExpandableElementRootComponentSpec {
                         .textSizeSp(20)
                         .flexGrow(1)
                         .alignSelf(YogaAlign.CENTER)
-                        .textAlignment(Layout.Alignment.ALIGN_CENTER)
+                        .alignment(TextAlignment.CENTER)
                         .clickHandler(ExpandableElementRootComponent.onClick(c, false))))
         .child(
             RecyclerCollectionComponent.create(c)


### PR DESCRIPTION
Fixes #516

Design notes:
- Did not use [Layout.Alignment](https://developer.android.com/reference/android/text/Layout.Alignment) because it doesn't differentiate between VIEW_START/END and TEXT_START/END
- Did not use `View.TEXT_ALIGNMENT_*`/[`android:textAlignment`](https://developer.android.com/reference/android/view/View#attr_android:textAlignment) because
  - Default value of `INHERIT` cannot be supported by Litho without adding this property to all Components which doesn't seem ideal
  - `GRAVITY` cannot be supported unless Litho adds a gravity prop to Text, which doesn't seem necessary
  - `LEFT` and `RIGHT` are not supported directly as values
- Proposed solution is to use our own Enum for `TextAlignment`.
- This deprecates the `textAlignment` prop for the new `alignment` prop that handles the new cases. Unfortunately the old prop's dependences on an Enum requires a migration.