### PR TITLE
Override getColorFilter() in BorderColorDrawable

### DIFF
--- a/litho-core/src/main/java/com/facebook/litho/drawable/BorderColorDrawable.java
+++ b/litho-core/src/main/java/com/facebook/litho/drawable/BorderColorDrawable.java
@@ -36,7 +36,6 @@ import javax.annotation.Nullable;
 public class BorderColorDrawable extends Drawable implements ComparableDrawable {
 
   private static final int QUICK_REJECT_COLOR = Color.TRANSPARENT;
-  private static final float CLIP_ANGLE = 45f;
   private static final RectF sClipBounds = new RectF();
   private static final RectF sDrawBounds = new RectF();
   private static final RectF sInnerDrawBounds = new RectF();
@@ -318,6 +317,11 @@ public class BorderColorDrawable extends Drawable implements ComparableDrawable 
     if (mPaint != null) {
       mPaint.setColorFilter(colorFilter);
     }
+  }
+
+  @Override
+  public ColorFilter getColorFilter() {
+    return mPaint != null ? mPaint.getColorFilter() : null;
   }
 
   @Override


### PR DESCRIPTION
## Summary

This change overrides getColorFilter() in BorderColorDrawable to provide
the ColorFilter set on the Paint if the latter is available or null
otherwise. This getColorFilter() implementation is symmetrical to the
existing setColorFilter() implementation.

## Changelog

Provides a symmetrical getColorFilter() implementation in BorderColorDrawable,
to match the existing implementation of setColorFilter().

## Test Plan

We have manually verified that adding this getColorFilter() implementation
fixes an issue observed around the border color not being applied properly
during animations.
