### PR TITLE
Use javax.lang.model APIs instead of javac implementation classes

### DIFF
--- a/litho-processor/src/main/java/com/facebook/litho/specmodels/processor/TestTargetExtractor.java
+++ b/litho-processor/src/main/java/com/facebook/litho/specmodels/processor/TestTargetExtractor.java
@@ -17,9 +17,9 @@
 package com.facebook.litho.specmodels.processor;
 
 import com.facebook.litho.annotations.TestSpec;
-import com.sun.tools.javac.code.Type;
 import javax.annotation.Nullable;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.MirroredTypeException;
 import javax.lang.model.type.TypeMirror;
 
@@ -31,7 +31,7 @@ public class TestTargetExtractor {
       element.getAnnotation(TestSpec.class).value();
     } catch (MirroredTypeException e) {
       final TypeMirror typeMirror = e.getTypeMirror();
-      return (TypeElement) ((Type.ClassType) typeMirror).asElement();
+      return (TypeElement) ((DeclaredType) typeMirror).asElement();
     }
 
     return null;


### PR DESCRIPTION
## Summary

`com.sun.tools.javac.code.Type.ClassType` is an internal javac API that should not be used in annotation processors, `javax.lang.model.type.DeclaredType` is the corresponding public interface.

## Test Plan

Existing tests.