### PR TITLE
added new baseline enums to yoga

### DIFF
--- a/lib/yoga/src/main/cpp/yoga/YGEnums.cpp
+++ b/lib/yoga/src/main/cpp/yoga/YGEnums.cpp
@@ -1,10 +1,9 @@
 /*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * This source code is licensed under the MIT license found in the LICENSE
+ * file in the root directory of this source tree.
  */
-
 #include "YGEnums.h"
 
 const char* YGAlignToString(const YGAlign value) {
@@ -25,6 +24,10 @@ const char* YGAlignToString(const YGAlign value) {
       return "space-between";
     case YGAlignSpaceAround:
       return "space-around";
+    case YGAlignBaslineFirst:
+      return "baseline-first";
+    case YGAlignBaslineLast:
+      return "baseline-last";
   }
   return "unknown";
 }
@@ -179,8 +182,6 @@ const char* YGOverflowToString(const YGOverflow value) {
 
 const char* YGPositionTypeToString(const YGPositionType value) {
   switch (value) {
-    case YGPositionTypeStatic:
-      return "static";
     case YGPositionTypeRelative:
       return "relative";
     case YGPositionTypeAbsolute:

--- a/lib/yoga/src/main/cpp/yoga/YGEnums.h
+++ b/lib/yoga/src/main/cpp/yoga/YGEnums.h
@@ -1,10 +1,9 @@
 /*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * This source code is licensed under the MIT license found in the LICENSE
+ * file in the root directory of this source tree.
  */
-
 #pragma once
 
 #include "YGMacros.h"
@@ -63,7 +62,9 @@ YG_ENUM_SEQ_DECL(
     YGAlignStretch,
     YGAlignBaseline,
     YGAlignSpaceBetween,
-    YGAlignSpaceAround);
+    YGAlignSpaceAround,
+    YGAlignBaslineFirst,
+    YGAlignBaslineLast);
 
 YG_ENUM_SEQ_DECL(YGDimension, YGDimensionWidth, YGDimensionHeight)
 
@@ -128,11 +129,7 @@ YG_ENUM_SEQ_DECL(
     YGOverflowHidden,
     YGOverflowScroll)
 
-YG_ENUM_SEQ_DECL(
-    YGPositionType,
-    YGPositionTypeStatic,
-    YGPositionTypeRelative,
-    YGPositionTypeAbsolute)
+YG_ENUM_SEQ_DECL(YGPositionType, YGPositionTypeRelative, YGPositionTypeAbsolute)
 
 YG_ENUM_DECL(
     YGPrintOptions,

--- a/lib/yoga/src/main/java/com/facebook/yoga/YogaAlign.java
+++ b/lib/yoga/src/main/java/com/facebook/yoga/YogaAlign.java
@@ -1,12 +1,14 @@
-/*
+/**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * This source code is licensed under the MIT license found in the LICENSE
+ * file in the root directory of this source tree.
  */
-
 package com.facebook.yoga;
 
+import com.facebook.proguard.annotations.DoNotStrip;
+
+@DoNotStrip
 public enum YogaAlign {
   AUTO(0),
   FLEX_START(1),
@@ -15,7 +17,9 @@ public enum YogaAlign {
   STRETCH(4),
   BASELINE(5),
   SPACE_BETWEEN(6),
-  SPACE_AROUND(7);
+  SPACE_AROUND(7),
+  BASELINE_FIRST(8),
+  BASELINE_LAST(9);
 
   private final int mIntValue;
 
@@ -37,6 +41,8 @@ public enum YogaAlign {
       case 5: return BASELINE;
       case 6: return SPACE_BETWEEN;
       case 7: return SPACE_AROUND;
+      case 8: return BASELINE_FIRST;
+      case 9: return BASELINE_LAST;
       default: throw new IllegalArgumentException("Unknown enum value: " + value);
     }
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you taking the time to work on these 
changes. Please provide enough information so that others can review your pull request. The three 
fields below are mandatory. -->

## Summary

Add the new baseline enums to yoga align.
Currently Yoga only has a BASELINE enums. New baseline enums are used in web:
BASELINE_LAST
BASELINE_FIRST
https://developer.mozilla.org/en-US/docs/Web/CSS/align-items#support_in_flex_layout
Given that Litho has a custom baseline function, developers can take advantage of the new baseline types in the layout calculation.

## Changelog

Added baseline_first and baseline_last in Yoga.

## Test Plan



<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, output of 
the test runner and how you invoked it (you've added tests, right?), screenshots/videos if the pull 
request changes UI. -->

https://drive.google.com/file/d/1PQt4GLJoMoaD5AaUZ818KzpOscP16msn/view?usp=sharing
https://drive.google.com/file/d/1Bp7BhdJqneERAUm8gwxXvdcOyQ9u7AvJ/view?usp=sharing