### PR TITLE
Remove unnecessary public modifiers from ClickableSpanListener interface methods

### DIFF
--- a/litho-widget/src/main/java/com/facebook/litho/widget/ClickableSpanListener.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/ClickableSpanListener.java
@@ -31,11 +31,11 @@ public interface ClickableSpanListener {
    * @return true if click action needs to be handled here instead of delegating it to {@link
    *     ClickableSpan#onClick(View)}.
    */
-  public boolean onClick(ClickableSpan span, View view);
+  boolean onClick(ClickableSpan span, View view);
 
   /**
    * @return true if long click action needs to be handled here instead of delegating to {@link
    *     LongClickableSpan#onLongClick(View)}.
    */
-  public boolean onLongClick(LongClickableSpan span, View view);
+  boolean onLongClick(LongClickableSpan span, View view);
 }


### PR DESCRIPTION
## Summary

The abstract methods in the ClickableSpanListener interface include 'public' modifiers - those are redundant, since all interface abstract methods are implicitly public anyway.
 
## Changelog

Remove the 'public' modifiers from ClickableSpanListener's onClick and onLongClick methods.

## Test Plan

N/A - this change doesn't modify any functionality
