### PR TITLE
Propagate isParentIncrementalMountDisabled flag when creating Section…

### DIFF
--- a/litho-core/src/main/java/com/facebook/litho/ComponentContext.java
+++ b/litho-core/src/main/java/com/facebook/litho/ComponentContext.java
@@ -508,7 +508,7 @@ public class ComponentContext {
     }
   }
 
-  boolean isParentIncrementalMountDisabled() {
+  public boolean isParentIncrementalMountDisabled() {
     return mIsParentIncrementalMountDisabled;
   }
 

--- a/litho-sections-core/src/main/java/com/facebook/litho/sections/SectionContext.java
+++ b/litho-sections-core/src/main/java/com/facebook/litho/sections/SectionContext.java
@@ -45,7 +45,8 @@ public class SectionContext extends ComponentContext {
         context.getAndroidContext(),
         context.getLogTag(),
         context.getLogger(),
-        context.getTreePropsCopy());
+        context.getTreePropsCopy(),
+        context.isParentIncrementalMountDisabled());
   }
 
   public SectionContext(Context context, @Nullable String logTag, ComponentsLogger logger) {
@@ -57,8 +58,16 @@ public class SectionContext extends ComponentContext {
       @Nullable String logTag,
       ComponentsLogger logger,
       @Nullable TreeProps treeProps) {
-    super(context, logTag, logger);
-    super.setTreeProps(treeProps);
+    this(context, logTag, logger, treeProps, false);
+  }
+
+  public SectionContext(
+      Context context,
+      @Nullable String logTag,
+      ComponentsLogger logger,
+      @Nullable TreeProps treeProps,
+      boolean isParentIncrementalMountDisabled) {
+    super(context, logTag, logger, null, null, treeProps, null, isParentIncrementalMountDisabled);
     mKeyHandler = new KeyHandler();
   }
 


### PR DESCRIPTION
…Context from ComponentContext

<!-- Thanks for submitting a pull request! We appreciate you taking the time to work on these 
changes. Please provide enough information so that others can review your pull request. The three 
fields below are mandatory. -->

## Summary

Commit https://github.com/facebook/litho/commit/c88a6605d8e77378e0ac89b267dcb260daddc6f4 introduced ComponentContext.isParentIncrementalMountDisabled flag to "only enable incremental mount if parent incremental mount is enabled". 

However, this doesn't work for any SectionSpec, because when the SectionContext is created from a ComponentContext, it doesn't propagate the isParentIncrementalMountDisabled flag forward.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be
a brief oneline we can mention in our release notes: https://github.com/facebook/litho/releases -->

Propagate isParentIncrementalMountDisabled flag when creating SessionContext from ComponentContext

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, output of 
the test runner and how you invoked it (you've added tests, right?), screenshots/videos if the pull 
request changes UI. -->

Existing tests.