### PR TITLE
Fix support for disappear transitions

### DIFF
--- a/litho-rendercore-transitions/src/main/java/com/facebook/litho/TransitionManager.java
+++ b/litho-rendercore-transitions/src/main/java/com/facebook/litho/TransitionManager.java
@@ -284,10 +284,12 @@ public class TransitionManager {
     List<AnimationBinding> currentAnimationBindings = new ArrayList<>();
     if (currentLayoutState != null) {
       List<Transition> currentTransitions = currentLayoutState.getTransitions();
-      for (Transition transition : currentTransitions) {
-        AnimationBinding binding = createAnimationsForTransition(transition);
-        if (binding != null) {
-          currentAnimationBindings.add(binding);
+      if (currentTransitions != null) {
+        for (Transition transition : currentTransitions) {
+          AnimationBinding binding = createAnimationsForTransition(transition);
+          if (binding != null) {
+            currentAnimationBindings.add(binding);
+          }
         }
       }
     }

--- a/litho-rendercore-transitions/src/main/java/com/facebook/litho/TransitionManager.java
+++ b/litho-rendercore-transitions/src/main/java/com/facebook/litho/TransitionManager.java
@@ -279,7 +279,29 @@ public class TransitionManager {
       }
     }
 
+    // First, create animation bindings for the previous LayoutState in case there are any
+    // transitions for disappearing items that are no longer in the new LayoutState.
+    List<AnimationBinding> currentAnimationBindings = new ArrayList<>();
+    if (currentLayoutState != null) {
+      List<Transition> currentTransitions = currentLayoutState.getTransitions();
+      for (Transition transition : currentTransitions) {
+        AnimationBinding binding = createAnimationsForTransition(transition);
+        if (binding != null) {
+          currentAnimationBindings.add(binding);
+        }
+      }
+    }
+
+    // Create animation bindings for the new LayoutState.
     createTransitionAnimations(rootTransition);
+
+    // Merge the animation bindings from the previous LayoutState with the new one.
+    if (!currentAnimationBindings.isEmpty()) {
+      if (mRootAnimationToRun != null) {
+        currentAnimationBindings.add(mRootAnimationToRun);
+      }
+      mRootAnimationToRun = new ParallelBinding(0, currentAnimationBindings);
+    }
 
     // If we recorded any mount content diffs that didn't result in an animation being created for
     // that transition id, clean them up now.


### PR DESCRIPTION
## Summary

The current setupTransitions() implementation never looks at any
transitions defined on the previous LayoutState when creating
AnimationBindings. This can be an issue for disappear transitions
because the new LayoutState will no longer contain any disappearing
items.

This change adds logic in the TransitionManager to first create
AnimationBindings for the previous LayoutState, then create
AnimationBindings for the new LayoutState and finally merge the two.

## Changelog

Fixes support for disappear transitions in TransitionManager

## Test Plan

We have manually verified disappear transitions are working as expected
after this change.