### PR TITLE
Provide maven repo url override for Robolectric to fix OSS CI

### DIFF
--- a/litho-core-kotlin/src/main/kotlin/com/facebook/litho/Base.kt
+++ b/litho-core-kotlin/src/main/kotlin/com/facebook/litho/Base.kt
@@ -18,12 +18,16 @@ package com.facebook.litho
 
 import android.app.Activity
 
-typealias DslScope = ComponentContext
+class DslScope(c: ComponentContext) {
+  val context = c
+  val androidContext = c.androidContext
+  val resourceResolver = c.resourceResolver
+}
 
 inline fun build(
     c: ComponentContext,
     content: DslScope.() -> Component?
-): Component? = c.content()
+): Component? = DslScope(c).content()
 
 fun Activity.setContent(component: Component) {
   setContentView(LithoView.create(this, component))

--- a/litho-core-kotlin/src/main/kotlin/com/facebook/litho/Container.kt
+++ b/litho-core-kotlin/src/main/kotlin/com/facebook/litho/Container.kt
@@ -30,7 +30,7 @@ inline fun DslScope.Column(
     reverse: Boolean = false,
     content: DslColumnBuilder.() -> Unit = {}
 ): Column =
-    DslColumnBuilder(this).apply {
+    DslColumnBuilder(context).apply {
       alignContent(alignContent)
       alignItems(alignItems)
       justifyContent(justifyContent)
@@ -47,7 +47,7 @@ inline fun DslScope.Row(
     reverse: Boolean = false,
     content: DslRowBuilder.() -> Unit = {}
 ): Row =
-    DslRowBuilder(this).apply {
+    DslRowBuilder(context).apply {
       alignContent(alignContent)
       alignItems(alignItems)
       justifyContent(justifyContent)

--- a/litho-core-kotlin/src/main/kotlin/com/facebook/litho/KComponent.kt
+++ b/litho-core-kotlin/src/main/kotlin/com/facebook/litho/KComponent.kt
@@ -21,6 +21,6 @@ open class KComponent(
     private val content: DslScope.() -> Component?
 ) : Component() {
   override fun onCreateLayout(c: ComponentContext): Component? {
-    return c.content()
+    return DslScope(c).content()
   }
 }

--- a/litho-core-kotlin/src/main/kotlin/com/facebook/litho/KState.kt
+++ b/litho-core-kotlin/src/main/kotlin/com/facebook/litho/KState.kt
@@ -26,7 +26,7 @@ import kotlin.reflect.KProperty
  * trigger a UI layout only once per batch.
  */
 fun <T> DslScope.useState(initializer: () -> T): StateDelegate<T> =
-    StateDelegate(this, initializer)
+    StateDelegate(context, initializer)
 
 /** Delegate to access and initialize a state variable. */
 class StateDelegate<T>(private val c: ComponentContext, private val initializer: () -> T) {
@@ -66,7 +66,7 @@ class StateUpdater(private val stateHandler: StateHandler) {
  * Assignments to the state variables, created by [useState], are only allowed inside this block.
  */
 fun DslScope.updateState(block: StateUpdater.() -> Unit) {
-  this.updateHookStateAsync { stateHandler: StateHandler ->
+  context.updateHookStateAsync { stateHandler: StateHandler ->
     StateUpdater(stateHandler).block()
   }
 }

--- a/litho-fresco-kotlin/src/main/kotlin/com/facebook/litho/fresco/FrescoImage.kt
+++ b/litho-fresco-kotlin/src/main/kotlin/com/facebook/litho/fresco/FrescoImage.kt
@@ -27,7 +27,7 @@ inline fun DslScope.FrescoImage(
     controller: DraweeController,
     imageAspectRatio: Float
 ): FrescoImage =
-    FrescoImage.create(this)
+    FrescoImage.create(context)
         .controller(controller)
         .imageAspectRatio(imageAspectRatio)
         .build()

--- a/litho-it/build.gradle
+++ b/litho-it/build.gradle
@@ -40,6 +40,8 @@ android {
 
     testOptions {
         unitTests.all {
+            systemProperty 'robolectric.dependency.repo.url', 'https://repo1.maven.org/maven2'
+
             jvmArgs '-Dcom.facebook.litho.is_oss=true'
             testLogging {
                 events "passed", "skipped", "failed", "standardOut", "standardError"

--- a/litho-widget-kotlin/src/main/kotlin/com/facebook/litho/widget/Card.kt
+++ b/litho-widget-kotlin/src/main/kotlin/com/facebook/litho/widget/Card.kt
@@ -41,7 +41,7 @@ inline fun DslScope.Card(
     disableClipBottomRight: Boolean = false,
     child: DslScope.() -> Component.Builder<*>
 ): Card =
-    Card.create(this)
+    Card.create(context)
         .cardBackgroundColor(cardBackgroundColor)
         .cornerRadiusDip(cornerRadius.value)
         .elevationDip(elevation.value)

--- a/litho-widget-kotlin/src/main/kotlin/com/facebook/litho/widget/Image.kt
+++ b/litho-widget-kotlin/src/main/kotlin/com/facebook/litho/widget/Image.kt
@@ -28,7 +28,7 @@ inline fun DslScope.Image(
     drawable: Drawable,
     scaleType: ScaleType = ScaleType.FIT_CENTER
 ): Image =
-    Image.create(this)
+    Image.create(context)
         .drawable(drawable)
         .scaleType(scaleType)
         .build()

--- a/litho-widget-kotlin/src/main/kotlin/com/facebook/litho/widget/Progress.kt
+++ b/litho-widget-kotlin/src/main/kotlin/com/facebook/litho/widget/Progress.kt
@@ -28,7 +28,7 @@ inline fun DslScope.Progress(
     @ColorInt color: Int,
     indeterminateDrawable: Drawable? = null
 ): Progress =
-    Progress.create(this)
+    Progress.create(context)
         .color(color)
         .indeterminateDrawable(indeterminateDrawable)
         .build()

--- a/litho-widget-kotlin/src/main/kotlin/com/facebook/litho/widget/Text.kt
+++ b/litho-widget-kotlin/src/main/kotlin/com/facebook/litho/widget/Text.kt
@@ -34,7 +34,7 @@ inline fun DslScope.Text(
     @ColorInt textColor: Int = Color.BLACK,
     textStyle: Int = NORMAL
 ): Text =
-    Text.create(this)
+    Text.create(context)
         .text(text)
         .textSizeSp(textSize.value)
         .textColor(textColor)

--- a/sample-kotlin/src/main/kotlin/com/facebook/samples/litho/kotlin/lithography/components/FeedItemCard.kt
+++ b/sample-kotlin/src/main/kotlin/com/facebook/samples/litho/kotlin/lithography/components/FeedItemCard.kt
@@ -27,7 +27,7 @@ class FeedItemCard(artist: Artist) : KComponent({
   Padding(horizontal = 16.dp, vertical = 8.dp) {
     Column {
       +Card {
-        FeedItemComponent.create(this).artist(artist)
+        FeedItemComponent.create(context).artist(artist)
       }
     }
   }

--- a/sample-kotlin/src/main/kotlin/com/facebook/samples/litho/kotlin/lithography/components/FeedItemComponentSpec.kt
+++ b/sample-kotlin/src/main/kotlin/com/facebook/samples/litho/kotlin/lithography/components/FeedItemComponentSpec.kt
@@ -76,16 +76,16 @@ object FeedItemComponentSpec {
       }
 
   private fun DslScope.imageRecycler(artist: Artist): Component.Builder<*> =
-      RecyclerCollectionComponent.create(this)
+      RecyclerCollectionComponent.create(context)
           .recyclerConfiguration(recyclerConfiguration)
           .section(
-              ImagesSection.create(SectionContext(this))
+              ImagesSection.create(SectionContext(context))
                   .images(artist.images)
                   .build())
           .aspectRatio(2f)
 
   private fun DslScope.singleImage(artist: Artist): Component.Builder<*> =
-      SingleImageComponent.create(this)
+      SingleImageComponent.create(context)
           .imageUri(artist.images[0])
           .imageAspectRatio(2f)
 }


### PR DESCRIPTION
Summary:
On Jan 15, 2020 Maven doesn't support unsecure HTTP communication. More context: https://support.sonatype.com/hc/en-us/articles/360041287334-Central-501-HTTPS-Required
As a consequence this fails the build on CI when Robolectric tries to fetch its deps via 'http://repo1.maven.org/maven2'. This diff uses Robolectric's system prop to override default repo url.

Differential Revision: D19949460

