### PR TITLE
Add yoga directory to its own include paths

### DIFF
--- a/lib/yoga/src/main/cpp/CMakeLists.txt
+++ b/lib/yoga/src/main/cpp/CMakeLists.txt
@@ -22,3 +22,5 @@ file(GLOB yogacore_SRC yoga/*.cpp)
 add_library(yogacore STATIC ${yogacore_SRC})
 
 target_link_libraries(yogacore android log)
+target_include_directories(yogacore PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
Summary: Adds `lib/yoga/src/main/cpp` to the include paths for Yoga, so that it can include its own files as `#include <yoga/...>`.

Reviewed By: passy

Differential Revision: D15760065

