### PR TITLE
Use Collections.emptyList() over EMPTY_LIST to avoid untyped cast

### DIFF
--- a/litho-it/src/test/java/com/facebook/litho/specmodels/generator/ComponentBodyGeneratorTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/specmodels/generator/ComponentBodyGeneratorTest.java
@@ -276,7 +276,7 @@ public class ComponentBodyGeneratorTest {
                 + "@com.facebook.litho.annotations.Comparable(\n"
                 + "    type = 5\n"
                 + ")\n"
-                + "java.util.List<? extends java.lang.Number> arg9 = (java.util.List<? extends java.lang.Number>) java.util.Collections.EMPTY_LIST;\n");
+                + "java.util.List<? extends java.lang.Number> arg9 = java.util.Collections.emptyList();\n");
 
     dataHolder = ComponentBodyGenerator.generateProps(mMountSpecModelDI, RunMode.normal());
     assertThat(dataHolder.getFieldSpecs()).hasSize(6);
@@ -344,7 +344,7 @@ public class ComponentBodyGeneratorTest {
                 + "@com.facebook.litho.annotations.Comparable(\n"
                 + "    type = 5\n"
                 + ")\n"
-                + "java.util.List<java.lang.Number> numbers = (java.util.List<java.lang.Number>) java.util.Collections.EMPTY_LIST;\n");
+                + "java.util.List<java.lang.Number> numbers = java.util.Collections.emptyList();\n");
   }
 
   @Test

--- a/litho-processor/src/main/java/com/facebook/litho/specmodels/generator/ComponentBodyGenerator.java
+++ b/litho-processor/src/main/java/com/facebook/litho/specmodels/generator/ComponentBodyGenerator.java
@@ -249,7 +249,7 @@ public class ComponentBodyGenerator {
         assignInitializer(fieldBuilder, specModel, prop);
       } else if (prop.hasVarArgs()) {
         fieldBuilder.initializer(
-            "($T) $T.EMPTY_LIST", propFieldTypeName, ClassName.get(Collections.class));
+            "$T.emptyList()", ClassName.get(Collections.class));
       }
 
       FieldSpec field = fieldBuilder.build();


### PR DESCRIPTION
Causes a compiler warning (which errors with `-Werror`)