### PR TITLE
Replace a commented out @Test with @Test @Ignore

### DIFF
--- a/litho-it/src/test/java/com/facebook/litho/ComponentTreeTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/ComponentTreeTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
@@ -775,7 +776,8 @@ public class ComponentTreeTest {
   }
 
   // TODO(T37885964): Fix me
-  // @Test
+  @Test
+  @Ignore
   public void testCreateOneLayoutStateFuture() {
     MyTestComponent root1 = new MyTestComponent("MyTestComponent");
     root1.testId = 1;


### PR DESCRIPTION
Omitting @test looks like a test that someone forgot to annotate and triggers an ErrorProne check; @ignore is the canonical way to skip a failing test temporarily.

Resubmitting https://github.com/facebook/litho/pull/629 on behalf of @graememorgan