### PR TITLE
Move litho tests to run with binary resources

### DIFF
--- a/litho-core-kotlin/src/test/kotlin/com/facebook/litho/BUCK
+++ b/litho-core-kotlin/src/test/kotlin/com/facebook/litho/BUCK
@@ -29,7 +29,6 @@ litho_robolectric4_test(
     ],
     source = "8",
     target = "8",
-    use_binary_resources = False,
     deps = [
         LITHO_ANDROIDSUPPORT_TESTING_CORE_TARGET,
         LITHO_ASSERTJ_TARGET,

--- a/litho-it-powermock/src/test/java/com/facebook/litho/testing/viewtree/BUCK
+++ b/litho-it-powermock/src/test/java/com/facebook/litho/testing/viewtree/BUCK
@@ -24,7 +24,6 @@ litho_robolectric4_test(
     fork_mode = "per_test",
     source = "8",
     target = "8",
-    use_binary_resources = False,
     deps = [
         LITHO_ANDROIDSUPPORT_TESTING_CORE_TARGET,
         LITHO_BUILD_CONFIG_TARGET,

--- a/litho-it-spec/src/test/java/com/facebook/litho/BUCK
+++ b/litho-it-spec/src/test/java/com/facebook/litho/BUCK
@@ -37,7 +37,6 @@ litho_robolectric4_test(
         LITHO_PROGUARD_ANNOTATIONS_TARGET,
         LITHO_ROBOLECTRIC_V4_TARGET,
     ],
-    use_binary_resources = False,
     deps = [
         LITHO_ANDROIDSUPPORT_TESTING_CORE_TARGET,
         LITHO_BUILD_CONFIG_TARGET,

--- a/litho-it/src/main/BUCK
+++ b/litho-it/src/main/BUCK
@@ -1,3 +1,5 @@
+load("@fbsource//tools/build_defs:fb_native_wrapper.bzl", "fb_native")
+
 # Copyright (c) 2017-present, Facebook, Inc.
 #
 # This source code is licensed under the Apache 2.0 license found in the
@@ -16,4 +18,10 @@ fb_android_resource(
         make_dep_path("litho-it/src/test/..."),
         make_dep_path("litho-it-powermock/src/test/..."),
     ],
+)
+
+fb_native.android_manifest(
+    name = "manifest",
+    skeleton = "AndroidManifest.xml",
+    visibility = ["PUBLIC"],
 )

--- a/litho-it/src/test/java/com/facebook/litho/ApplyStylesTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/ApplyStylesTest.java
@@ -27,7 +27,6 @@ import com.facebook.litho.testing.testrunner.LithoTestRunner;
 import com.facebook.rendercore.testing.ViewAssertions;
 import com.facebook.rendercore.testing.match.MatchNode;
 import com.facebook.rendercore.testing.match.ViewMatchNode;
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -38,15 +37,8 @@ public class ApplyStylesTest {
 
   public @Rule LithoViewRule mLithoViewRule = new LithoViewRule();
 
-  @Before
-  public void setup() {
-    setComponentStyleableAttributes();
-  }
-
   @Test
   public void styles_withWidthHeightStyle_appliesWidthHeight() {
-    setComponentStyleableAttributes();
-
     mLithoViewRule
         .setSizeSpecs(
             View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED),
@@ -324,57 +316,5 @@ public class ApplyStylesTest {
                 .child(
                     ViewMatchNode.forType(ComponentHost.class)
                         .prop("isDuplicateParentStateEnabled", true)));
-  }
-
-  /**
-   * This is a hack around a BUCK and/or Robolectric issue where we use incorrect resource values.
-   * Component tests require the correct values for the ComponentLayout styleable array in order to
-   * bind props to the layout. The array that we define here needs to be kept up-to-date with the
-   * attrs defined in litho-core/src/main/res/*attrs.xml files.
-   */
-  static void setComponentStyleableAttributes() {
-
-    System.arraycopy(
-        new int[] {
-          com.facebook.litho.R.attr.flex_direction,
-          com.facebook.litho.R.attr.flex_layoutDirection,
-          com.facebook.litho.R.attr.flex_justifyContent,
-          com.facebook.litho.R.attr.flex_alignItems,
-          com.facebook.litho.R.attr.flex_alignSelf,
-          com.facebook.litho.R.attr.flex_positionType,
-          com.facebook.litho.R.attr.flex_wrap,
-          com.facebook.litho.R.attr.flex_left,
-          com.facebook.litho.R.attr.flex_top,
-          com.facebook.litho.R.attr.flex_right,
-          com.facebook.litho.R.attr.flex_bottom,
-          com.facebook.litho.R.attr.flex,
-          android.R.attr.layout_width,
-          android.R.attr.layout_height,
-          android.R.attr.padding,
-          android.R.attr.paddingLeft,
-          android.R.attr.paddingTop,
-          android.R.attr.paddingRight,
-          android.R.attr.paddingBottom,
-          android.R.attr.paddingStart,
-          android.R.attr.paddingEnd,
-          android.R.attr.layout_margin,
-          android.R.attr.layout_marginLeft,
-          android.R.attr.layout_marginTop,
-          android.R.attr.layout_marginRight,
-          android.R.attr.layout_marginBottom,
-          android.R.attr.layout_marginStart,
-          android.R.attr.layout_marginEnd,
-          android.R.attr.contentDescription,
-          android.R.attr.background,
-          android.R.attr.foreground,
-          android.R.attr.minHeight,
-          android.R.attr.minWidth,
-          android.R.attr.importantForAccessibility,
-          android.R.attr.duplicateParentState,
-        },
-        /* srcPos */ 0,
-        com.facebook.litho.R.styleable.ComponentLayout,
-        /* destPos */ 0,
-        com.facebook.litho.R.styleable.ComponentLayout.length);
   }
 }

--- a/litho-it/src/test/java/com/facebook/litho/BUCK
+++ b/litho-it/src/test/java/com/facebook/litho/BUCK
@@ -57,7 +57,6 @@ litho_robolectric4_test(
     ],
     source = "8",
     target = "8",
-    use_binary_resources = False,
     deps = [
         ":testutil",
         LITHO_ANDROIDSUPPORT_RECYCLERVIEW_TARGET,

--- a/litho-it/src/test/java/com/facebook/litho/animation/BUCK
+++ b/litho-it/src/test/java/com/facebook/litho/animation/BUCK
@@ -45,7 +45,6 @@ litho_robolectric4_test(
     ],
     source = "8",
     target = "8",
-    use_binary_resources = False,
     deps = [
         LITHO_ANDROIDSUPPORT_RECYCLERVIEW_TARGET,
         LITHO_ANDROIDSUPPORT_TESTING_CORE_TARGET,

--- a/litho-it/src/test/java/com/facebook/litho/animation/BUCK
+++ b/litho-it/src/test/java/com/facebook/litho/animation/BUCK
@@ -20,7 +20,6 @@ load(
     "LITHO_ROBOLECTRIC_V4_TARGET",
     "LITHO_SOLOADER_TARGET",
     "LITHO_STATS_TARGET",
-    "LITHO_TESTING_CORE_TARGET",
     "LITHO_TESTING_TARGET",
     "LITHO_TESTING_WHITEBOX_TARGET",
     "LITHO_TEST_RES",
@@ -28,28 +27,17 @@ load(
     "LITHO_VIEWCOMPAT_TARGET",
     "LITHO_WIDGET_TARGET",
     "LITHO_YOGA_TARGET",
-    "litho_android_library",
     "litho_robolectric4_test",
     "make_dep_path",
 )
 
 litho_robolectric4_test(
-    name = "litho",
+    name = "animation",
     srcs = glob(
         [
-            "**/*.java",
-        ],
-        exclude = [
-            "animation/**/*.java",
-            "dataflow/**/*.java",
-            "intellij/**/*.java",
-            "sections/specmodels/**/*.java",
-            "processor/**/*.java",
-            "specmodels/**/*.java",
-            "testing/**/*.java",
+            "*.java",
         ],
     ),
-    autoglob = False,
     contacts = ["oncall+components_for_android@xmail.facebook.com"],
     is_androidx = True,
     provided_deps = [
@@ -59,7 +47,6 @@ litho_robolectric4_test(
     target = "8",
     use_binary_resources = False,
     deps = [
-        ":testutil",
         LITHO_ANDROIDSUPPORT_RECYCLERVIEW_TARGET,
         LITHO_ANDROIDSUPPORT_TESTING_CORE_TARGET,
         LITHO_ANDROIDSUPPORT_TARGET,
@@ -103,26 +90,5 @@ litho_robolectric4_test(
         make_dep_path("litho-testing/src/main/java/com/facebook/litho/testing/shadows:shadows"),
         make_dep_path("litho-testing/src/main/java/com/facebook/litho/testing/testrunner:testrunner"),
         make_dep_path("litho-testing/src/main/java/com/facebook/litho/testing/viewtree:viewtree"),
-    ],
-)
-
-litho_android_library(
-    name = "testutil",
-    srcs = [
-        "StateUpdateTestComponent.java",
-        "TouchExpansionTestInternalNode.java",
-    ],
-    autoglob = False,
-    source = "8",
-    target = "8",
-    visibility = [
-        make_dep_path("litho-it/src/test/java/com/facebook/litho/..."),
-    ],
-    deps = [
-        LITHO_ANDROIDSUPPORT_TARGET,
-        LITHO_JAVA_TARGET,
-        LITHO_JSR_TARGET,
-        LITHO_TESTING_CORE_TARGET,
-        LITHO_YOGA_TARGET,
     ],
 )

--- a/litho-it/src/test/java/com/facebook/litho/dataflow/BUCK
+++ b/litho-it/src/test/java/com/facebook/litho/dataflow/BUCK
@@ -47,7 +47,6 @@ litho_robolectric4_test(
     ],
     source = "8",
     target = "8",
-    use_binary_resources = False,
     deps = [
         ":nodes",
         LITHO_ANDROIDSUPPORT_RECYCLERVIEW_TARGET,

--- a/litho-it/src/test/java/com/facebook/litho/dataflow/BUCK
+++ b/litho-it/src/test/java/com/facebook/litho/dataflow/BUCK
@@ -34,22 +34,12 @@ load(
 )
 
 litho_robolectric4_test(
-    name = "litho",
+    name = "tests",
     srcs = glob(
         [
-            "**/*.java",
-        ],
-        exclude = [
-            "animation/**/*.java",
-            "dataflow/**/*.java",
-            "intellij/**/*.java",
-            "sections/specmodels/**/*.java",
-            "processor/**/*.java",
-            "specmodels/**/*.java",
-            "testing/**/*.java",
+            "*Test.java",
         ],
     ),
-    autoglob = False,
     contacts = ["oncall+components_for_android@xmail.facebook.com"],
     is_androidx = True,
     provided_deps = [
@@ -59,7 +49,7 @@ litho_robolectric4_test(
     target = "8",
     use_binary_resources = False,
     deps = [
-        ":testutil",
+        ":nodes",
         LITHO_ANDROIDSUPPORT_RECYCLERVIEW_TARGET,
         LITHO_ANDROIDSUPPORT_TESTING_CORE_TARGET,
         LITHO_ANDROIDSUPPORT_TARGET,
@@ -88,7 +78,6 @@ litho_robolectric4_test(
         make_dep_path("litho-it/src/main/java/com/facebook/litho/testing/error:error"),
         make_dep_path("litho-it/src/main/java/com/facebook/litho/testing/treeprop:treeprop"),
         make_dep_path("litho-it/src/main/java/com/facebook/litho/widget:widget"),
-        make_dep_path("litho-it/src/test/java/com/facebook/litho/dataflow:nodes"),
         make_dep_path("litho-processor/src/main/java/com/facebook/litho/specmodels/internal:internal"),
         make_dep_path("litho-sections-core/src/main/java/com/facebook/litho/sections:sections"),
         make_dep_path("litho-sections-core/src/main/java/com/facebook/litho/sections/common:common"),
@@ -107,11 +96,12 @@ litho_robolectric4_test(
 )
 
 litho_android_library(
-    name = "testutil",
-    srcs = [
-        "StateUpdateTestComponent.java",
-        "TouchExpansionTestInternalNode.java",
-    ],
+    name = "nodes",
+    srcs = glob(
+        [
+            "*Node.java",
+        ],
+    ),
     autoglob = False,
     source = "8",
     target = "8",
@@ -120,6 +110,7 @@ litho_android_library(
     ],
     deps = [
         LITHO_ANDROIDSUPPORT_TARGET,
+        LITHO_RENDERCORE_TARGET,
         LITHO_JAVA_TARGET,
         LITHO_JSR_TARGET,
         LITHO_TESTING_CORE_TARGET,

--- a/litho-it/src/test/java/com/facebook/litho/testing/BUCK
+++ b/litho-it/src/test/java/com/facebook/litho/testing/BUCK
@@ -24,7 +24,6 @@ litho_robolectric4_test(
     contacts = ["oncall+components_for_android@xmail.facebook.com"],
     source = "8",
     target = "8",
-    use_binary_resources = False,
     deps = [
         LITHO_ANDROIDSUPPORT_TESTING_CORE_TARGET,
         LITHO_ASSERTJ_TARGET,

--- a/litho-it/src/test/java/com/facebook/litho/testing/assertj/BUCK
+++ b/litho-it/src/test/java/com/facebook/litho/testing/assertj/BUCK
@@ -21,7 +21,6 @@ litho_robolectric4_test(
     contacts = ["oncall+components_for_android@xmail.facebook.com"],
     source = "8",
     target = "8",
-    use_binary_resources = False,
     deps = [
         LITHO_BUILD_CONFIG_TARGET,
         LITHO_JAVA_TARGET,

--- a/litho-it/src/test/java/com/facebook/litho/testing/helper/BUCK
+++ b/litho-it/src/test/java/com/facebook/litho/testing/helper/BUCK
@@ -26,7 +26,6 @@ litho_robolectric4_test(
     ],
     source = "8",
     target = "8",
-    use_binary_resources = False,
     deps = [
         LITHO_ANDROIDSUPPORT_TESTING_CORE_TARGET,
         LITHO_ASSERTJ_TARGET,

--- a/litho-it/src/test/java/com/facebook/litho/testing/subcomponents/BUCK
+++ b/litho-it/src/test/java/com/facebook/litho/testing/subcomponents/BUCK
@@ -29,7 +29,6 @@ litho_robolectric4_test(
     ],
     source = "8",
     target = "8",
-    use_binary_resources = False,
     deps = [
         LITHO_ANNOTATIONS_TARGET,
         LITHO_ASSERTJ_TARGET,

--- a/litho-it/src/test/java/com/facebook/litho/testing/viewtree/BUCK
+++ b/litho-it/src/test/java/com/facebook/litho/testing/viewtree/BUCK
@@ -25,7 +25,6 @@ litho_robolectric4_test(
     contacts = ["oncall+components_for_android@xmail.facebook.com"],
     source = "8",
     target = "8",
-    use_binary_resources = False,
     deps = [
         LITHO_ANDROIDSUPPORT_TESTING_CORE_TARGET,
         LITHO_BUILD_CONFIG_TARGET,

--- a/litho-testing/src/main/java/com/facebook/litho/testing/testrunner/LithoTestRunner.java
+++ b/litho-testing/src/main/java/com/facebook/litho/testing/testrunner/LithoTestRunner.java
@@ -36,47 +36,16 @@ public class LithoTestRunner extends RobolectricTestRunner {
     super(testClass);
   }
 
-  enum ProjectEnvironment {
-    INTERNAL,
-    OSS;
-
-    static ProjectEnvironment detectFromSystemProperties() {
-      final String property = System.getProperty("com.facebook.litho.is_oss");
-      // If this isn't set, you're probably not running Buck, ergo this isn't an internal build.
-      if (property == null) {
-        return OSS;
-      }
-
-      return property.equals("true") ? OSS : INTERNAL;
-    }
-  }
-
-  private static String getResPrefix() {
+  @Override
+  protected Config buildGlobalConfig() {
     // If we're running with gradle, the test runner will start running from within
     // the given sub-project.
     if (System.getProperty("org.gradle.test.worker") != null) {
-      return "../litho-it/src/main/";
+      return new Config.Builder().setManifest("../litho-it/src/main/AndroidManifest.xml").build();
     }
 
-    String prefix = "";
-    switch (ProjectEnvironment.detectFromSystemProperties()) {
-      case OSS:
-        break;
-      case INTERNAL:
-        final String internalRoot = System.getProperty("com.facebook.litho.internal_root");
-        if (internalRoot != null) {
-          prefix = internalRoot + "/";
-        }
-    }
-
-    return prefix + "litho-it/src/main/";
-  }
-
-  @Override
-  protected Config buildGlobalConfig() {
-    // We are hard-coding the path here instead of relying on BUCK internals
-    // to allow for building with gradle in the Open Source version.
-    return new Config.Builder().setManifest(getResPrefix() + "AndroidManifest.xml").build();
+    // BUCK will set up the manifest correctly, so nothing to do here.
+    return super.buildGlobalConfig();
   }
 
   @Override

--- a/sample-codelab/src/test/java/com/facebook/samples/lithocodelab/examples/modules/BUCK
+++ b/sample-codelab/src/test/java/com/facebook/samples/lithocodelab/examples/modules/BUCK
@@ -26,7 +26,6 @@ litho_robolectric4_test(
     contacts = ["oncall+components_for_android@xmail.facebook.com"],
     source = "8",
     target = "8",
-    use_binary_resources = False,
     deps = [
         LITHO_ANDROIDSUPPORT_RECYCLERVIEW_TARGET,
         LITHO_ASSERTJ_TARGET,

--- a/sample/src/test/java/com/facebook/samples/litho/BUCK
+++ b/sample/src/test/java/com/facebook/samples/litho/BUCK
@@ -34,7 +34,6 @@ litho_robolectric4_test(
     contacts = ["oncall+components_for_android@xmail.facebook.com"],
     source = "8",
     target = "8",
-    use_binary_resources = False,
     deps = [
         ":testspecs",
         LITHO_ANDROIDSUPPORT_RECYCLERVIEW_TARGET,

--- a/tools/build_defs/oss/litho_defs.bzl
+++ b/tools/build_defs/oss/litho_defs.bzl
@@ -80,6 +80,8 @@ LITHO_TESTING_ESPRESSO_TARGET = make_dep_path("litho-espresso/src/main/java/com/
 
 LITHO_TEST_RES = make_dep_path("litho-it/src/main:res")
 
+LITHO_TEST_MANIFEST = make_dep_path("litho-it/src/main:manifest")
+
 LITHO_SECTIONS_TARGET = make_dep_path("litho-sections-core/src/main/java/com/facebook/litho/sections:sections")
 
 LITHO_SECTIONS_COMMON_TARGET = make_dep_path("litho-sections-core/src/main/java/com/facebook/litho/sections/common:common")
@@ -256,6 +258,7 @@ def litho_robolectric4_test(
     kwargs["cxx_library_whitelist"] = [
         "//lib/yogajni:jni",
     ]
+    kwargs["robolectric_manifest"] = kwargs.pop("robolectric_manifest", LITHO_TEST_MANIFEST)
 
     # T41117446 Remove after AndroidX conversion is done.
     kwargs.pop("is_androidx", False)


### PR DESCRIPTION
Summary:
Legacy resources are deprecated, we should use binary resources which is closer to emulating what the Android resource system does.

We fix LithoTestRunner to only set a manifest for the gradle build, and we set the Litho manifest in the bzl macro.

Differential Revision: D25794343

