### PR TITLE
Use the injected treeProps for Layout PerfEvent

### DIFF
--- a/litho-core/src/main/java/com/facebook/litho/ComponentTree.java
+++ b/litho-core/src/main/java/com/facebook/litho/ComponentTree.java
@@ -1774,7 +1774,7 @@ public class ComponentTree {
     final PerfEvent layoutEvent =
         logger != null
             ? LogTreePopulator.populatePerfEventFromLogger(
-                mContext, logger, logger.newPerformanceEvent(mContext, EVENT_LAYOUT_CALCULATE))
+                mContext, treeProps, logger, logger.newPerformanceEvent(mContext, EVENT_LAYOUT_CALCULATE))
             : null;
 
     if (layoutEvent != null) {

--- a/litho-core/src/main/java/com/facebook/litho/LogTreePopulator.java
+++ b/litho-core/src/main/java/com/facebook/litho/LogTreePopulator.java
@@ -26,10 +26,26 @@ import javax.annotation.CheckReturnValue;
 public final class LogTreePopulator {
   private LogTreePopulator() {}
 
+    /**
+     * Annotate a log event with the log tag set in the context, and extract the treeprops from a
+     * given {@link ComponentContext} and convert them into perf event annotations using a {@link
+     * ComponentsLogger} implementation.
+     *
+     * @return Annotated perf event, or <code>null</code> if the resulting event isn't deemed worthy
+     *     of reporting.
+     */
+    @Nullable
+    @CheckReturnValue
+    public static PerfEvent populatePerfEventFromLogger(
+            ComponentContext c, ComponentsLogger logger, @Nullable PerfEvent perfEvent) {
+      return populatePerfEventFromLogger(c, c.getTreeProps(), logger, perfEvent);
+    }
+
   /**
    * Annotate a log event with the log tag set in the context, and extract the treeprops from a
-   * given {@link ComponentContext} and convert them into perf event annotations using a {@link
-   * ComponentsLogger} implementation.
+   * given {@link ComponentContext} or saved treeprops and convert them into perf event annotations
+   * using a {@link ComponentsLogger} implementation. If the treeprops of the given
+   * {@link ComponentContext} is null, the saved treeprops will be used.
    *
    * @return Annotated perf event, or <code>null</code> if the resulting event isn't deemed worthy
    *     of reporting.
@@ -37,7 +53,7 @@ public final class LogTreePopulator {
   @Nullable
   @CheckReturnValue
   public static PerfEvent populatePerfEventFromLogger(
-      ComponentContext c, ComponentsLogger logger, @Nullable PerfEvent perfEvent) {
+      ComponentContext c, @Nullable TreeProps savedTreeProps, ComponentsLogger logger, @Nullable PerfEvent perfEvent) {
     if (perfEvent == null) {
       return null;
     }
@@ -50,7 +66,7 @@ public final class LogTreePopulator {
 
     perfEvent.markerAnnotate(FrameworkLogEvents.PARAM_LOG_TAG, logTag);
 
-    @Nullable final TreeProps treeProps = c.getTreeProps();
+    @Nullable final TreeProps treeProps = c.getTreeProps() == null ? savedTreeProps : c.getTreeProps();
     if (treeProps == null) {
       return perfEvent;
     }

--- a/litho-core/src/main/java/com/facebook/litho/LogTreePopulator.java
+++ b/litho-core/src/main/java/com/facebook/litho/LogTreePopulator.java
@@ -38,14 +38,14 @@ public final class LogTreePopulator {
     @CheckReturnValue
     public static PerfEvent populatePerfEventFromLogger(
             ComponentContext c, ComponentsLogger logger, @Nullable PerfEvent perfEvent) {
-      return populatePerfEventFromLogger(c, c.getTreeProps(), logger, perfEvent);
+      return populatePerfEventFromLogger(c, null, logger, perfEvent);
     }
 
   /**
-   * Annotate a log event with the log tag set in the context, and extract the treeprops from a
-   * given {@link ComponentContext} or saved treeprops and convert them into perf event annotations
-   * using a {@link ComponentsLogger} implementation. If the treeprops of the given
-   * {@link ComponentContext} is null, the saved treeprops will be used.
+   * Annotate a log event with the log tag set in the context, and extract the treeprops from saved
+   * treeprops or a given {@link ComponentContext} and convert them into perf event annotations
+   * using a {@link ComponentsLogger} implementation. If the saved treeprops is null, the treeprops
+   * of the given {@link ComponentContext} will be used.
    *
    * @return Annotated perf event, or <code>null</code> if the resulting event isn't deemed worthy
    *     of reporting.
@@ -66,7 +66,7 @@ public final class LogTreePopulator {
 
     perfEvent.markerAnnotate(FrameworkLogEvents.PARAM_LOG_TAG, logTag);
 
-    @Nullable final TreeProps treeProps = c.getTreeProps() == null ? savedTreeProps : c.getTreeProps();
+    @Nullable final TreeProps treeProps = savedTreeProps == null ? c.getTreeProps() : savedTreeProps;
     if (treeProps == null) {
       return perfEvent;
     }


### PR DESCRIPTION
At the runtime, the ComponentContext's treeProps could be null. In this case, it would better to use the treeProps that provided by caller.