### PR TITLE
Remove unnecessary null checks from DebugComponent

### DIFF
--- a/litho-core/src/main/java/com/facebook/litho/DebugComponent.java
+++ b/litho-core/src/main/java/com/facebook/litho/DebugComponent.java
@@ -195,7 +195,7 @@ public final class DebugComponent {
   @Nullable
   public View getMountedView() {
     final Component component = mNode.getTailComponent();
-    if (component != null && Component.isMountViewSpec(component)) {
+    if (Component.isMountViewSpec(component)) {
       return (View) getMountedContent();
     }
 
@@ -206,7 +206,7 @@ public final class DebugComponent {
   @Nullable
   public Drawable getMountedDrawable() {
     final Component component = mNode.getTailComponent();
-    if (component != null && Component.isMountDrawableSpec(component)) {
+    if (Component.isMountDrawableSpec(component)) {
       return (Drawable) getMountedContent();
     }
 


### PR DESCRIPTION
## Summary

Remove two unnecessary null checks from DebugComponent.  In both cases, the second condition of the `if` statement (`Component.isMountViewSpec(component)`) internally performs the same null check ([here](https://github.com/facebook/litho/blob/bc7ebe1a33d9d5e518d975ddb895732f1c25922e/litho-core/src/main/java/com/facebook/litho/Component.java#L798)).

## Changelog

Remove two unnecessary null checks from DebugComponent.

## Test Plan

This quick change only removes redundancy: it does not actually change the logic or UI.