### PR TITLE
Exclude Kotlin modules from OSS CI build to unblock CI checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,8 @@ aliases:
     name: Buck Dependencies
     command: |
       cd workspace/repo
-      $HOME/litho-working-dir/workspace/buck/bin/buck fetch //...
+      # $HOME/litho-working-dir/workspace/buck/bin/buck fetch //... # explicitly exclude Kotlin modules until OSS BUCK config will be fixed
+      $HOME/litho-working-dir/workspace/buck/bin/buck fetch //:components sample sample-barebones sample-codelab litho-it/... litho-it-powermock/...
 
   # Save Litho BUCK test results
   - &save-litho-buck-tests-results
@@ -174,7 +175,8 @@ commands:
           name: Build <<parameters.module_name>> with BUCK
           command: |
             cd workspace/repo
-            buck fetch //...
+            # buck fetch //... # explicitly exclude Kotlin modules until OSS BUCK config will be fixed
+            buck fetch //:components sample sample-barebones sample-codelab litho-it/... litho-it-powermock/...
             buck build <<parameters.module_name>> --num-threads=4
   
   gradle_build:
@@ -201,7 +203,8 @@ commands:
           name: Run <<parameters.module_name>> tests with BUCK
           command: |
             cd workspace/repo
-            buck fetch //...
+            # buck fetch //... # explicitly exclude Kotlin modules until OSS BUCK config will be fixed
+            buck fetch //:components sample sample-barebones sample-codelab litho-it/... litho-it-powermock/...
             buck test <<parameters.module_name>>/src/test/... --num-threads=4 --xml <<parameters.module_name>>_tests.xml
       - run: *save-litho-buck-tests-results
       - *store_litho_tests_results


### PR DESCRIPTION
Summary: Kotlin modules need a proper setup for Kotlin libs & compiler, which not an obvious and quick task. So, we need to make sure that CI is working until that time.

Differential Revision: D18527832

