### PR TITLE
Typo fix in class name.

### DIFF
--- a/docs/_docs/sections-building-blocks.md
+++ b/docs/_docs/sections-building-blocks.md
@@ -114,7 +114,7 @@ The Sections hierarchy becomes a “data source” for the `RecyclerCollectionCo
 
 ```java
 final Component listComponent = RecyclerCollectionComponent.create(c)
-    .section(MyGroupSection.create(new SectionContent(c))
+    .section(MyGroupSection.create(new SectionContext(c))
         .dataModel(...)
         .build())
     .build();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you taking the time to work on these 
changes. Please provide enough information so that others can review your pull request. The three 
fields below are mandatory. -->

## Summary

Typo fix in class name. The correct class name here is `SectionContext` and not SectionContent.

## Changelog

SectionContent -> SectionContext

## Test Plan

Verified in PlaygroundActivity and buck build.