### PR TITLE
Allow Nullable annotations on LIST types in BuilderGenerator

### DIFF
--- a/litho-processor/src/main/java/com/facebook/litho/specmodels/generator/BuilderGenerator.java
+++ b/litho-processor/src/main/java/com/facebook/litho/specmodels/generator/BuilderGenerator.java
@@ -725,7 +725,7 @@ public class BuilderGenerator {
                   requiredIndex,
                   prop.getName() + "Res",
                   Arrays.asList(
-                      parameterWithoutNullableAnnotation(
+                      parameter(
                           prop,
                           ParameterizedTypeName.get(ClassNames.LIST, TypeName.INT.box()),
                           "resIds")),
@@ -775,7 +775,7 @@ public class BuilderGenerator {
                   requiredIndex,
                   prop.getName() + "Res",
                   Arrays.asList(
-                      parameterWithoutNullableAnnotation(
+                      parameter(
                           prop,
                           ParameterizedTypeName.get(ClassNames.LIST, TypeName.INT.box()),
                           "resIds",
@@ -844,7 +844,7 @@ public class BuilderGenerator {
                   requiredIndex,
                   prop.getName() + "Attr",
                   Arrays.asList(
-                      parameterWithoutNullableAnnotation(
+                      parameter(
                           prop,
                           ParameterizedTypeName.get(ClassNames.LIST, TypeName.INT.box()),
                           "attrResIds"),
@@ -863,7 +863,7 @@ public class BuilderGenerator {
                   requiredIndex,
                   prop.getName() + "Attr",
                   Arrays.asList(
-                      parameterWithoutNullableAnnotation(
+                      parameter(
                           prop,
                           ParameterizedTypeName.get(ClassNames.LIST, TypeName.INT.box()),
                           "attrResIds")),
@@ -953,7 +953,7 @@ public class BuilderGenerator {
                   requiredIndex,
                   prop.getName() + "Dip",
                   Arrays.asList(
-                      parameterWithoutNullableAnnotation(
+                      parameter(
                           prop,
                           ParameterizedTypeName.get(ClassNames.LIST, TypeName.FLOAT.box()),
                           "dips")),
@@ -998,7 +998,7 @@ public class BuilderGenerator {
                   requiredIndex,
                   prop.getName() + "Sp",
                   Arrays.asList(
-                      parameterWithoutNullableAnnotation(
+                      parameter(
                           prop,
                           ParameterizedTypeName.get(ClassNames.LIST, TypeName.FLOAT.box()),
                           "sips")),


### PR DESCRIPTION
## Summary

The current implementation of BuilderGenerator does not allow Nullable
annotations for Lists of Integers and Floats. Lists are technically
nullable so this change partially reverts commit
b47a9f117dde8d039a741e64d45e783fa14c939a only for Lists.

Using @Nullable for Lists allows us to more effectively use NullChecker
for static analysis.

## Changelog

Allows Nullable annotations for Lists in BuilderGenerator

## Test Plan

This change is a partial revert of a previous commit and has been tested
locally.
