### PR TITLE
Fix javac-tools buck fetch error

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -1,6 +1,6 @@
 [maven_repositories]
   jcenter = https://jcenter.bintray.com/
-  nuiton = http://maven.nuiton.org/release/
+  nuiton = https://nexus.nuiton.org/nexus/content/groups/releases/
   central = https://repo1.maven.org/maven2/
   google = https://maven.google.com/
 


### PR DESCRIPTION
Summary: Apparently nuition repo url has changed, it was redirecting (HTTP 303) but `buck fetch` couldn't follow redirect.

Reviewed By: colriot

Differential Revision: D18504380

