### PR TITLE
Change method name 'get' to 'getContentType', 'animate' to 'createTransition'

### DIFF
--- a/litho-core/src/main/java/com/facebook/litho/OutputUnitsAffinityGroup.java
+++ b/litho-core/src/main/java/com/facebook/litho/OutputUnitsAffinityGroup.java
@@ -64,7 +64,7 @@ public class OutputUnitsAffinityGroup<T> {
     }
   }
 
-  public T get(@OutputUnitType int type) {
+  public T getContentType(@OutputUnitType int type) {
     return (T) mContent[type];
   }
 
@@ -91,20 +91,20 @@ public class OutputUnitsAffinityGroup<T> {
   }
 
   public T getAt(int index) {
-    return get(typeAt(index));
+    return getContentType(typeAt(index));
   }
 
   public T getMostSignificantUnit() {
     if (mContent[OutputUnitType.HOST] != null) {
-      return get(OutputUnitType.HOST);
+      return getContentType(OutputUnitType.HOST);
     } else if (mContent[OutputUnitType.CONTENT] != null) {
-      return get(OutputUnitType.CONTENT);
+      return getContentType(OutputUnitType.CONTENT);
     } else if (mContent[OutputUnitType.BACKGROUND] != null) {
-      return get(OutputUnitType.BACKGROUND);
+      return getContentType(OutputUnitType.BACKGROUND);
     } else if (mContent[OutputUnitType.FOREGROUND] != null) {
-      return get(OutputUnitType.FOREGROUND);
+      return getContentType(OutputUnitType.FOREGROUND);
     } else {
-      return get(OutputUnitType.BORDER);
+      return getContentType(OutputUnitType.BORDER);
     }
   }
 

--- a/litho-core/src/main/java/com/facebook/litho/TransitionManager.java
+++ b/litho-core/src/main/java/com/facebook/litho/TransitionManager.java
@@ -311,7 +311,7 @@ public class TransitionManager {
       return;
     }
     final OutputUnitsAffinityGroup<Object> mountContentGroup = animationState.mountContentGroup;
-    if (mountContentGroup == null || mountContentGroup.get(type) == null) {
+    if (mountContentGroup == null || mountContentGroup.getContentType(type) == null) {
       return;
     }
 
@@ -752,7 +752,7 @@ public class TransitionManager {
   private void recursivelySetChildClippingForGroup(
       OutputUnitsAffinityGroup<Object> mountContentGroup, boolean clipChildren) {
     // We only need to set clipping to view containers (OutputUnitType.HOST)
-    recursivelySetChildClipping(mountContentGroup.get(OutputUnitType.HOST), clipChildren);
+    recursivelySetChildClipping(mountContentGroup.getContentType(OutputUnitType.HOST), clipChildren);
   }
 
   /**

--- a/litho-it/src/test/java/com/facebook/litho/OutputUnitsAffinityGroupTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/OutputUnitsAffinityGroupTest.java
@@ -33,11 +33,11 @@ public class OutputUnitsAffinityGroupTest {
     final OutputUnitsAffinityGroup<Object> group = new OutputUnitsAffinityGroup<>();
 
     assertThat(group.size()).isZero();
-    assertThat(group.get(OutputUnitType.CONTENT)).isNull();
-    assertThat(group.get(OutputUnitType.BACKGROUND)).isNull();
-    assertThat(group.get(OutputUnitType.FOREGROUND)).isNull();
-    assertThat(group.get(OutputUnitType.BORDER)).isNull();
-    assertThat(group.get(OutputUnitType.HOST)).isNull();
+    assertThat(group.getContentType(OutputUnitType.CONTENT)).isNull();
+    assertThat(group.getContentType(OutputUnitType.BACKGROUND)).isNull();
+    assertThat(group.getContentType(OutputUnitType.FOREGROUND)).isNull();
+    assertThat(group.getContentType(OutputUnitType.BORDER)).isNull();
+    assertThat(group.getContentType(OutputUnitType.HOST)).isNull();
   }
 
   @Test
@@ -48,7 +48,7 @@ public class OutputUnitsAffinityGroupTest {
     group.add(OutputUnitType.CONTENT, content);
 
     assertThat(group.size()).isEqualTo(1);
-    assertThat(group.get(OutputUnitType.CONTENT)).isSameAs(content);
+    assertThat(group.getContentType(OutputUnitType.CONTENT)).isSameAs(content);
     assertThat(group.typeAt(0)).isEqualTo(OutputUnitType.CONTENT);
     assertThat(group.getAt(0)).isSameAs(content);
 
@@ -56,8 +56,8 @@ public class OutputUnitsAffinityGroupTest {
     group.add(OutputUnitType.BACKGROUND, background);
 
     assertThat(group.size()).isEqualTo(2);
-    assertThat(group.get(OutputUnitType.CONTENT)).isSameAs(content);
-    assertThat(group.get(OutputUnitType.BACKGROUND)).isSameAs(background);
+    assertThat(group.getContentType(OutputUnitType.CONTENT)).isSameAs(content);
+    assertThat(group.getContentType(OutputUnitType.BACKGROUND)).isSameAs(background);
     final int type0 = group.typeAt(0);
     final int type1 = group.typeAt(1);
     assertThat(type0).isIn(OutputUnitType.CONTENT, OutputUnitType.BACKGROUND);
@@ -76,9 +76,9 @@ public class OutputUnitsAffinityGroupTest {
     final Object border = new Object();
     group.add(OutputUnitType.BORDER, border);
     assertThat(group.size()).isEqualTo(3);
-    assertThat(group.get(OutputUnitType.CONTENT)).isSameAs(content);
-    assertThat(group.get(OutputUnitType.BACKGROUND)).isSameAs(background);
-    assertThat(group.get(OutputUnitType.BORDER)).isSameAs(border);
+    assertThat(group.getContentType(OutputUnitType.CONTENT)).isSameAs(content);
+    assertThat(group.getContentType(OutputUnitType.BACKGROUND)).isSameAs(background);
+    assertThat(group.getContentType(OutputUnitType.BORDER)).isSameAs(border);
   }
 
   @Test

--- a/sample/src/main/java/com/facebook/samples/litho/animations/bounds/BoundsAnimationComponentSpec.java
+++ b/sample/src/main/java/com/facebook/samples/litho/animations/bounds/BoundsAnimationComponentSpec.java
@@ -264,7 +264,7 @@ public class BoundsAnimationComponentSpec {
   }
 
   @OnCreateTransition
-  static Transition animate(ComponentContext c, @State boolean autoBoundsTransitionEnabled) {
+  static Transition createTransition(ComponentContext c, @State boolean autoBoundsTransitionEnabled) {
     String[] transitionKeys =
         autoBoundsTransitionEnabled
             ? new String[] {


### PR DESCRIPTION
The class OutputUnitsAffinityGroup is used to represent OutputUnitsAffinityGroup.  This method named 'get' is to get element at the index type. Thus, the method name 'getContentType' is more intuitive than 'get'.

The class BoundsAnimationComponentSpec is used to represent BoundsAnimationComponentSpec.  This method named 'animate' is to create a transition for the animation. Thus, the method name 'createTransition' is more intuitive than 'animate'.