### PR TITLE
explicit type casting needed

### DIFF
--- a/docs/_docs/sections-tutorial.md
+++ b/docs/_docs/sections-tutorial.md
@@ -90,14 +90,14 @@ static Children onCreateChildren(final SectionContext c) {
                       .disablePTR(true)
                       .recyclerConfiguration(new ListRecyclerConfiguration(LinearLayoutManager.HORIZONTAL, /*reverse layout*/ false, SNAP_TO_CENTER))
                       .section(
-                          DataDiffSection.create(c)
+                          DataDiffSection.<Integer>create(c)
                               .data(generateData(32))
                               .renderEventHandler(ListSection.onRender(c))
                               .build())
                       .canMeasureRecycler(true))
               .build())
         .child(
-            DataDiffSection.create(c)
+            DataDiffSection.<Integer>create(c)
                 .data(generateData(32))
                 .renderEventHandler(ListSection.onRender(c)))
         .build();


### PR DESCRIPTION
Type casting is required otherwise there is an error message from the complier: ```error: incompatible types: List<integer> cannot be converted to List<Object>```

<!-- Thanks for submitting a pull request! We appreciate you taking the time to work on these 
changes. Please provide enough information so that others can review your pull request. The three 
fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request 
solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be
a brief oneline we can mention in our release notes: https://github.com/facebook/litho/releases -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, output of 
the test runner and how you invoked it (you've added tests, right?), screenshots/videos if the pull 
request changes UI. -->
