### PR TITLE
Avoid mocking Android Views in DynamicPropsTest

### DIFF
--- a/litho-it/src/test/java/com/facebook/litho/DynamicPropsTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/DynamicPropsTest.java
@@ -221,25 +221,7 @@ public class DynamicPropsTest {
           protected void setComponent(Component component) {}
         };
 
-    // We are using an old version of Robolectric which has a very limited
-    // implementation of RenderNode which will always returns an elevation
-    // of 0. To get around this we verify the correct elevation values are
-    // applied using the fake LithoView extension below.
-    final LithoView lithoView =
-        new LithoView(mContext) {
-          private float elevation;
-
-          @Override
-          public void setElevation(float elevation) {
-            this.elevation = elevation;
-            super.setElevation(elevation);
-          }
-
-          @Override
-          public float getElevation() {
-            return this.elevation;
-          }
-        };
+    final LithoView lithoView = new LithoView(mContext);
 
     final float startValue = 1f;
     final DynamicValue<Float> elevationDV = new DynamicValue<>(startValue);


### PR DESCRIPTION
## Summary
The testDynamicElevationApplied() test in DynamicPropsTest is currently
using Mockito to mock an Android View. This change removes mocking and
uses a fake LithoView extension instead to retrieve the set elevation.

## Changelog

Remove the need to mock an Android View in DynamicPropsTest

## Test Plan

This change only affects tests and is not user visible
