### PR TITLE
Add support for A11y headers in Litho.

### DIFF
--- a/litho-core/src/main/java/com/facebook/litho/CommonProps.java
+++ b/litho-core/src/main/java/com/facebook/litho/CommonProps.java
@@ -95,6 +95,8 @@ public interface CommonProps extends CommonPropsCopyable, LayoutProps {
 
   void selected(boolean isSelected);
 
+  void accessibilityHeading(boolean isHeading);
+
   void visibleHeightRatio(float visibleHeightRatio);
 
   void visibleWidthRatio(float visibleWidthRatio);

--- a/litho-core/src/main/java/com/facebook/litho/CommonPropsHolder.java
+++ b/litho-core/src/main/java/com/facebook/litho/CommonPropsHolder.java
@@ -365,6 +365,11 @@ class CommonPropsHolder implements CommonProps {
   }
 
   @Override
+  public void accessibilityHeading(boolean isHeading) {
+    getOrCreateNodeInfo().setAccessibilityHeading(isHeading);
+  }
+
+  @Override
   public void visibleHeightRatio(float visibleHeightRatio) {
     getOrCreateOtherProps().visibleHeightRatio(visibleHeightRatio);
   }

--- a/litho-core/src/main/java/com/facebook/litho/Component.java
+++ b/litho-core/src/main/java/com/facebook/litho/Component.java
@@ -1014,6 +1014,11 @@ public abstract class Component extends ComponentLifecycle
       return getThis();
     }
 
+    public T accessibilityHeading(boolean isHeading) {
+      mComponent.getOrCreateCommonProps().accessibilityHeading(isHeading);
+      return getThis();
+    }
+
     /**
      * If true, component duplicates its drawable state (focused, pressed, etc.) from the direct
      * parent.

--- a/litho-core/src/main/java/com/facebook/litho/Component.java
+++ b/litho-core/src/main/java/com/facebook/litho/Component.java
@@ -1014,6 +1014,22 @@ public abstract class Component extends ComponentLifecycle
       return getThis();
     }
 
+    /**
+     * Ports {@link android.view.ViewCompat#setAccessibilityHeading}
+     * into components world. However, since the aforementioned ViewCompat's method is available only on
+     * API 19 and above, calling this method on lower APIs will have no effect. On the legit
+     * versions, on the other hand, calling this method will lead to the component being treated
+     * as a heading.
+     * The AccessibilityHeading property allows accessibility services to help
+     * users navigate directly from one heading to the next.
+     * See <a
+     * href="https://developer.android.com/reference/android/support/v4/view/accessibility/
+     * AccessibilityNodeInfoCompat#setheading">https://developer.android.com/reference/android/
+     * support/v4/view/accessibility/AccessibilityNodeInfoCompat#setheading</a> for more
+     * information.
+     *
+     * <p>Default: false
+     */
     public T accessibilityHeading(boolean isHeading) {
       mComponent.getOrCreateCommonProps().accessibilityHeading(isHeading);
       return getThis();

--- a/litho-core/src/main/java/com/facebook/litho/ComponentAccessibilityDelegate.java
+++ b/litho-core/src/main/java/com/facebook/litho/ComponentAccessibilityDelegate.java
@@ -115,6 +115,12 @@ class ComponentAccessibilityDelegate extends ExploreByTouchHelper {
         node.setClassName(AccessibilityRole.NONE);
       }
     }
+
+    if (mNodeInfo != null
+        && mNodeInfo.getAccessibilityHeadingState() != NodeInfo.ACCESSIBILITY_HEADING_UNSET) {
+      node.setHeading(
+          mNodeInfo.getAccessibilityHeadingState() == NodeInfo.ACCESSIBILITY_HEADING_SET_TRUE);
+    }
   }
 
   @Override

--- a/litho-core/src/main/java/com/facebook/litho/DefaultNodeInfo.java
+++ b/litho-core/src/main/java/com/facebook/litho/DefaultNodeInfo.java
@@ -117,6 +117,7 @@ class DefaultNodeInfo implements NodeInfo {
   private @ClickableState int mClickableState = CLICKABLE_UNSET;
   private @EnabledState int mEnabledState = ENABLED_UNSET;
   private @SelectedState int mSelectedState = SELECTED_UNSET;
+  private @AccessibilityHeadingState int mAccessibilityHeadingState = ACCESSIBILITY_HEADING_UNSET;
 
   private int mPrivateFlags;
 
@@ -477,6 +478,20 @@ class DefaultNodeInfo implements NodeInfo {
   }
 
   @Override
+  public void setAccessibilityHeading(boolean isHeading) {
+    if (isHeading) {
+      mAccessibilityHeadingState = ACCESSIBILITY_HEADING_SET_TRUE;
+    } else {
+      mAccessibilityHeadingState = ACCESSIBILITY_HEADING_SET_FALSE;
+    }
+  }
+
+  @Override
+  public int getAccessibilityHeadingState() {
+    return mAccessibilityHeadingState;
+  }
+
+  @Override
   public float getScale() {
     return mScale;
   }
@@ -647,6 +662,10 @@ class DefaultNodeInfo implements NodeInfo {
     }
     if (getSelectedState() != SELECTED_UNSET) {
       target.setSelected(getSelectedState() == SELECTED_SET_TRUE);
+    }
+    if (getAccessibilityHeadingState() != ACCESSIBILITY_HEADING_UNSET) {
+      target.setAccessibilityHeading(
+          getAccessibilityHeadingState() == ACCESSIBILITY_HEADING_SET_TRUE);
     }
     if ((mPrivateFlags & PFLAG_SCALE_IS_SET) != 0) {
       target.setScale(mScale);

--- a/litho-core/src/main/java/com/facebook/litho/NodeInfo.java
+++ b/litho-core/src/main/java/com/facebook/litho/NodeInfo.java
@@ -64,6 +64,18 @@ public interface NodeInfo {
   @Retention(RetentionPolicy.SOURCE)
   @interface SelectedState {}
 
+  static final int ACCESSIBILITY_HEADING_UNSET = 0;
+  static final int ACCESSIBILITY_HEADING_SET_TRUE = 1;
+  static final int ACCESSIBILITY_HEADING_SET_FALSE = 2;
+
+  @IntDef({
+    ACCESSIBILITY_HEADING_UNSET,
+    ACCESSIBILITY_HEADING_SET_TRUE,
+    ACCESSIBILITY_HEADING_SET_FALSE
+  })
+  @Retention(RetentionPolicy.SOURCE)
+  @interface AccessibilityHeadingState {}
+
   void setContentDescription(@Nullable CharSequence contentDescription);
 
   @Nullable
@@ -219,6 +231,11 @@ public interface NodeInfo {
 
   @SelectedState
   int getSelectedState();
+
+  void setAccessibilityHeading(boolean isHeading);
+
+  @AccessibilityHeadingState
+  int getAccessibilityHeadingState();
 
   float getScale();
 

--- a/litho-it/src/test/java/com/facebook/litho/CommonPropsTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/CommonPropsTest.java
@@ -148,6 +148,7 @@ public class CommonPropsTest {
     mCommonProps.enabled(false);
     mCommonProps.visibleHeightRatio(55);
     mCommonProps.visibleWidthRatio(56);
+    mCommonProps.accessibilityHeading(false);
 
     final EventHandler<VisibleEvent> visibleHandler = mock(EventHandler.class);
     final EventHandler<FocusedVisibleEvent> focusedHandler = mock(EventHandler.class);
@@ -285,6 +286,7 @@ public class CommonPropsTest {
     verify(mNodeInfo).setEnabled(false);
     verify(mNode).visibleHeightRatio(55);
     verify(mNode).visibleWidthRatio(56);
+    verify(mNodeInfo).setAccessibilityHeading(false);
 
     verify(mNode).visibleHandler(visibleHandler);
     verify(mNode).focusedHandler(focusedHandler);

--- a/litho-it/src/test/java/com/facebook/litho/LayoutStateCreateTreeTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/LayoutStateCreateTreeTest.java
@@ -452,6 +452,7 @@ public class LayoutStateCreateTreeTest {
                 .focusable(true)
                 .selected(false)
                 .enabled(false)
+                .accessibilityHeading(false)
                 .visibleHeightRatio(55)
                 .visibleWidthRatio(56)
                 .visibleHandler(visibleHandler)
@@ -561,6 +562,7 @@ public class LayoutStateCreateTreeTest {
     verify(nodeInfo).setEnabled(false);
     verify(node).visibleHeightRatio(55);
     verify(node).visibleWidthRatio(56);
+    verify(nodeInfo).setAccessibilityHeading(false);
 
     verify(node).visibleHandler(visibleHandler);
     verify(node).focusedHandler(focusedHandler);

--- a/litho-it/src/test/java/com/facebook/litho/NodeInfoTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/NodeInfoTest.java
@@ -16,6 +16,9 @@
 
 package com.facebook.litho;
 
+import static com.facebook.litho.NodeInfo.ACCESSIBILITY_HEADING_SET_FALSE;
+import static com.facebook.litho.NodeInfo.ACCESSIBILITY_HEADING_SET_TRUE;
+import static com.facebook.litho.NodeInfo.ACCESSIBILITY_HEADING_UNSET;
 import static com.facebook.litho.NodeInfo.ENABLED_SET_FALSE;
 import static com.facebook.litho.NodeInfo.ENABLED_SET_TRUE;
 import static com.facebook.litho.NodeInfo.ENABLED_UNSET;
@@ -89,6 +92,30 @@ public class NodeInfoTest {
 
     mNodeInfo.copyInto(mUpdatedNodeInfo);
     assertThat(interceptTouchHandler).isSameAs(mUpdatedNodeInfo.getInterceptTouchHandler());
+  }
+
+  @Test
+  public void testAccessibilityHeadingTrue() {
+    assertThat(mNodeInfo.getAccessibilityHeadingState()).isEqualTo(ACCESSIBILITY_HEADING_UNSET);
+    mNodeInfo.setAccessibilityHeading(true);
+
+    assertThat(mNodeInfo.getAccessibilityHeadingState()).isEqualTo(ACCESSIBILITY_HEADING_SET_TRUE);
+
+    mNodeInfo.copyInto(mUpdatedNodeInfo);
+    assertThat(mUpdatedNodeInfo.getAccessibilityHeadingState())
+        .isEqualTo(ACCESSIBILITY_HEADING_SET_TRUE);
+  }
+
+  @Test
+  public void testAccessibilityHeadingFalse() {
+    assertThat(mNodeInfo.getAccessibilityHeadingState()).isEqualTo(ACCESSIBILITY_HEADING_UNSET);
+    mNodeInfo.setAccessibilityHeading(false);
+
+    assertThat(mNodeInfo.getAccessibilityHeadingState()).isEqualTo(ACCESSIBILITY_HEADING_SET_FALSE);
+
+    mNodeInfo.copyInto(mUpdatedNodeInfo);
+    assertThat(mUpdatedNodeInfo.getAccessibilityHeadingState())
+        .isEqualTo(ACCESSIBILITY_HEADING_SET_FALSE);
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you taking the time to work on these 
changes. Please provide enough information so that others can review your pull request. The three 
fields below are mandatory. -->

## Summary
Add support for **Accessibility Headers** in Litho.
This will help the users to choose to “Navigate by Headings” and ignore scrolling through each and every sub items under a heading. “Navigate based on Heading“ can be chosen from Local Context Menu with talkback on ( Gesture for local context menu - Swipe up then right).
[ViewCompat](https://developer.android.com/reference/kotlin/androidx/core/view/ViewCompat?hl=en#setaccessibilityheading) and [AccessibilityNodeInfoCompat](https://developer.android.com/reference/android/support/v4/view/accessibility/AccessibilityNodeInfoCompat#setheading) have required API’s which can indicate that a view or corresponding accessibilityNode is an “Accessibility Heading” when talkback is enabled.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request 
solve? -->

## Changelog
Add support for **Accessibility Headers** in Litho.
<!-- Help reviewers and the release process by writing your own changelog entry. This should just be
a brief oneline we can mention in our release notes: https://github.com/facebook/litho/releases -->

## Test Plan
Verified locally by switching talkback on and navigate by headers. It works fine and no crash found.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, output of 
the test runner and how you invoked it (you've added tests, right?), screenshots/videos if the pull 
request changes UI. -->
