### PR TITLE
Adds a new LithoHandler implementation that uses Executors

### DIFF
--- a/litho-core/build.gradle
+++ b/litho-core/build.gradle
@@ -41,7 +41,7 @@ android {
         }
 
         release {
-            buildConfigField 'boolean', internalBuildField, 'false';
+            buildConfigField 'boolean', internalBuildField, 'false'
             buildConfigField 'boolean', useIncrementalMountHelper, 'true'
         }
     }
@@ -70,6 +70,7 @@ dependencies {
 
     // Android Support Library
     compileOnly deps.supportAnnotations
+    implementation deps.guava
     implementation deps.supportCore
     implementation deps.supportCustomView
     implementation deps.supportViewPager

--- a/litho-core/build.gradle
+++ b/litho-core/build.gradle
@@ -70,7 +70,6 @@ dependencies {
 
     // Android Support Library
     compileOnly deps.supportAnnotations
-    implementation deps.guava
     implementation deps.supportCore
     implementation deps.supportCustomView
     implementation deps.supportViewPager

--- a/litho-core/src/main/java/com/facebook/litho/BUCK
+++ b/litho-core/src/main/java/com/facebook/litho/BUCK
@@ -55,7 +55,6 @@ litho_android_library(
     deps = [
         "//fbandroid/third-party/java/infer-annotations:infer-annotations",
         "//fbandroid/third-party/java/jsr-305:jsr-305",
-        LITHO_GUAVA_TARGET,
         LITHO_INFERANNOTATIONS_TARGET,
         LITHO_PERFBOOST_TARGET,
         LITHO_RES_TARGET,

--- a/litho-core/src/main/java/com/facebook/litho/BUCK
+++ b/litho-core/src/main/java/com/facebook/litho/BUCK
@@ -55,6 +55,7 @@ litho_android_library(
     deps = [
         "//fbandroid/third-party/java/infer-annotations:infer-annotations",
         "//fbandroid/third-party/java/jsr-305:jsr-305",
+        LITHO_GUAVA_TARGET,
         LITHO_INFERANNOTATIONS_TARGET,
         LITHO_PERFBOOST_TARGET,
         LITHO_RES_TARGET,

--- a/litho-core/src/main/java/com/facebook/litho/ExecutorLithoHandler.java
+++ b/litho-core/src/main/java/com/facebook/litho/ExecutorLithoHandler.java
@@ -1,0 +1,74 @@
+package com.facebook.litho;
+
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.Multiset;
+import java.util.concurrent.Executor;
+import javax.annotation.concurrent.GuardedBy;
+
+/**
+ * A {@code LithoHandler} implementation that runs all layout computations against the provided
+ * {@code Executor}. This {@code LithoHandler} can be used in apps that have a well established
+ * threading model and need to run layout against one of their already available executors.
+ */
+public final class ExecutorLithoHandler implements LithoHandler {
+
+  @GuardedBy("pendingTasks")
+  private final Multiset<Runnable> pendingTasks = HashMultiset.create();
+  private final Executor executor;
+
+  /**
+   * Instantiates an {@code ExecutorLithoHandler} that uses the given {@code Executor} to run all
+   * layout tasks against.
+   */
+  public ExecutorLithoHandler(Executor executor) {
+    this.executor = executor;
+  }
+
+  @Override
+  public void post(final Runnable runnable, String tag) {
+    synchronized (pendingTasks) {
+      pendingTasks.add(runnable);
+    }
+
+    executor.execute(new Runnable() {
+      @Override
+      public void run() {
+        boolean canRun;
+        synchronized (pendingTasks) {
+          canRun = pendingTasks.remove(runnable);
+        }
+        if (canRun) {
+          runnable.run();
+        }
+      }
+    });
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * In this implementation, postAtFront() is equivalent to post().
+   */
+  @Override
+  public void postAtFront(Runnable runnable, String tag) {
+    post(runnable, tag);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * This implementation removes all instances of the provided {@code Runnable} and prevents them
+   * from running if they have not started yet.
+   */
+  @Override
+  public void remove(Runnable runnable) {
+    synchronized (pendingTasks) {
+      pendingTasks.setCount(runnable, 0);
+    }
+  }
+
+  @Override
+  public boolean isTracing() {
+    return false;
+  }
+}

--- a/litho-it/src/test/java/com/facebook/litho/ExecutorLithoHandlerTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/ExecutorLithoHandlerTest.java
@@ -1,0 +1,88 @@
+package com.facebook.litho;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.facebook.litho.testing.testrunner.LithoTestRunner;
+import java.util.ArrayDeque;
+import java.util.concurrent.Executor;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(LithoTestRunner.class)
+public final class ExecutorLithoHandlerTest {
+
+  private static final String TAG = "testTag";
+
+  private final QueuingExecutor executor = new QueuingExecutor();
+  private final ExecutorLithoHandler lithoHandler = new ExecutorLithoHandler(executor);
+
+  private int runCounter;
+  private Runnable runnable = () -> runCounter++;
+
+  @Test
+  public void testIsTracing_returnsFalse() {
+    assertThat(lithoHandler.isTracing()).isFalse();
+  }
+
+  @Test
+  public void testPost_multipleInstancesOfSameRunnable_runsAll() {
+    lithoHandler.post(runnable, TAG);
+    lithoHandler.post(runnable, TAG);
+
+    executor.runAllQueuedTasks();
+
+    assertThat(runCounter).isEqualTo(2);
+  }
+
+  @Test
+  public void testPost_multipleRunnables_runsAll() {
+    Runnable runnable2 = () -> runCounter += 2;
+
+    lithoHandler.post(runnable, TAG);
+    lithoHandler.post(runnable2, TAG);
+
+    executor.runAllQueuedTasks();
+
+    assertThat(runCounter).isEqualTo(3);
+  }
+
+  @Test
+  public void testRemove_removesAllInstances() {
+    lithoHandler.post(runnable, TAG);
+    lithoHandler.post(runnable, TAG);
+    lithoHandler.post(runnable, TAG);
+    lithoHandler.remove(runnable);
+
+    executor.runAllQueuedTasks();
+
+    assertThat(runCounter).isEqualTo(0);
+  }
+
+  @Test
+  public void testRemoveThenPost_runsOnce() {
+    lithoHandler.post(runnable, TAG);
+    lithoHandler.post(runnable, TAG);
+    lithoHandler.remove(runnable);
+    lithoHandler.post(runnable, TAG);
+
+    executor.runAllQueuedTasks();
+
+    assertThat(runCounter).isEqualTo(1);
+  }
+
+  private static class QueuingExecutor implements Executor {
+    private final ArrayDeque<Runnable> queue = new ArrayDeque<>();
+
+    @Override
+    public void execute(Runnable runnable) {
+      queue.add(runnable);
+    }
+
+    public void runAllQueuedTasks() {
+      while (!queue.isEmpty()) {
+        Runnable runnable = queue.removeFirst();
+        runnable.run();
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This change adds the ExecutorLithoHandler, which is a LithoHandler
implementation that runs all layout computations against a given
Executor. The ExecutorLithoHandler can be used in apps that already
have a well established threading model and would like to use one
of their pre-existing Executors to run all layout against.

## Changelog

Adds a new LithoHandler implementation that uses Executors.

## Test Plan

Unit tests have been added as part of the change.

