### PR TITLE
Compute range on sync layout

### DIFF
--- a/litho-core/src/main/java/com/facebook/litho/config/ComponentsConfiguration.java
+++ b/litho-core/src/main/java/com/facebook/litho/config/ComponentsConfiguration.java
@@ -228,6 +228,9 @@ public class ComponentsConfiguration {
 
   public static boolean useVisibilityExtension = false;
 
+  /** Start parallel layout of visible range just before serial synchronous layouts in RecyclerBinder */
+  public static boolean computeRangeOnSyncLayout = false;
+
   /**
    * If {@code false} we won't force Component to update when Device Orientation change, and rely on
    * its size change.

--- a/litho-widget/src/main/java/com/facebook/litho/widget/RecyclerBinder.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/RecyclerBinder.java
@@ -3203,6 +3203,10 @@ public class RecyclerBinder
   }
 
   private void computeRange(int firstVisible, int lastVisible) {
+    computeRange(firstVisible, lastVisible, mRangeTraverser);
+  }
+
+  private void computeRange(int firstVisible, int lastVisible, RecyclerRangeTraverser traverser) {
     final int rangeSize;
     final int rangeStart;
     final int rangeEnd;
@@ -3227,7 +3231,7 @@ public class RecyclerBinder
       }
     }
 
-    mRangeTraverser.traverse(
+    traverser.traverse(
         0,
         treeHoldersSize,
         firstVisible,
@@ -3571,6 +3575,26 @@ public class RecyclerBinder
         final int childrenWidthSpec = getActualChildrenWidthSpec(componentTreeHolder);
         final int childrenHeightSpec = getActualChildrenHeightSpec(componentTreeHolder);
         if (!componentTreeHolder.isTreeValidForSizeSpecs(childrenWidthSpec, childrenHeightSpec)) {
+
+          if (ComponentsConfiguration.computeRangeOnSyncLayout) {
+            // Since synchronous layout is about to happen, and the ScrollListener that updates the
+            // visible and working ranges will not fire until after the full frame is rendered,
+            // we want to kick off background layout for the estimated visible range in the scrolling
+            // direction in an attempt to take advantage of more parallel layout.
+            if (mCurrentFirstVisiblePosition != RecyclerView.NO_POSITION
+                && mCurrentLastVisiblePosition != RecyclerView.NO_POSITION) {
+              // Get the last known visible range if available.
+              final int range = mCurrentLastVisiblePosition - mCurrentFirstVisiblePosition;
+              if (position > mCurrentLastVisiblePosition) {
+                // Scrolling down
+                computeRange(position, position + range, RecyclerRangeTraverser.FORWARD_TRAVERSER);
+              } else if (position < mCurrentFirstVisiblePosition) {
+                // Scrolling up
+                computeRange(position - range, position, RecyclerRangeTraverser.BACKWARD_TRAVERSER);
+              }
+            }
+          }
+
           final Size size = new Size();
           componentTreeHolder.computeLayoutSync(
               mComponentContext, childrenWidthSpec, childrenHeightSpec, size);


### PR DESCRIPTION
RecyclerBinder's prefetch happens on onScroll events, but onScroll is only fired *after* a full frame is rendered. 

For fast flings, this could lead to situations where an entire screen is rendered serially and synchronously on the main thread before any parallel layout is kicked off in onScroll.

This change kicks off parallel rendering of an estimated screen size in the direction of scroll immediately upon encountering a synchronous layout.

Combined with LayoutStateFutures, this should unblock the main thread faster than serial synchronous layout in these situations.