### PR TITLE
Use floats for textSizeDip in Kotlin tutorial

### DIFF
--- a/docs/tutorial/project-setup.mdx
+++ b/docs/tutorial/project-setup.mdx
@@ -195,7 +195,7 @@ public class MyActivity extends AppCompatActivity {
     	  this /* context */,
     	  Text.create(c)
             .text("Hello, World!")
-            .textSizeDip(50)
+            .textSizeDip(50f)
             .build());
 
     setContentView(lithoView);
@@ -222,7 +222,7 @@ class MyActivity : AppCompatActivity() {
         this /* context */,
         Text.create(c)
             .text("Hello, World!")
-            .textSizeDip(50)
+            .textSizeDip(50f)
             .build())
 
     setContentView(lithoView)


### PR DESCRIPTION
## Summary

The "Setting up the project" tutorial page has this Kotlin:
```kotlin
Text.create(c)
  .text("Hello, World!")
  .textSizeDip(50)
  .build())
```
but this doesn't work, as `textSizeDip` takes a float. This fixes it by using float notation (`50f`).

## Changelog

Minor docs fixup

## Test Plan

N/A
