### PR TITLE
Fix crashes caused by measuring of the Litho TextInputSpec

### DIFF
--- a/litho-widget/src/main/java/com/facebook/litho/widget/TextInputSpec.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/TextInputSpec.java
@@ -1161,6 +1161,14 @@ class TextInputSpec {
     }
   }
 
+  /**
+   * We use this instead of vanilla EditText for measurement as the ConstantState of the EditText
+   * background drawable is not thread-safe and shared across all EditText instances. This is
+   * especially important as we measure this component mostly in background thread and it could lead
+   * to race conditions where different instances are accessing/modifying same ConstantState
+   * concurrently. Mutating background drawable will make sure that ConstantState is not shared
+   * therefore will become thread-safe.
+   */
   static class ForMeasureEditText extends EditText {
 
     public ForMeasureEditText(Context context) {
@@ -1170,5 +1178,13 @@ class TextInputSpec {
     // This view is not intended to be drawn and invalidated
     @Override
     public void invalidate() {}
+
+    @Override
+    public void setBackground(Drawable background) {
+      if (background != null) {
+        background.mutate();
+      }
+      super.setBackground(background);
+    }
   }
 }


### PR DESCRIPTION
## Summary

Litho TextInputSpec replaces the deprecated EditTextSpec, however there
was a fix specific for setBackground in EditTextSpec that was not in
TextInputSpec. This change is copying over the fix from the deprecated
EditableTextSpec into the new TextInputSpec.

## Changelog

Reintroduce a fix into the new TextInputSpec from the deprecated EditableTextSpec
to resolve potential race conditions.

## Test Plan

Verified locally that re-introducing this fix into TextInputSpec fixes the crashes
that we observed.

