### PR TITLE
Expose font descent in Litho Text Spec

### DIFF
--- a/litho-widget/src/main/java/com/facebook/litho/widget/TextSpec.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/TextSpec.java
@@ -242,7 +242,8 @@ class TextSpec {
       Output<Float> shadowDy,
       Output<Integer> shadowColor,
       Output<VerticalGravity> verticalGravity,
-      Output<Typeface> typeface) {
+      Output<Typeface> typeface,
+      Output<Float> measuredLineDescent) {
 
     TextStylesHelper.onLoadStyle(
         c,
@@ -369,9 +370,9 @@ class TextSpec {
     // Adjust height according to the minimum number of lines.
     int preferredHeight = LayoutMeasureUtil.getHeight(newLayout);
     final int lineCount = newLayout.getLineCount();
+    final TextPaint paint = newLayout.getPaint();
+    measuredLineDescent.set(paint.descent());
     if (lineCount < minLines) {
-      final TextPaint paint = newLayout.getPaint();
-
       final int layoutLineHeight =
           Math.round(paint.getFontMetricsInt(null) * spacingMultiplier + extraSpacing);
       preferredHeight += layoutLineHeight * (minLines - lineCount);


### PR DESCRIPTION
## Summary

This will allow us to extract font specs in Elements TextComponentSpec for calculating baseline last height by reflection:

```
Field field = Text.class.getDeclaredField("measuredLineDescent");
TextPaint paint = (TextPaint) field.get(textComponent);
```

## Changelog

Expose font descent in Litho Text Spec
