### PR TITLE
Add a reference to the associated EditText view in EditorActionEvent

### DIFF
--- a/litho-widget/src/main/java/com/facebook/litho/widget/EditorActionEvent.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/EditorActionEvent.java
@@ -17,6 +17,7 @@
 package com.facebook.litho.widget;
 
 import android.view.KeyEvent;
+import android.widget.EditText;
 import com.facebook.litho.annotations.Event;
 
 /**
@@ -27,4 +28,5 @@ import com.facebook.litho.annotations.Event;
 public class EditorActionEvent {
   public int actionId;
   public KeyEvent event;
+  public EditText view;
 }

--- a/litho-widget/src/main/java/com/facebook/litho/widget/TextInputSpec.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/TextInputSpec.java
@@ -1109,7 +1109,8 @@ class TextInputSpec {
     @Override
     public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
       if (mEditorActionEventHandler != null) {
-        return TextInput.dispatchEditorActionEvent(mEditorActionEventHandler, actionId, event);
+        return TextInput.dispatchEditorActionEvent(
+            mEditorActionEventHandler, actionId, event, EditTextWithEventHandlers.this);
       }
       return false;
     }


### PR DESCRIPTION
## Summary

Add a reference in EditorActionEvent to the EditText view associated with the event. This allows the users to access the underlying EditText view when the event is received, similarly to the TextChangedEvent.

## Changelog

Add a reference to the associated EditText view in EditorActionEvent.

## Test Plan

No relevant tests; I confirmed that `dispatchEditorActionEvent` is not called in any other places.
