### PR TITLE
Add Opacity Configuration

### DIFF
--- a/litho-core-kotlin/src/main/kotlin/com/facebook/litho/Resources.kt
+++ b/litho-core-kotlin/src/main/kotlin/com/facebook/litho/Resources.kt
@@ -16,6 +16,7 @@
 
 package com.facebook.litho
 
+import android.graphics.Color
 import android.graphics.drawable.Drawable
 import androidx.annotation.AttrRes
 import androidx.annotation.ColorInt
@@ -73,11 +74,18 @@ fun DslScope.drawableAttr(@AttrRes id: Int, @DrawableRes defResId: Int = 0): Dra
     drawableRes(resourceResolver.resolveResIdAttr(id, defResId))
 
 /**
- * Return a [android.graphics.drawable.Drawable] for a [ColorInt] value as a [Drawable]
+ * Return a [android.graphics.drawable.Drawable] for a [String] hex color value as a [Drawable]
  * instance.
  */
-fun DslScope.drawableColor(@ColorInt color: Int): Drawable =
-    ComparableColorDrawable.create(color)
+fun DslScope.drawableColor(hexColor: String): Drawable =
+        ComparableColorDrawable.create(Color.parseColor("#$hexColor"))
+
+/**
+ * Return a [android.graphics.drawable.Drawable] for a [String] hex color value as a [Drawable]
+ * instance.
+ */
+fun DslScope.drawableColor(hexColor: String, opacity: Opacity): Drawable =
+        ComparableColorDrawable.create(Color.parseColor("#${opacity.percent}$hexColor"))
 
 /**
  * Return a [android.graphics.drawable.Drawable] for a [ColorInt] value as a [Drawable]

--- a/litho-core-kotlin/src/main/kotlin/com/facebook/litho/Style.kt
+++ b/litho-core-kotlin/src/main/kotlin/com/facebook/litho/Style.kt
@@ -221,3 +221,35 @@ fun positionRelative(start: Dp? = null, top: Dp? = null, end: Dp? = null, bottom
         positionEnd = end,
         positionBottom = bottom,
         positionType = YogaPositionType.RELATIVE)
+
+class Opacity(value: String) {
+
+  var percent = value
+
+  companion object {
+    /**
+     * Used to assign the value of opacity
+     */
+    val _100 = Opacity("FF")
+    val _95 = Opacity("F2")
+    val _90 = Opacity("E6")
+    val _85 = Opacity("D9")
+    val _80 = Opacity("CC")
+    val _75 = Opacity("BF")
+    val _70 = Opacity("B3")
+    val _65 = Opacity("A6")
+    val _60 = Opacity("99")
+    val _55 = Opacity("8C")
+    val _50 = Opacity("80")
+    val _45 = Opacity("73")
+    val _40 = Opacity("66")
+    val _35 = Opacity("59")
+    val _30 = Opacity("4D")
+    val _25 = Opacity("40")
+    val _20 = Opacity("33")
+    val _15 = Opacity("26")
+    val _10 = Opacity("1A")
+    val _5 = Opacity("0D")
+    val _0 = Opacity("00")
+  }
+}

--- a/sample-kotlin/src/main/kotlin/com/facebook/samples/litho/kotlin/lithography/components/ActionsComponent.kt
+++ b/sample-kotlin/src/main/kotlin/com/facebook/samples/litho/kotlin/lithography/components/ActionsComponent.kt
@@ -29,7 +29,7 @@ import com.facebook.litho.padding
 class ActionsComponent(style: Style) : KComponent(style) {
 
   override fun DslScope.render(): Component? {
-    return Decoration(background = drawableColor(0xddffffff)) {
+    return Decoration(background = drawableColor("ffffff")) {
       Row(style = padding(2.dp)) {
         +FavouriteButton()
       }

--- a/sample-kotlin/src/main/kotlin/com/facebook/samples/litho/kotlin/lithography/components/DecadeSeparator.kt
+++ b/sample-kotlin/src/main/kotlin/com/facebook/samples/litho/kotlin/lithography/components/DecadeSeparator.kt
@@ -32,9 +32,9 @@ import com.facebook.samples.litho.kotlin.lithography.data.Decade
 import com.facebook.yoga.YogaAlign.CENTER
 
 class DecadeSeparator(decade: Decade) : KComponent({
-  Decoration(background = drawableColor(0xFFFAFAFA)) {
+  Decoration(background = drawableColor("FAFAFA")) {
     Row(alignItems = CENTER, style = padding(16.dp)) {
-      +Decoration(background = drawableColor(0xFFAAAAAA)) {
+      +Decoration(background = drawableColor("AAAAAA")) {
         Row(style = size(height = Dp.Hairline) + flex(grow = 1f))
       }
 
@@ -44,7 +44,7 @@ class DecadeSeparator(decade: Decade) : KComponent({
           textColor = 0xFFAAAAAA.toInt(),
           style = margin(horizontal = 10.dp) + flex(shrink = 0f))
 
-      +Decoration(background = drawableColor(0xFFAAAAAA)) {
+      +Decoration(background = drawableColor("AAAAAA")) {
         Row(style = size(height = Dp.Hairline) + flex(grow = 1f))
       }
     }

--- a/sample-kotlin/src/main/kotlin/com/facebook/samples/litho/kotlin/lithography/components/FeedItemComponent.kt
+++ b/sample-kotlin/src/main/kotlin/com/facebook/samples/litho/kotlin/lithography/components/FeedItemComponent.kt
@@ -27,6 +27,7 @@ import com.facebook.litho.dp
 import com.facebook.litho.drawableColor
 import com.facebook.litho.padding
 import com.facebook.litho.position
+import com.facebook.litho.Opacity
 import com.facebook.litho.sections.SectionContext
 import com.facebook.litho.sections.widget.ListRecyclerConfiguration
 import com.facebook.litho.sections.widget.RecyclerCollectionComponent
@@ -40,7 +41,7 @@ class FeedItemComponent(artist: Artist) : KComponent({
   Column {
     +Column {
       +imageBlock(artist)
-      +Decoration(background = drawableColor(0xddffffff)) {
+      +Decoration(background = drawableColor("ffffff", Opacity._50)) {
         Text(
             text = artist.name,
             style = position(start = 4.dp, bottom = 4.dp) + padding(horizontal = 6.dp),


### PR DESCRIPTION
## Summary
Hi, I'm trying to improve this Open Source by adding an opacity configuration in `drawableColor`. Please help to review my code. If you have any suggestions, feel free to give me comments 😁

## Changelog

- Added opacity configuration in `drawableColor`
- Change `drawableColor` int color parameter to string hex color

## Test Plan

Currently, if we want to add background color in `Decoration`, we must pass integer color in `drawableColor`, like `0xFFFFFFFF`. I have some improvement in that. I changed the integer parameter in `drawableColor` with string hex color. For example, if we want to set the drawable color, we can use `drawableColor("ffffff")`.

And then, if we want to add opacity in drawable color, we can use `drawableColor("ffffff", Opacity.<_NUMBER>)`.
