### PR TITLE
Add support for OnItemTouchListener in RecyclerSpec

### DIFF
--- a/litho-it/src/test/java/com/facebook/litho/widget/RecyclerSpecTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/widget/RecyclerSpecTest.java
@@ -24,6 +24,8 @@ import static org.mockito.Mockito.when;
 
 import android.content.Context;
 import androidx.recyclerview.widget.RecyclerView;
+import androidx.recyclerview.widget.RecyclerView.ItemAnimator;
+import androidx.recyclerview.widget.RecyclerView.OnItemTouchListener;
 import androidx.recyclerview.widget.SnapHelper;
 import com.facebook.litho.Component;
 import com.facebook.litho.ComponentContext;
@@ -43,6 +45,8 @@ public class RecyclerSpecTest {
   private ComponentContext mComponentContext;
   private TestSectionsRecyclerView mSectionsRecyclerView;
   private TestLithoRecyclerView mRecyclerView;
+  private ItemAnimator mAnimator;
+  private OnItemTouchListener onItemTouchListener;
 
   @Before
   public void setup() {
@@ -51,6 +55,9 @@ public class RecyclerSpecTest {
     mSectionsRecyclerView =
         new TestSectionsRecyclerView(mComponentContext.getAndroidContext(), mRecyclerView);
     mSectionsRecyclerView.setHasBeenDetachedFromWindow(true);
+    mAnimator = mock(RecyclerView.ItemAnimator.class);
+    mRecyclerView.setItemAnimator(mAnimator);
+    onItemTouchListener = mock(OnItemTouchListener.class);
   }
 
   @Test
@@ -75,6 +82,7 @@ public class RecyclerSpecTest {
         snapHelper,
         true,
         touchInterceptor,
+        onItemTouchListener,
         refreshHandler);
 
     assertThat(mSectionsRecyclerView.isEnabled()).isTrue();
@@ -99,7 +107,13 @@ public class RecyclerSpecTest {
     final int size = 3;
     List<RecyclerView.OnScrollListener> scrollListeners = createListOfScrollListeners(size);
 
-    RecyclerSpec.onUnbind(mComponentContext, mSectionsRecyclerView, binder, null, scrollListeners);
+    RecyclerSpec.onUnbind(
+        mComponentContext,
+        mSectionsRecyclerView,
+        binder,
+        null,
+        onItemTouchListener,
+        scrollListeners);
 
     verify(binder).unbind(mRecyclerView);
     verifyRemoveOnScrollListenerWasCalledNTimes(mRecyclerView, size);

--- a/litho-sections-widget/src/main/java/com/facebook/litho/sections/widget/RecyclerCollectionComponentSpec.java
+++ b/litho-sections-widget/src/main/java/com/facebook/litho/sections/widget/RecyclerCollectionComponentSpec.java
@@ -28,6 +28,7 @@ import androidx.recyclerview.widget.OrientationHelper;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.recyclerview.widget.RecyclerView.ItemAnimator;
 import androidx.recyclerview.widget.RecyclerView.ItemDecoration;
+import androidx.recyclerview.widget.RecyclerView.OnItemTouchListener;
 import androidx.recyclerview.widget.RecyclerView.OnScrollListener;
 import androidx.recyclerview.widget.SnapHelper;
 import com.facebook.litho.Column;
@@ -159,6 +160,7 @@ public class RecyclerCollectionComponentSpec {
           Integer refreshProgressBarBackgroundColor,
       @Prop(optional = true, resType = ResType.COLOR) int refreshProgressBarColor,
       @Prop(optional = true) @Nullable LithoRecylerView.TouchInterceptor touchInterceptor,
+      @Prop(optional = true) OnItemTouchListener itemTouchListener,
       @Prop(optional = true) boolean setRootAsync,
       @Prop(optional = true) boolean disablePTR,
       @Prop(optional = true) RecyclerConfiguration recyclerConfiguration,
@@ -221,6 +223,7 @@ public class RecyclerCollectionComponentSpec {
             .refreshProgressBarColor(refreshProgressBarColor)
             .snapHelper(snapHelper)
             .touchInterceptor(touchInterceptor)
+            .onItemTouchListener(itemTouchListener)
             .binder(binder)
             .itemAnimator(
                 RecyclerCollectionComponentSpec.itemAnimator == itemAnimator

--- a/litho-widget/src/main/java/com/facebook/litho/widget/RecyclerSpec.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/RecyclerSpec.java
@@ -197,6 +197,7 @@ class RecyclerSpec {
       @Nullable @Prop(optional = true) SnapHelper snapHelper,
       @Prop(optional = true) boolean pullToRefresh,
       @Prop(optional = true) @Nullable LithoRecylerView.TouchInterceptor touchInterceptor,
+      @Prop(optional = true) RecyclerView.OnItemTouchListener onItemTouchListener,
       @Nullable @Prop(optional = true) final EventHandler refreshHandler) {
 
     // contentDescription should be set on the recyclerView itself, and not the sectionsRecycler.
@@ -229,6 +230,10 @@ class RecyclerSpec {
       recyclerView.setTouchInterceptor(touchInterceptor);
     }
 
+    if (onItemTouchListener != null) {
+      recyclerView.addOnItemTouchListener(onItemTouchListener);
+    }
+
     // We cannot detach the snap helper in unbind, so it may be possible for it to get
     // attached twice which causes SnapHelper to raise an exception.
     if (snapHelper != null && recyclerView.getOnFlingListener() == null) {
@@ -253,6 +258,7 @@ class RecyclerSpec {
       SectionsRecyclerView sectionsRecycler,
       @Prop Binder<RecyclerView> binder,
       @Prop(optional = true) RecyclerEventsController recyclerEventsController,
+      @Prop(optional = true) RecyclerView.OnItemTouchListener onItemTouchListener,
       @Prop(optional = true, varArg = "onScrollListener") @Nullable
           List<OnScrollListener> onScrollListeners) {
     final LithoRecylerView recyclerView = (LithoRecylerView) sectionsRecycler.getRecyclerView();
@@ -273,6 +279,10 @@ class RecyclerSpec {
       for (OnScrollListener onScrollListener : onScrollListeners) {
         recyclerView.removeOnScrollListener(onScrollListener);
       }
+    }
+
+    if (onItemTouchListener != null) {
+      recyclerView.removeOnItemTouchListener(onItemTouchListener);
     }
 
     recyclerView.setTouchInterceptor(null);


### PR DESCRIPTION
## Summary

An optional property has been added into RecyclerSpec so that users can
optionally provide an OnItemTouchListener. The given Listener is passed
into the underlying RecyclerView to be triggered when an item has been
touched.

## Changelog

Adds support for OnItemTouchListener in RecyclerSpec

## Test Plan

Updated the RecyclerSpecTest to reflect the change and verified it is working
as expected locally.
