### PR TITLE
Adds @LooperMode.Mode.LEGACY in Litho tests that fail in PAUSED mode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,6 @@ subprojects {
             if (offlineDepsDir != null) {
                 systemProperty 'robolectric.dependency.dir', "${rootDir}/$offlineDepsDir"
             }
-            systemProperty 'robolectric.looperMode', "LEGACY"
         }
     }
 }

--- a/litho-it/src/test/java/com/facebook/litho/ComponentTreePropWithReconciliationTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/ComponentTreePropWithReconciliationTest.java
@@ -17,6 +17,7 @@
 package com.facebook.litho;
 
 import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
+import static org.robolectric.annotation.LooperMode.Mode.LEGACY;
 
 import android.view.View;
 import com.facebook.litho.testing.logging.TestComponentsReporter;
@@ -25,7 +26,9 @@ import com.facebook.litho.widget.TreePropTestContainerComponent;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LEGACY)
 @RunWith(LithoTestRunner.class)
 public class ComponentTreePropWithReconciliationTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/IncrementalModuleTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/IncrementalModuleTest.java
@@ -18,6 +18,7 @@ package com.facebook.litho;
 
 import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.robolectric.annotation.LooperMode.Mode.LEGACY;
 
 import android.graphics.Rect;
 import android.view.View;
@@ -32,7 +33,9 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LEGACY)
 @RunWith(LithoTestRunner.class)
 public class IncrementalModuleTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/IncrementalVisibilityEventsTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/IncrementalVisibilityEventsTest.java
@@ -22,6 +22,7 @@ import static com.facebook.litho.testing.helper.ComponentTestHelper.measureAndLa
 import static com.facebook.litho.testing.helper.ComponentTestHelper.mountComponent;
 import static com.facebook.litho.testing.helper.ComponentTestHelper.unbindComponent;
 import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.robolectric.annotation.LooperMode.Mode.LEGACY;
 
 import android.graphics.Rect;
 import android.view.ViewGroup;
@@ -46,7 +47,9 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LEGACY)
 @RunWith(LithoTestRunner.class)
 public class IncrementalVisibilityEventsTest {
   private static final int LEFT = 0;

--- a/litho-it/src/test/java/com/facebook/litho/LithoStatsTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/LithoStatsTest.java
@@ -18,6 +18,7 @@ package com.facebook.litho;
 
 import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.robolectric.annotation.LooperMode.Mode.LEGACY;
 
 import com.facebook.litho.stats.LithoStats;
 import com.facebook.litho.testing.helper.ComponentTestHelper;
@@ -27,8 +28,10 @@ import java.util.concurrent.CountDownLatch;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLooper;
 
+@LooperMode(LEGACY)
 @RunWith(LithoTestRunner.class)
 public class LithoStatsTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/SizeSpecMountWrapperComponentSpecTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/SizeSpecMountWrapperComponentSpecTest.java
@@ -19,6 +19,7 @@ package com.facebook.litho;
 import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.isA;
+import static org.robolectric.annotation.LooperMode.Mode.LEGACY;
 
 import android.graphics.Color;
 import android.widget.FrameLayout;
@@ -32,7 +33,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LEGACY)
 @RunWith(LithoTestRunner.class)
 public class SizeSpecMountWrapperComponentSpecTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/animation/AnimatedPropertyNodeTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/animation/AnimatedPropertyNodeTest.java
@@ -36,7 +36,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class AnimatedPropertyNodeTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/choreographercompat/ChoreographerCompatTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/choreographercompat/ChoreographerCompatTest.java
@@ -26,8 +26,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLooper;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class ChoreographerCompatTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/dataflow/DataFlowGraphTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/dataflow/DataFlowGraphTest.java
@@ -23,7 +23,9 @@ import com.facebook.litho.testing.testrunner.LithoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class DataFlowGraphTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/dataflow/GraphBindingFinishesTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/dataflow/GraphBindingFinishesTest.java
@@ -24,7 +24,9 @@ import com.facebook.litho.testing.testrunner.LithoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class GraphBindingFinishesTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/dataflow/InterpolatorNodeTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/dataflow/InterpolatorNodeTest.java
@@ -24,7 +24,9 @@ import com.facebook.litho.testing.testrunner.LithoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class InterpolatorNodeTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/dataflow/MappingNodeTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/dataflow/MappingNodeTest.java
@@ -25,7 +25,9 @@ import com.facebook.litho.testing.testrunner.LithoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class MappingNodeTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/dataflow/MockTimingSourceTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/dataflow/MockTimingSourceTest.java
@@ -29,7 +29,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class MockTimingSourceTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/dataflow/TimingNodeTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/dataflow/TimingNodeTest.java
@@ -24,7 +24,9 @@ import com.facebook.litho.testing.testrunner.LithoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class TimingNodeTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/drawable/ComparableGradientDrawableTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/drawable/ComparableGradientDrawableTest.java
@@ -23,7 +23,9 @@ import android.graphics.drawable.GradientDrawable;
 import com.facebook.litho.testing.testrunner.LithoTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class ComparableGradientDrawableTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/sections/BatchedTargetTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/sections/BatchedTargetTest.java
@@ -39,8 +39,10 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.MockitoAnnotations;
+import org.robolectric.annotation.LooperMode;
 
 /** Tests {@link BatchedTarget} */
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class BatchedTargetTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/sections/ChangeSetStateTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/sections/ChangeSetStateTest.java
@@ -28,8 +28,10 @@ import com.facebook.litho.widget.ComponentRenderInfo;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
 /** Tests {@link ChangeSetState} */
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class ChangeSetStateTest {
   private SectionContext mSectionContext;

--- a/litho-it/src/test/java/com/facebook/litho/sections/ChangeSetStatsTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/sections/ChangeSetStatsTest.java
@@ -21,7 +21,9 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 import com.facebook.litho.testing.testrunner.LithoTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class ChangeSetStatsTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/sections/ChangeSetTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/sections/ChangeSetTest.java
@@ -28,8 +28,10 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
 /** Tests {@link ChangeSet} */
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class ChangeSetTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/sections/ChangeTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/sections/ChangeTest.java
@@ -26,8 +26,10 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
 /** Tests {@link Change} */
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class ChangeTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/sections/ChangesInfoTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/sections/ChangesInfoTest.java
@@ -23,8 +23,10 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
 /** Tests {@link ChangesInfo} */
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class ChangesInfoTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/sections/FocusDispatcherTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/sections/FocusDispatcherTest.java
@@ -23,8 +23,10 @@ import com.facebook.litho.testing.testrunner.LithoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
 /** Tests {@link FocusDispatcher} */
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class FocusDispatcherTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/sections/LithoStatsSectionsTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/sections/LithoStatsSectionsTest.java
@@ -19,6 +19,7 @@ package com.facebook.litho.sections;
 import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.robolectric.annotation.LooperMode.Mode.LEGACY;
 
 import android.os.Looper;
 import com.facebook.litho.Component;
@@ -36,8 +37,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Shadows;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLooper;
 
+@LooperMode(LEGACY)
 @RunWith(LithoTestRunner.class)
 public class LithoStatsSectionsTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/sections/SectionTreeEventHandlerTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/sections/SectionTreeEventHandlerTest.java
@@ -28,7 +28,9 @@ import com.facebook.litho.testing.testrunner.LithoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class SectionTreeEventHandlerTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/sections/SectionTreeTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/sections/SectionTreeTest.java
@@ -51,9 +51,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Shadows;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLooper;
 
 /** Tests {@link SectionTree} */
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class SectionTreeTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/sections/common/DataDiffSectionSpecTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/sections/common/DataDiffSectionSpecTest.java
@@ -55,8 +55,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.robolectric.annotation.LooperMode;
 
 /** Tests {@link DataDiffSectionSpec} */
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class DataDiffSectionSpecTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/sections/common/SingleComponentSectionSpecTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/sections/common/SingleComponentSectionSpecTest.java
@@ -35,8 +35,10 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
 /** Tests {@link SingleComponentSectionSpec} */
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class SingleComponentSectionSpecTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/sections/processor/TreePropSectionTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/sections/processor/TreePropSectionTest.java
@@ -32,8 +32,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.annotation.LooperMode;
 
 /** Tests passing {@link TreeProp}s down a Section tree. */
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class TreePropSectionTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/sections/processor/TreePropTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/sections/processor/TreePropTest.java
@@ -34,8 +34,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.annotation.LooperMode;
 
 /** Tests passing {@link TreeProp}s down a Component tree. */
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class TreePropTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/sections/widget/LithoStartupLoggerTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/sections/widget/LithoStartupLoggerTest.java
@@ -20,6 +20,7 @@ import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static com.facebook.litho.SizeSpec.EXACTLY;
 import static com.facebook.litho.SizeSpec.makeSizeSpec;
 import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.robolectric.annotation.LooperMode.Mode.LEGACY;
 
 import androidx.recyclerview.widget.RecyclerView;
 import com.facebook.litho.ComponentContext;
@@ -38,8 +39,10 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
 /** Tests {@link com.facebook.litho.LithoStartupLogger} */
+@LooperMode(LEGACY)
 @RunWith(LithoTestRunner.class)
 public class LithoStartupLoggerTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/sections/widget/RecyclerCollectionComponentSpecTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/sections/widget/RecyclerCollectionComponentSpecTest.java
@@ -63,8 +63,10 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
 /** Tests {@link RecyclerCollectionComponentSpec} */
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class RecyclerCollectionComponentSpecTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/testing/LithoRepresentationTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/testing/LithoRepresentationTest.java
@@ -34,7 +34,9 @@ import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class LithoRepresentationTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/testing/assertj/SubComponentDeepExtractorTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/testing/assertj/SubComponentDeepExtractorTest.java
@@ -34,7 +34,9 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class SubComponentDeepExtractorTest {
   @Rule public ComponentsRule mComponentsRule = new ComponentsRule();

--- a/litho-it/src/test/java/com/facebook/litho/testing/specmodels/InjectPropMatcherGenerationTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/testing/specmodels/InjectPropMatcherGenerationTest.java
@@ -34,7 +34,9 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class InjectPropMatcherGenerationTest {
   @Rule public ComponentsRule mComponentsRule = new ComponentsRule();

--- a/litho-it/src/test/java/com/facebook/litho/testing/subcomponents/CommonPropMatcherTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/testing/subcomponents/CommonPropMatcherTest.java
@@ -34,7 +34,9 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class CommonPropMatcherTest {
   @Rule public ComponentsRule mComponentsRule = new ComponentsRule();

--- a/litho-it/src/test/java/com/facebook/litho/testing/subcomponents/GenericMatcherGenerationTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/testing/subcomponents/GenericMatcherGenerationTest.java
@@ -35,7 +35,9 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class GenericMatcherGenerationTest {
   @Rule public ComponentsRule mComponentsRule = new ComponentsRule();

--- a/litho-it/src/test/java/com/facebook/litho/testing/viewtree/ComponentQueriesTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/testing/viewtree/ComponentQueriesTest.java
@@ -29,8 +29,10 @@ import com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
 /** Tests {@link ComponentQueries} */
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class ComponentQueriesTest {
   private ComponentContext mContext;

--- a/litho-it/src/test/java/com/facebook/litho/testing/viewtree/ViewExtractorsTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/testing/viewtree/ViewExtractorsTest.java
@@ -29,8 +29,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.annotation.LooperMode;
 
 /** Tests {@link ViewExtractors} */
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class ViewExtractorsTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/testing/viewtree/ViewTreeTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/testing/viewtree/ViewTreeTest.java
@@ -30,8 +30,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.annotation.LooperMode;
 
 /** Tests {@link ViewTree} */
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class ViewTreeTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/testing/viewtree/ViewTreeUtilTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/testing/viewtree/ViewTreeUtilTest.java
@@ -21,8 +21,10 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 import com.facebook.litho.testing.testrunner.LithoTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
 /** Test for {@link ViewTreeUtil} */
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class ViewTreeUtilTest {
   @Test

--- a/litho-it/src/test/java/com/facebook/litho/utils/MapDiffUtilsTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/utils/MapDiffUtilsTest.java
@@ -22,7 +22,9 @@ import com.facebook.litho.testing.testrunner.LithoTestRunner;
 import java.util.HashMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class MapDiffUtilsTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/utils/MeasureUtilsTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/utils/MeasureUtilsTest.java
@@ -32,7 +32,9 @@ import com.facebook.litho.Size;
 import com.facebook.litho.testing.testrunner.LithoTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class MeasureUtilsTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/widget/ComponentWarmerTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/widget/ComponentWarmerTest.java
@@ -18,6 +18,7 @@ package com.facebook.litho.widget;
 
 import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.robolectric.annotation.LooperMode.Mode.LEGACY;
 
 import android.os.HandlerThread;
 import android.os.Looper;
@@ -40,8 +41,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Shadows;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLooper;
 
+@LooperMode(LEGACY)
 @RunWith(LithoTestRunner.class)
 public class ComponentWarmerTest {
 


### PR DESCRIPTION
## Summary

Some Litho tests fail in the new Roboelectric PAUSED LooperMode and
therefore need to explicitly use the LEGACY mode.

## Changelog

Not a user visible change, only affecting tests.

## Test Plan

This change only affects tests.
