### PR TITLE
Un-deprecate the estimatedViewPortCount API in RecyclerBinder

### DIFF
--- a/litho-widget/src/main/java/com/facebook/litho/widget/RecyclerBinder.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/RecyclerBinder.java
@@ -643,10 +643,10 @@ public class RecyclerBinder
     }
 
     /**
-     * This is a temporary hack that allows a surface to manually provide an estimated range. It
-     * will go away so don't depend on it.
+     * This is used in very specific cases on critical performance paths where measuring the first
+     * item cannot be relied on to estimate the viewport count. It should not be used in the common
+     * case, use with caution.
      */
-    @Deprecated
     public Builder estimatedViewportCount(int estimatedViewportCount) {
       if (estimatedViewportCount <= 0) {
         throw new IllegalArgumentException(


### PR DESCRIPTION
## Summary

The estimatedViewPortCount API was added a few months back and was
initially marked as @Deprecated. This API has found legitimate uses in
certain scenarios, so it can be un-deprecated and added to the list of
public RecyclerBinder APIs, but with a comment offering a warming that
it should only be used under specific scenarios and not in the general
case.

## Changelog

Un-deprecate the estimatedViewPortCount API in RecyclerBinder

## Test Plan

N/A, as this commit is mainly affecting documentation.
