### PR TITLE
Assign test_ownership_2020 as owner for unowned robolectric tests in fbandroid

### DIFF
--- a/litho-it/src/test/java/com/facebook/litho/testing/subcomponents/BUCK
+++ b/litho-it/src/test/java/com/facebook/litho/testing/subcomponents/BUCK
@@ -23,6 +23,7 @@ load(
 litho_robolectric4_test(
     name = "testing",
     srcs = glob(["*Test.java"]),
+    contacts = ["oncall+test_ownership_2020@xmail.facebook.com"],
     provided_deps = [
         LITHO_ROBOLECTRIC_V4_TARGET,
     ],


### PR DESCRIPTION
Summary: Changelog: [Internal]

Reviewed By: IanChilds

Differential Revision: D22882186

