### PR TITLE
Upgrade Litho tests to Robolectric 3.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ ext.deps = [
         inferAnnotations   : 'com.facebook.infer.annotation:infer-annotation:0.17.0',
         // Debugging and testing
         guava              : 'com.google.guava:guava:20.0',
-        robolectric        : 'org.robolectric:robolectric:3.0',
+        robolectric        : 'org.robolectric:robolectric:3.8',
         junit              : 'junit:junit:4.12',
         hamcrestLibrary    : 'org.hamcrest:hamcrest-library:1.3',
         powermockMockito   : 'org.powermock:powermock-api-mockito:1.5.6',

--- a/litho-it-powermock/build.gradle
+++ b/litho-it-powermock/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     testImplementation deps.assertjCore
     testImplementation deps.guava
     testImplementation deps.inferAnnotations
+    testImplementation deps.junit
     testImplementation deps.powermockJunit
     testImplementation deps.powermockMockito
     testImplementation deps.powermockXstream

--- a/litho-it-spec/build.gradle
+++ b/litho-it-spec/build.gradle
@@ -58,6 +58,7 @@ dependencies {
 
     // Testing deps
     testImplementation deps.assertjCore
+    testImplementation deps.junit
     testImplementation deps.robolectric
 }
 

--- a/litho-it/build.gradle
+++ b/litho-it/build.gradle
@@ -40,6 +40,8 @@ android {
 
     testOptions {
         unitTests.all {
+            systemProperty 'robolectric.dependency.repo.url', 'https://repo1.maven.org/maven2'
+
             jvmArgs '-Dcom.facebook.litho.is_oss=true'
             testLogging {
                 events "passed", "skipped", "failed", "standardOut", "standardError"

--- a/litho-it/src/test/java/com/facebook/litho/ComponentsPoolsTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/ComponentsPoolsTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.util.ActivityController;
+import org.robolectric.android.controller.ActivityController;
 
 @RunWith(ComponentsTestRunner.class)
 public class ComponentsPoolsTest {

--- a/litho-testing/src/main/java/com/facebook/litho/testing/shadows/ColorDrawableShadow.java
+++ b/litho-testing/src/main/java/com/facebook/litho/testing/shadows/ColorDrawableShadow.java
@@ -16,7 +16,7 @@
 
 package com.facebook.litho.testing.shadows;
 
-import static org.robolectric.internal.Shadow.directlyOn;
+import static org.robolectric.shadow.api.Shadow.directlyOn;
 
 import android.graphics.Canvas;
 import android.graphics.ColorFilter;

--- a/litho-testing/src/main/java/com/facebook/litho/testing/testrunner/ComponentsTestRunner.java
+++ b/litho-testing/src/main/java/com/facebook/litho/testing/testrunner/ComponentsTestRunner.java
@@ -96,11 +96,8 @@ public class ComponentsTestRunner extends RobolectricTestRunner {
     final Config config = super.getConfig(method);
     // We are hard-coding the path here instead of relying on BUCK internals
     // to allow for building with gradle in the Open Source version.
-    return new Config.Implementation(config) {
-      @Override
-      public String manifest() {
-        return getResPrefix() + "AndroidManifest.xml";
-      }
-    };
+    return new Config.Implementation.Builder(config)
+        .setManifest(getResPrefix() + "AndroidManifest.xml")
+        .build();
   }
 }


### PR DESCRIPTION
Summary: To support `robolectric.dependency.repo.url` prop for overriding Maven Repo (to fix Circle CI) we need Robolectric of version 3.1+.

Differential Revision: D19949477

