### PR TITLE
Ensure ScrollableContainerType specs properly clean up their internal…

### DIFF
--- a/litho-widget/src/main/java/com/facebook/litho/widget/HorizontalScrollSpec.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/HorizontalScrollSpec.java
@@ -29,6 +29,7 @@ import com.facebook.litho.Component;
 import com.facebook.litho.ComponentContext;
 import com.facebook.litho.ComponentLayout;
 import com.facebook.litho.ComponentTree;
+import com.facebook.litho.HasLithoViewChildren;
 import com.facebook.litho.LithoView;
 import com.facebook.litho.Output;
 import com.facebook.litho.R;
@@ -50,6 +51,7 @@ import com.facebook.litho.annotations.PropDefault;
 import com.facebook.litho.annotations.ResType;
 import com.facebook.litho.annotations.State;
 import com.facebook.yoga.YogaDirection;
+import java.util.List;
 
 /**
  * A component that wraps another component and allow it to be horizontally scrollable. It's
@@ -241,7 +243,8 @@ class HorizontalScrollSpec {
             .build());
   }
 
-  static class HorizontalScrollLithoView extends HorizontalScrollView {
+  static class HorizontalScrollLithoView extends HorizontalScrollView
+      implements HasLithoViewChildren {
     private final LithoView mLithoView;
 
     private int mComponentWidth;
@@ -283,6 +286,11 @@ class HorizontalScrollSpec {
           MeasureSpec.getSize(widthMeasureSpec), MeasureSpec.getSize(heightMeasureSpec));
     }
 
+    @Override
+    public void obtainLithoViewChildren(List<LithoView> lithoViews) {
+      lithoViews.add(mLithoView);
+    }
+
     void mount(
         ComponentTree componentTree,
         ScrollPosition scrollPosition,
@@ -297,8 +305,9 @@ class HorizontalScrollSpec {
     }
 
     void unmount() {
-      // Clear all component-related state from the view.
-      mLithoView.unbind();
+      mLithoView.unmountAllItems();
+      mLithoView.setComponentTree(null);
+
       mComponentWidth = 0;
       mComponentHeight = 0;
       mScrollPosition = null;

--- a/litho-widget/src/main/java/com/facebook/litho/widget/HorizontalScrollSpec.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/HorizontalScrollSpec.java
@@ -305,7 +305,7 @@ class HorizontalScrollSpec {
     }
 
     void unmount() {
-      mLithoView.unmountAllItems();
+      mLithoView.unbind();
       mLithoView.setComponentTree(null);
 
       mComponentWidth = 0;

--- a/litho-widget/src/main/java/com/facebook/litho/widget/LithoScrollView.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/LithoScrollView.java
@@ -24,15 +24,17 @@ import androidx.annotation.Nullable;
 import androidx.core.widget.NestedScrollView;
 import androidx.recyclerview.widget.RecyclerView;
 import com.facebook.litho.ComponentTree;
+import com.facebook.litho.HasLithoViewChildren;
 import com.facebook.litho.LithoView;
 import com.facebook.litho.widget.VerticalScrollSpec.OnInterceptTouchListener;
 import com.facebook.litho.widget.VerticalScrollSpec.ScrollPosition;
+import java.util.List;
 
 /**
  * Extension of {@link NestedScrollView} that allows to add more features needed for @{@link
  * VerticalScrollSpec}.
  */
-public class LithoScrollView extends NestedScrollView {
+public class LithoScrollView extends NestedScrollView implements HasLithoViewChildren {
 
   private final LithoView mLithoView;
 
@@ -96,6 +98,11 @@ public class LithoScrollView extends NestedScrollView {
     mOnInterceptTouchListener = onInterceptTouchListener;
   }
 
+  @Override
+  public void obtainLithoViewChildren(List<LithoView> lithoViews) {
+    lithoViews.add(mLithoView);
+  }
+
   void mount(
       ComponentTree contentComponentTree,
       final ScrollPosition scrollPosition,
@@ -122,6 +129,7 @@ public class LithoScrollView extends NestedScrollView {
   }
 
   void unmount() {
+    mLithoView.unmountAllItems();
     mLithoView.setComponentTree(null);
 
     mScrollPosition = null;

--- a/litho-widget/src/main/java/com/facebook/litho/widget/LithoScrollView.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/LithoScrollView.java
@@ -129,7 +129,7 @@ public class LithoScrollView extends NestedScrollView implements HasLithoViewChi
   }
 
   void unmount() {
-    mLithoView.unmountAllItems();
+    mLithoView.unbind();
     mLithoView.setComponentTree(null);
 
     mScrollPosition = null;


### PR DESCRIPTION
## Summary

Ensure ScrollableContainerType specs properly clean up their internal LithoView

This change achieves two things:

1) Ensures that the ScrollableContainerType specs implement the
HasLithoViewChildren interface. This interface needs to be implemented by all
containers of LithoView, as it's used for cleanup and visibility handling.

2) Ensures that the necessary cleanup methods are invoked against the internal
LithoView.

## Changelog

ScrollableContainerType specs implement HasLithoViewChildren and properly
clean up their internal LithoView.

## Test Plan

Verified cleanup is properly triggered using both VerticalScrollSpec and HorizontalScrollSpec.
