### PR TITLE
TextInputSpec: Move the cursor to the end when the text is set

### DIFF
--- a/litho-it/src/test/java/com/facebook/litho/widget/TextInputSpecTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/widget/TextInputSpecTest.java
@@ -66,6 +66,8 @@ public class TextInputSpecTest {
 
     assertThat(editText.getText().toString()).isEqualTo(text);
     assertThat(editText.getTextSize()).isEqualTo(textSize);
+    assertThat(editText.getSelectionStart()).isEqualTo(textSize);
+    assertThat(editText.getSelectionEnd()).isEqualTo(textSize);
   }
 
   @Test

--- a/litho-widget/src/main/java/com/facebook/litho/widget/TextInputSpec.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/TextInputSpec.java
@@ -516,6 +516,7 @@ class TextInputSpec {
     }
     if (text != null && !ObjectsCompat.equals(editText.getText().toString(), text.toString())) {
       editText.setText(text);
+      editText.setSelection(text.length());
     }
   }
 
@@ -910,6 +911,7 @@ class TextInputSpec {
 
     // If line count changes state update will be triggered by view
     editText.setText(text);
+    editText.setSelection(text.length());
     return false;
   }
 


### PR DESCRIPTION
## Summary

This change ensures that whenever the text is set on a TextInput
component, the cursor is always placed at the end of the given text.
This allows users to continue inserting text at the end if so required

## Changelog

When text is set in the TextInput component, the cursor moves at the end.

## Test Plan

Added extra assertions in TextInputSpecTest
