### PR TITLE
NPE fix for concurrency issues.

### DIFF
--- a/litho-core/src/main/java/com/facebook/litho/ComponentContext.java
+++ b/litho-core/src/main/java/com/facebook/litho/ComponentContext.java
@@ -217,10 +217,11 @@ public class ComponentContext {
 
   /** Returns true if this method is called during layout creation. */
   boolean isCreateLayoutInProgress() {
-    if (mLayoutStateContext == null || mLayoutStateContext.getLayoutState() == null) {
+    try {
+      return mLayoutStateContext.getLayoutState().isCreateLayoutInProgress();
+    } catch (NullPointerException e){
       return false;
     }
-    return mLayoutStateContext.getLayoutState().isCreateLayoutInProgress();
   }
 
   @Nullable


### PR DESCRIPTION
## Summary

We are using this library in a project and get NPEs on a specific configuration because of concurrency issues. This catches the NPE and defaults to false.

## Changelog
- Fix NPEs in a rare scenario

## Test Plan

N/A
