### PR TITLE
Fix ellipsizing with styled custom ellipsis text

### DIFF
--- a/litho-it/src/test/java/com/facebook/litho/widget/TextSpecTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/widget/TextSpecTest.java
@@ -16,6 +16,7 @@
 
 package com.facebook.litho.widget;
 
+import static androidx.core.text.TextDirectionHeuristicsCompat.FIRSTSTRONG_LTR;
 import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -30,9 +31,11 @@ import android.graphics.drawable.Drawable;
 import android.text.Layout;
 import android.text.Spannable;
 import android.text.style.ClickableSpan;
+import android.text.TextUtils.TruncateAt;
 import android.util.SparseArray;
 import android.view.MotionEvent;
 import android.view.View;
+import androidx.core.text.TextDirectionHeuristicCompat;
 import com.facebook.litho.ComponentContext;
 import com.facebook.litho.EventHandler;
 import com.facebook.litho.LithoView;
@@ -508,6 +511,137 @@ public class TextSpecTest {
             getMountedDrawableLayoutAlignment(
                 ARABIC_RTL_TEST_STRING, YogaDirection.RTL, null, TextAlignment.RIGHT))
         .isEqualTo(Layout.Alignment.ALIGN_NORMAL);
+  }
+
+  /* Test for LTR text aligned left. */
+  @Test
+  public void testCustomEllipsisTextForLtrShortText() {
+    TextDrawable textDrawable =
+        getMountedDrawableForTextWithMaxLines(
+            "Simple\nSome second line", 1, "Truncate", TextAlignment.LEFT, FIRSTSTRONG_LTR);
+
+    assertEquals(textDrawable.getText().toString(), "SimpleTruncate");
+  }
+
+  @Test
+  public void testCustomEllipsisTextForLtrLongText() {
+    TextDrawable textDrawable =
+        getMountedDrawableForTextWithMaxLines(
+            "Simple sentence that should be quite long quite long quite long quite long quite long"
+                + " quite long quite long\n"
+                + "Some second line",
+            1,
+            "Truncate",
+            TextAlignment.LEFT,
+            FIRSTSTRONG_LTR);
+
+    assertEquals(
+        textDrawable.getText().toString(),
+        "Simple sentence that should be quite long quite long quite long quite long quite long"
+            + " quiteTruncate");
+  }
+
+  @Test
+  public void testCustomEllipsisTextForLtrShortTextWithShortEllipsis() {
+    TextDrawable textDrawable =
+        getMountedDrawableForTextWithMaxLines(
+            "Simple\nSome second line", 1, ".", TextAlignment.LEFT, FIRSTSTRONG_LTR);
+
+    assertEquals(textDrawable.getText().toString(), "Simple.");
+  }
+
+  @Test
+  public void testCustomEllipsisTextForLtrLongTextWithShortEllipsis() {
+    TextDrawable textDrawable =
+        getMountedDrawableForTextWithMaxLines(
+            "Simple sentence that should be quite long quite long quite long quite long quite long"
+                + " quite long quite long\n"
+                + "Some second line",
+            1,
+            ".",
+            TextAlignment.LEFT,
+            FIRSTSTRONG_LTR);
+
+    assertEquals(
+        textDrawable.getText().toString(),
+        "Simple sentence that should be quite long quite long quite long quite long quite long"
+            + " quite long q.");
+  }
+
+  /* Test for LTR text aligned right. */
+  @Test
+  public void testCustomEllipsisTextForLtrShortTextAlignedRight() {
+    TextDrawable textDrawable =
+        getMountedDrawableForTextWithMaxLines(
+            "Simple\nSome second line", 1, "Truncate", TextAlignment.RIGHT, FIRSTSTRONG_LTR);
+
+    assertEquals(textDrawable.getText().toString(), "SimpleTruncate");
+  }
+
+  @Test
+  public void testCustomEllipsisTextForLtrLongTextAlignedRight() {
+    TextDrawable textDrawable =
+        getMountedDrawableForTextWithMaxLines(
+            "Simple sentence that should be quite long quite long quite long quite long quite long"
+                + " quite long quite long\n"
+                + "Some second line",
+            1,
+            "Truncate",
+            TextAlignment.RIGHT,
+            FIRSTSTRONG_LTR);
+
+    assertEquals(
+        textDrawable.getText().toString(),
+        "Simple sentence that should be quite long quite long quite long quite long quite long"
+            + " quiteTruncate");
+  }
+
+  @Test
+  public void testCustomEllipsisTextForLtrShortTextWithShortEllipsisAlignedRight() {
+    TextDrawable textDrawable =
+        getMountedDrawableForTextWithMaxLines(
+            "Simple\nSome second line", 1, ".", TextAlignment.RIGHT, FIRSTSTRONG_LTR);
+
+    assertEquals(textDrawable.getText().toString(), "Simple.");
+  }
+
+  @Test
+  public void testCustomEllipsisTextForLtrLongTextWithShortEllipsisAlignedRight() {
+    TextDrawable textDrawable =
+        getMountedDrawableForTextWithMaxLines(
+            "Simple sentence that should be quite long quite long quite long quite long quite long"
+                + " quite long quite long\n"
+                + "Some second line",
+            1,
+            ".",
+            TextAlignment.RIGHT,
+            FIRSTSTRONG_LTR);
+
+    assertEquals(
+        textDrawable.getText().toString(),
+        "Simple sentence that should be quite long quite long quite long quite long quite long"
+            + " quite long q.");
+  }
+
+  private TextDrawable getMountedDrawableForTextWithMaxLines(
+      CharSequence text,
+      int maxLines,
+      String customEllipsisText,
+      TextAlignment alignment,
+      TextDirectionHeuristicCompat textDirection) {
+    return (TextDrawable)
+        ComponentTestHelper.mountComponent(
+            mContext,
+            Text.create(mContext)
+                .ellipsize(TruncateAt.END)
+                .textDirection(textDirection)
+                .text(text)
+                .alignment(alignment)
+                .maxLines(maxLines)
+                .customEllipsisText(customEllipsisText)
+                .build())
+            .getDrawables()
+            .get(0);
   }
 
   private Layout.Alignment getMountedDrawableLayoutAlignment(

--- a/litho-widget/src/main/java/com/facebook/litho/widget/TextSpec.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/TextSpec.java
@@ -700,9 +700,45 @@ class TextSpec {
     if (customEllipsisText != null && !customEllipsisText.equals("")) {
       final int ellipsizedLineNumber = getEllipsizedLineNumber(textLayout.get());
       if (ellipsizedLineNumber != -1) {
+        Layout customEllipsisLayout =
+            createTextLayout(
+                c,
+                SizeSpec.makeSizeSpec((int) layoutWidth, EXACTLY),
+                ellipsize,
+                shouldIncludeFontPadding,
+                maxLines,
+                shadowRadius,
+                shadowDx,
+                shadowDy,
+                shadowColor,
+                isSingleLine,
+                customEllipsisText,
+                textColor,
+                textColorStateList,
+                linkColor,
+                textSize,
+                extraSpacing,
+                spacingMultiplier,
+                letterSpacing,
+                textStyle,
+                typeface,
+                getTextAlignment(textAlignment, alignment),
+                glyphWarming,
+                layout.getResolvedLayoutDirection(),
+                minEms,
+                maxEms,
+                minTextWidth,
+                maxTextWidth,
+                c.getAndroidContext().getResources().getDisplayMetrics().density,
+                breakStrategy,
+                hyphenationFrequency,
+                justificationMode,
+                textDirection,
+                lineHeight);
+
         final CharSequence truncated =
             truncateText(
-                text, customEllipsisText, textLayout.get(), ellipsizedLineNumber, layoutWidth);
+                text, customEllipsisText, textLayout.get(), customEllipsisLayout, ellipsizedLineNumber, layoutWidth);
 
         Layout newLayout =
             createTextLayout(
@@ -760,6 +796,8 @@ class TextSpec {
    * @param text Text to truncate
    * @param customEllipsisText Text to append to the end to indicate truncation happened
    * @param newLayout A Layout object populated with measurement information for this text
+   * @param ellipsisTextLayout A Layout object populated with measurement information for the
+   *     ellipsis text.
    * @param ellipsizedLineNumber The line number within the text at which truncation occurs (i.e.
    *     the last visible line).
    * @return The provided text truncated in such a way that the 'customEllipsisText' can appear at
@@ -769,16 +807,14 @@ class TextSpec {
       CharSequence text,
       CharSequence customEllipsisText,
       Layout newLayout,
+      Layout ellipsisTextLayout,
       int ellipsizedLineNumber,
       float layoutWidth) {
-    Rect bounds = new Rect();
-    newLayout
-        .getPaint()
-        .getTextBounds(customEllipsisText.toString(), 0, customEllipsisText.length(), bounds);
+    float customEllipsisTextWidth = ellipsisTextLayout.getLineWidth(0);
     // Identify the X position at which to truncate the final line:
     // Note: The left position of the line is needed for the case of RTL text.
     final float ellipsisTarget =
-        layoutWidth - bounds.width() + newLayout.getLineLeft(ellipsizedLineNumber);
+        layoutWidth - customEllipsisTextWidth + newLayout.getLineLeft(ellipsizedLineNumber);
     // Get character offset number corresponding to that X position:
     int ellipsisOffset = newLayout.getOffsetForHorizontal(ellipsizedLineNumber, ellipsisTarget);
     if (ellipsisOffset > 0) {


### PR DESCRIPTION
## Summary

At the moment it seems that Litho is not measuring styled ellipsis text properly.
This PR creates a new text Layout for the custom ellipsis text and uses that to
calculate the text width and drive text truncation. It also caters for cases when
the text might be left aligned or have an RTL direction.

## Changelog

Fixes the way styled ellipsis text is measured.

## Test Plan

Unit tests have been added.
