### PR TITLE
Reset scroll position of horizontal scroll view on unmount

### DIFF
--- a/litho-widget/src/main/java/com/facebook/litho/widget/HorizontalScrollSpec.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/HorizontalScrollSpec.java
@@ -303,6 +303,7 @@ class HorizontalScrollSpec {
       mComponentHeight = 0;
       mScrollPosition = null;
       mOnScrollChangeListener = null;
+      setScrollX(0);
     }
   }
 


### PR DESCRIPTION
## Summary

If a horizontal scroll view is recycled, the "new" view will share the scroll position of the "old" view.

## Changelog

This change resets the scroll position of horizontal scroll views on `unmount` to prevent this recycling bug.

## Test Plan

Verified locally that this one-line change fixes the observed bug. Happy to add further testing if it would be useful.