### PR TITLE
Fix issue in SimpleMountSpecTesterSpec

### DIFF
--- a/litho-it/src/main/java/com/facebook/litho/widget/SimpleMountSpecTesterSpec.java
+++ b/litho-it/src/main/java/com/facebook/litho/widget/SimpleMountSpecTesterSpec.java
@@ -42,7 +42,7 @@ class SimpleMountSpecTesterSpec {
       Size size,
       @Prop(optional = true) @Nullable Integer measuredWidth,
       @Prop(optional = true) @Nullable Integer measuredHeight) {
-    if (measuredHeight == null && measuredHeight == null) {
+    if (measuredWidth == null && measuredHeight == null) {
       size.width = SizeSpec.getSize(widthSpec);
       size.height = SizeSpec.getSize(heightSpec);
     } else {


### PR DESCRIPTION
## Summary

Fixing an issue in SimpleMountSpecTesterSpec where measuredHeight was used twice
whereas measuredWidth was left unused. I believe the logic should check both
measuredHeight and measuredWidth.

## Changelog

Simple fix in SimpleMountSpecTesterSpec

## Test Plan

N/A, simple fix in a Spec used only in tests.
