### PR TITLE
Allow Specs to define their own disappearTo transitions.

### DIFF
--- a/litho-core/src/main/java/com/facebook/litho/TransitionManager.java
+++ b/litho-core/src/main/java/com/facebook/litho/TransitionManager.java
@@ -275,7 +275,29 @@ public class TransitionManager {
       }
     }
 
+    // First, create animation bindings for the previous LayoutState in case there are any
+    // transitions for disappearing items that are no longer in the new LayoutState.
+    List<AnimationBinding> currentAnimationBindings = new ArrayList<>();
+    if (currentLayoutState != null) {
+      List<Transition> currentTransitions = currentLayoutState.getTransitions();
+      for (Transition transition : currentTransitions) {
+        AnimationBinding binding = createAnimationsForTransition(transition);
+        if (binding != null) {
+          currentAnimationBindings.add(binding);
+        }
+      }
+    }
+
+    // Create animation bindings for the new LayoutState.
     createTransitionAnimations(rootTransition);
+
+    // Merge the animation bindings from the previous LayoutState with the new one.
+    if (!currentAnimationBindings.isEmpty()) {
+      if (mRootAnimationToRun != null) {
+        currentAnimationBindings.add(mRootAnimationToRun);
+      }
+      mRootAnimationToRun = new ParallelBinding(0, currentAnimationBindings);
+    }
 
     // If we recorded any mount content diffs that didn't result in an animation being created for
     // that transition id, clean them up now.


### PR DESCRIPTION
Create AnimationBindings from the previous LayoutState to allow Specs to define their own disappearance transitions.

This may not be the best way to solve this. Open to feedback.

## Summary

If a Spec defines a disappearTo transition for itself, it will not animate (appearFrom works). This change causes TransitionManager to include transitions defined in the previous LayoutState to be included when creating animations, which allows those disappearTo animations to run.

## Changelog

A Spec can now define its own disappearTo transition.

## Test Plan

Tested manually with our own Specs. Let me know what other tests you'd like me to add.