### PR TITLE
Add support for getting testKeys set on container Components

### DIFF
--- a/litho-core/src/main/java/com/facebook/litho/CommonProps.java
+++ b/litho-core/src/main/java/com/facebook/litho/CommonProps.java
@@ -57,6 +57,9 @@ public interface CommonProps extends CommonPropsCopyable, LayoutProps {
 
   void background(@Nullable Drawable background);
 
+  @Nullable
+  String getTestKey();
+
   void testKey(String testKey);
 
   @Nullable

--- a/litho-core/src/main/java/com/facebook/litho/CommonProps.java
+++ b/litho-core/src/main/java/com/facebook/litho/CommonProps.java
@@ -29,7 +29,9 @@ import androidx.annotation.StyleRes;
 import com.facebook.infer.annotation.ThreadConfined;
 import com.facebook.yoga.YogaEdge;
 
-/** Common props that are accessible outside of the framework. */
+/**
+ * Common props that are accessible outside of the framework.
+ */
 @ThreadConfined(ThreadConfined.ANY)
 public interface CommonProps extends CommonPropsCopyable, LayoutProps {
 
@@ -57,6 +59,11 @@ public interface CommonProps extends CommonPropsCopyable, LayoutProps {
 
   void background(@Nullable Drawable background);
 
+  /**
+   * Returns the test key associated with this Component or null if none is set. Note that this
+   * method will not return the test key for Container Components that resolve into LayoutNodes or
+   * the test keys for Components that are all resolved into a single InternalNode.
+   */
   @Nullable
   String getTestKey();
 
@@ -149,7 +156,7 @@ public interface CommonProps extends CommonPropsCopyable, LayoutProps {
   void dispatchPopulateAccessibilityEventHandler(
       @Nullable
           EventHandler<DispatchPopulateAccessibilityEventEvent>
-              dispatchPopulateAccessibilityEventHandler);
+          dispatchPopulateAccessibilityEventHandler);
 
   void onInitializeAccessibilityEventHandler(
       @Nullable
@@ -158,7 +165,7 @@ public interface CommonProps extends CommonPropsCopyable, LayoutProps {
   void onInitializeAccessibilityNodeInfoHandler(
       @Nullable
           EventHandler<OnInitializeAccessibilityNodeInfoEvent>
-              onInitializeAccessibilityNodeInfoHandler);
+          onInitializeAccessibilityNodeInfoHandler);
 
   void onPopulateAccessibilityEventHandler(
       @Nullable
@@ -167,7 +174,7 @@ public interface CommonProps extends CommonPropsCopyable, LayoutProps {
   void onRequestSendAccessibilityEventHandler(
       @Nullable
           EventHandler<OnRequestSendAccessibilityEventEvent>
-              onRequestSendAccessibilityEventHandler);
+          onRequestSendAccessibilityEventHandler);
 
   void performAccessibilityActionHandler(
       @Nullable EventHandler<PerformAccessibilityActionEvent> performAccessibilityActionHandler);
@@ -178,7 +185,7 @@ public interface CommonProps extends CommonPropsCopyable, LayoutProps {
   void sendAccessibilityEventUncheckedHandler(
       @Nullable
           EventHandler<SendAccessibilityEventUncheckedEvent>
-              sendAccessibilityEventUncheckedHandler);
+          sendAccessibilityEventUncheckedHandler);
 
   void scale(float scale);
 

--- a/litho-core/src/main/java/com/facebook/litho/CommonPropsHolder.java
+++ b/litho-core/src/main/java/com/facebook/litho/CommonPropsHolder.java
@@ -116,6 +116,12 @@ class CommonPropsHolder implements CommonProps {
 
   @Override
   @Nullable
+  public String getTestKey() {
+    return (mPrivateFlags & PFLAG_TEST_KEY_IS_SET) != 0 ? mTestKey : null;
+  }
+
+  @Override
+  @Nullable
   public Object getComponentTag() {
     return mComponentTag;
   }

--- a/litho-core/src/main/java/com/facebook/litho/DebugComponent.java
+++ b/litho-core/src/main/java/com/facebook/litho/DebugComponent.java
@@ -261,6 +261,22 @@ public final class DebugComponent {
   }
 
   /**
+   * Returns this component's testKey or null if none is set.
+   *
+   * <p>Unlike {@link #getTestKey()}, this function can return a test key set on any Component,
+   * including container Components which resolve into LayoutNodes.
+   *
+   * <p>Unlike {@link #getTestKey()}, this function can also return test keys set on individual
+   * Components even when they are all resolved into a single InternalNode.
+   */
+  @Nullable
+  public String getComponentTestKey() {
+    Component component = mNode.getComponents().get(mComponentIndex);
+    CommonProps props = component.getCommonProps();
+    return props == null ? null : props.getTestKey();
+  }
+
+  /**
    * @return This component's componentTag or null if none is set. Unlike {@link getTestKey}, this
    *     will return tags for any Component, including Components which are not LayoutNodes.
    */

--- a/litho-testing/src/main/java/com/facebook/litho/testing/subcomponents/InspectableComponent.java
+++ b/litho-testing/src/main/java/com/facebook/litho/testing/subcomponents/InspectableComponent.java
@@ -143,6 +143,17 @@ public class InspectableComponent {
     return mComponent.getTestKey();
   }
 
+  /**
+   * Returns this component's testKey or null if none is set.
+   *
+   * <p>Unlike {@link #getTestKey()}, this function can return a test key set on any Component,
+   * including container Components which resolve into LayoutNodes.
+   */
+  @Nullable
+  public String getComponentTestKey() {
+    return mComponent.getComponentTestKey();
+  }
+
   /** @return This component's componentTag or null if none is set. */
   @Nullable
   public Object getComponentTag() {


### PR DESCRIPTION
## Summary

Currently, if a test key is set on a Component which resolves into a
LayoutNode, the corresponding InspectableComponent and DebugComponent
fails to return its testKey.

## Changelog

TestKeys can now be returned from Components that resolve into LayoutNodes.

## Test Plan

Verified locally that the test key is properly returned on any Component.
