### PR TITLE
Fixing the issue : Vertical scrollbar isn't shown with verticalScrollSpec

### DIFF
--- a/litho-widget/src/main/java/com/facebook/litho/widget/LithoScrollView.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/LithoScrollView.java
@@ -1,0 +1,123 @@
+package com.facebook.litho.widget;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+import android.view.ViewTreeObserver;
+import androidx.annotation.Nullable;
+import androidx.core.widget.NestedScrollView;
+import androidx.recyclerview.widget.RecyclerView;
+import com.facebook.litho.ComponentTree;
+import com.facebook.litho.LithoView;
+import com.facebook.litho.widget.VerticalScrollSpec.OnInterceptTouchListener;
+import com.facebook.litho.widget.VerticalScrollSpec.ScrollPosition;
+
+
+/**
+ * Extension of {@link NestedScrollView} that allows to add more features needed for @{@link
+ * VerticalScrollSpec}.
+ */
+
+public class LithoScrollView extends NestedScrollView {
+
+  private final LithoView mLithoView;
+
+  @Nullable
+  private ScrollPosition mScrollPosition;
+  @Nullable
+  private ViewTreeObserver.OnPreDrawListener mOnPreDrawListener;
+  @Nullable
+  private OnInterceptTouchListener mOnInterceptTouchListener;
+  private boolean mIsIncrementalMountEnabled;
+
+  public LithoScrollView(Context context) {
+    this(context, null);
+  }
+
+  public LithoScrollView(Context context, @Nullable AttributeSet attrs) {
+    this(context, attrs, 0);
+
+  }
+
+  public LithoScrollView(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+    mLithoView = new LithoView(context);
+    addView(mLithoView);
+  }
+
+
+  @Override
+  public boolean onInterceptTouchEvent(MotionEvent ev) {
+    boolean result = false;
+    if (mOnInterceptTouchListener != null) {
+      result = mOnInterceptTouchListener.onInterceptTouch(this, ev);
+    }
+    if (!result && super.onInterceptTouchEvent(ev)) {
+      result = true;
+    }
+    return result;
+  }
+
+  @Override
+  protected void onScrollChanged(int l, int t, int oldl, int oldt) {
+    super.onScrollChanged(l, t, oldl, oldt);
+
+    if (mIsIncrementalMountEnabled) {
+      mLithoView.notifyVisibleBoundsChanged();
+    }
+
+    if (mScrollPosition != null) {
+      mScrollPosition.y = getScrollY();
+    }
+  }
+
+  /**
+   * NestedScrollView does not automatically consume the fling event. However, RecyclerView consumes
+   * this event if it's either vertically or horizontally scrolling. {@link RecyclerView#fling}
+   * Since this view is specifically made for vertically scrolling components, we always consume the
+   * nested fling event just like recycler view.
+   */
+  @Override
+  public boolean dispatchNestedFling(float velocityX, float velocityY, boolean consumed) {
+    return super.dispatchNestedFling(velocityX, velocityY, true);
+  }
+
+  public void setOnInterceptTouchListener(
+      @Nullable OnInterceptTouchListener onInterceptTouchListener) {
+    mOnInterceptTouchListener = onInterceptTouchListener;
+  }
+
+  void mount(
+      ComponentTree contentComponentTree,
+      final ScrollPosition scrollPosition,
+      boolean isIncrementalMountEnabled) {
+    mLithoView.setComponentTree(contentComponentTree);
+
+    mIsIncrementalMountEnabled = isIncrementalMountEnabled;
+    mScrollPosition = scrollPosition;
+    final ViewTreeObserver.OnPreDrawListener onPreDrawListener =
+        new ViewTreeObserver.OnPreDrawListener() {
+          @Override
+          public boolean onPreDraw() {
+            setScrollY(scrollPosition.y);
+            ViewTreeObserver currentViewTreeObserver = getViewTreeObserver();
+            if (currentViewTreeObserver.isAlive()) {
+              currentViewTreeObserver.removeOnPreDrawListener(this);
+            }
+            return true;
+          }
+        };
+    getViewTreeObserver().addOnPreDrawListener(onPreDrawListener);
+
+    mOnPreDrawListener = onPreDrawListener;
+  }
+
+  void unmount() {
+    mLithoView.setComponentTree(null);
+
+    mScrollPosition = null;
+    getViewTreeObserver().removeOnPreDrawListener(mOnPreDrawListener);
+    mOnPreDrawListener = null;
+  }
+}
+

--- a/litho-widget/src/main/res/layout/litho_scroll_view.xml
+++ b/litho-widget/src/main/res/layout/litho_scroll_view.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.facebook.litho.widget.LithoScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_height="0dp"
+    android:layout_width="0dp"
+    android:scrollbars="vertical">
+</com.facebook.litho.widget.LithoScrollView>
+


### PR DESCRIPTION
Fixing the issue : Vertical scrollbar isn't shown with verticalScrollSpec.

The issue is with NestedScrollView when used programatically doesn't initialize scrollBars.
NestedScrollView when used in xml initializes scrollbars.


## Summary

We observed an issue where vertical scrollbar is not shown with [VerticalScrollSpec](https://github.com/facebook/litho/blob/master/litho-widget/src/main/java/com/facebook/litho/widget/VerticalScrollSpec.java) even though [scrollbarEnabled defaults to true](https://github.com/facebook/litho/blob/master/litho-widget/src/main/java/com/facebook/litho/widget/VerticalScrollSpec.java#L237). Since [VerticalScrollSpec subclasses](https://github.com/facebook/litho/blob/master/litho-widget/src/main/java/com/facebook/litho/widget/VerticalScrollSpec.java#L250) the android’s native NestedScrollView , I tried lithoScrollView.getVerticalScrollbarThumbDrawable() and this returns null which indicates that scrollbar drawable is not set.



I started with using a [NestedScrollView](https://developer.android.com/reference/androidx/core/widget/NestedScrollView) in a native Android application (target-sdk = API level 28). 
If we use NestedScrollView via layout xml and vertical scrollbar can be enabled in 2 ways
 * android:scrollbars="vertical" - scrollbar shows up
 * Programatically in the activity NestedScrollView.setVerticalScrollBarEnabled(true); - scrollbar doesn’t show up

Debugging further, I found the [initializeScrollbars()](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/core/java/android/view/View.java#6509) in View class. As mentioned in the comments “This method should be called by subclasses that need scrollbars and when an instance of these subclasses is created programmatically rather than being inflated from XML. This method is automatically called when the XML is inflated.”. But this method is annotated with @Removed and this annotation was added in API level 21.
So after discussions with Litho team, implementing the xml way and inflating the LithoScrollView.

## Changelog

LithoScrollView to be inflated via xml .

## Test Plan

I tested VerticalScrollSpec in the sample playground and can see the vertical scrollbar now.
```
@LayoutSpec
public class PlaygroundComponentSpec {

  @OnCreateLayout
  static Component onCreateLayout(ComponentContext c) {
    return VerticalScroll.create(c).widthDip(100).heightDip(100).clipChildren(false)
        .backgroundColor(Color.RED).scrollbarEnabled(true)
        .childComponent(

            Column.create(c).child(Text.create(c).textSizeSp(40).text("Hello sample").widthDip(50).heightDip(50)).
                child(Row.create(c).backgroundColor(0xff00ff00).widthDip(100).heightDip(100))
          )

        .build();
  }
}
```