### PR TITLE
Mention context instead of component class in TreeProp validation errors

### DIFF
--- a/litho-it/src/test/java/com/facebook/litho/specmodels/model/TreePropValidationTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/specmodels/model/TreePropValidationTest.java
@@ -44,7 +44,7 @@ public class TreePropValidationTest {
   @Before
   public void setup() {
     when(mSpecModel.getRepresentedObject()).thenReturn(mModelRepresentedObject);
-    when(mSpecModel.getComponentClass()).thenReturn(ClassNames.COMPONENT_CONTEXT);
+    when(mSpecModel.getContextClass()).thenReturn(ClassNames.COMPONENT_CONTEXT);
   }
 
   @Test

--- a/litho-processor/src/main/java/com/facebook/litho/specmodels/model/TreePropValidation.java
+++ b/litho-processor/src/main/java/com/facebook/litho/specmodels/model/TreePropValidation.java
@@ -57,7 +57,7 @@ class TreePropValidation {
             new SpecModelValidationError(
                 onCreateTreePropMethod.representedObject,
                 "The first argument of an @OnCreateTreeProp method should be "
-                    + specModel.getComponentClass()
+                    + specModel.getContextClass()
                     + "."));
       }
     }


### PR DESCRIPTION
## Summary

Currently, `@OnCreateTreeProp` validation gives a confusing/incorrect error when missing the context argument. Given this spec:
```java
@LayoutSpec
public class MyComponentSpec {

    @OnCreateLayout
    public static Component onCreateLayout(
        ComponentContext c
    ) {
        return EmptyComponent.create(c).build();
    }

    @OnCreateTreeProp
    public static MyTreeProp onCreateTreeProp(
        @Prop MyTreeProp myProp
    ) {
        return myProp;
    }

}
```
The following error is reported:
>```
>MyComponentSpec.java:22: error: The first argument of an @OnCreateTreeProp method should be com.facebook.litho.Component.
>    public static MyTreeProp onCreateTreeProp(
>                             ^
>```

It actually wants a `ComponentContext`, not a `Component`. Similarly, in a Section spec, the error reports that the argument should be a `Section`, when it instead should be a `SectionContext`.

This seems to be happening because `TreePropValidation` is using `specModel.getComponentClass()` in the error message, when it should be using `specModel.getContextClass()`. It's correctly using the context class in the actual validation, so I'm assuming this was just a typo.

## Changelog

Fixed misleading error message when `@OnCreateTreeProp` methods are missing a context argument

## Test Plan

The test in `TreePropValidationTest` didn't pick this up because the spec it validates is mocked, and the correct (context) class name is returned directly from the mock. To avoid these kinds of problems, I changed the structure of the test to not rely on a mocked `LayoutSpec`, and instead create a real one, allowing the test to be more block-boxy.
