### PR TITLE
Fix typo "Compnent" -> "Component" in trigger-events page

### DIFF
--- a/docs/_docs/trigger-events.md
+++ b/docs/_docs/trigger-events.md
@@ -62,7 +62,7 @@ Create a trigger for your event inside your spec using the `@OnTrigger` annotati
 
 ```java
 @LayoutSpec
-public class CompnentWithCustomEventTriggerComponentSpec {
+public class ComponentWithCustomEventTriggerComponentSpec {
 
   ...
 
@@ -87,13 +87,13 @@ public class CustomEventTriggerExampleComponentSpec {
             Text.create(c)
                 .text("Trigger custom event")
                 .clickHandler(CustomEventTriggerExampleComponent.onClick(c, textInputHandle)))
-        .child(CompnentWithCustomEventTriggerComponent.create(c).handle(textInputHandle))
+        .child(ComponentWithCustomEventTriggerComponent.create(c).handle(textInputHandle))
         .build();
   }
 
   @OnEvent(ClickEvent.class)
   static void onClick(ComponentContext c, @Param Handle textInputHandle) {
-    CompnentWithCustomEventTriggerComponent.triggerCustomEvent(c, textInputHandle, 2);
+    ComponentWithCustomEventTriggerComponent.triggerCustomEvent(c, textInputHandle, 2);
   }
 }
 ```


### PR DESCRIPTION
Just a normal typo :)

<!-- Thanks for submitting a pull request! We appreciate you taking the time to work on these 
changes. Please provide enough information so that others can review your pull request. The three 
fields below are mandatory. -->

## Summary
Fixes a typo in the code example sections. This is not functional and does not exactly solve any existing problems, but improves the overall readability and public perception of Litho.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request 
solve? -->

## Changelog
Fix typo in trigger-events page

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be
a brief oneline we can mention in our release notes: https://github.com/facebook/litho/releases -->

## Test Plan
![image](https://user-images.githubusercontent.com/8211157/80455590-e7216a00-88e0-11ea-951e-b61b7a3a8c06.png)
No typos!
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, output of 
the test runner and how you invoked it (you've added tests, right?), screenshots/videos if the pull 
request changes UI. -->
