### PR TITLE
Add overScrollMode property to HorizontalScrollSpec and VerticalScrollSpec

### DIFF
--- a/litho-widget/src/main/java/com/facebook/litho/widget/HorizontalScrollSpec.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/HorizontalScrollSpec.java
@@ -16,6 +16,7 @@
 
 package com.facebook.litho.widget;
 
+import static android.view.View.OVER_SCROLL_ALWAYS;
 import static com.facebook.litho.SizeSpec.EXACTLY;
 import static com.facebook.litho.SizeSpec.UNSPECIFIED;
 
@@ -69,6 +70,7 @@ class HorizontalScrollSpec {
   @PropDefault static final boolean scrollbarEnabled = true;
   @PropDefault static final int initialScrollPosition = LAST_SCROLL_POSITION_UNSET;
   @PropDefault static final boolean incrementalMountEnabled = false;
+  @PropDefault static final int overScrollMode = OVER_SCROLL_ALWAYS;
 
   /** Scroll change listener invoked when the scroll position changes. */
   public interface OnScrollChangeListener {
@@ -181,6 +183,7 @@ class HorizontalScrollSpec {
       @Prop(optional = true) @Nullable OnScrollChangeListener onScrollChangeListener,
       @Prop(optional = true) @Nullable final ScrollStateListener scrollStateListener,
       @Prop(optional = true) boolean incrementalMountEnabled,
+      @Prop(optional = true) int overScrollMode,
       @State final ScrollPosition lastScrollPosition,
       @State ComponentTree childComponentTree,
       @FromBoundsDefined int componentWidth,
@@ -188,6 +191,7 @@ class HorizontalScrollSpec {
       @FromBoundsDefined final YogaDirection layoutDirection) {
 
     horizontalScrollLithoView.setHorizontalScrollBarEnabled(scrollbarEnabled);
+    horizontalScrollLithoView.setOverScrollMode(overScrollMode);
     horizontalScrollLithoView.mount(
         childComponentTree,
         lastScrollPosition,

--- a/litho-widget/src/main/java/com/facebook/litho/widget/HorizontalScrollSpec.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/HorizontalScrollSpec.java
@@ -16,7 +16,7 @@
 
 package com.facebook.litho.widget;
 
-import static android.view.View.OVER_SCROLL_ALWAYS;
+import static android.view.View.OVER_SCROLL_IF_CONTENT_SCROLLS;
 import static com.facebook.litho.SizeSpec.EXACTLY;
 import static com.facebook.litho.SizeSpec.UNSPECIFIED;
 
@@ -70,7 +70,7 @@ class HorizontalScrollSpec {
   @PropDefault static final boolean scrollbarEnabled = true;
   @PropDefault static final int initialScrollPosition = LAST_SCROLL_POSITION_UNSET;
   @PropDefault static final boolean incrementalMountEnabled = false;
-  @PropDefault static final int overScrollMode = OVER_SCROLL_ALWAYS;
+  @PropDefault static final int overScrollMode = OVER_SCROLL_IF_CONTENT_SCROLLS;
 
   /** Scroll change listener invoked when the scroll position changes. */
   public interface OnScrollChangeListener {

--- a/litho-widget/src/main/java/com/facebook/litho/widget/VerticalScrollSpec.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/VerticalScrollSpec.java
@@ -16,7 +16,7 @@
 
 package com.facebook.litho.widget;
 
-import static android.view.View.OVER_SCROLL_ALWAYS;
+import static android.view.View.OVER_SCROLL_IF_CONTENT_SCROLLS;
 import static com.facebook.litho.SizeSpec.AT_MOST;
 import static com.facebook.litho.SizeSpec.EXACTLY;
 import static com.facebook.litho.SizeSpec.UNSPECIFIED;
@@ -73,7 +73,7 @@ import com.facebook.litho.annotations.State;
 public class VerticalScrollSpec {
 
   @PropDefault static final boolean scrollbarFadingEnabled = true;
-  @PropDefault static final int overScrollMode = OVER_SCROLL_ALWAYS;
+  @PropDefault static final int overScrollMode = OVER_SCROLL_IF_CONTENT_SCROLLS;
 
   @OnCreateInitialState
   static void onCreateInitialState(

--- a/litho-widget/src/main/java/com/facebook/litho/widget/VerticalScrollSpec.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/VerticalScrollSpec.java
@@ -16,6 +16,7 @@
 
 package com.facebook.litho.widget;
 
+import static android.view.View.OVER_SCROLL_ALWAYS;
 import static com.facebook.litho.SizeSpec.AT_MOST;
 import static com.facebook.litho.SizeSpec.EXACTLY;
 import static com.facebook.litho.SizeSpec.UNSPECIFIED;
@@ -72,6 +73,7 @@ import com.facebook.litho.annotations.State;
 public class VerticalScrollSpec {
 
   @PropDefault static final boolean scrollbarFadingEnabled = true;
+  @PropDefault static final int overScrollMode = OVER_SCROLL_ALWAYS;
 
   @OnCreateInitialState
   static void onCreateInitialState(
@@ -196,6 +198,7 @@ public class VerticalScrollSpec {
       @Prop(optional = true) @Nullable VerticalScrollEventsController eventsController,
       @Prop(optional = true) @Nullable OnScrollChangeListener onScrollChangeListener,
       @Prop(optional = true) ScrollStateListener scrollStateListener,
+      @Prop(optional = true) int overScrollMode,
       // NOT THE SAME AS LITHO'S interceptTouchHandler COMMON PROP, see class javadocs
       @Prop(optional = true) @Nullable OnInterceptTouchListener onInterceptTouchListener,
       @State ComponentTree childComponentTree,
@@ -217,6 +220,7 @@ public class VerticalScrollSpec {
     }
     lithoScrollView.setOnScrollChangeListener(onScrollChangeListener);
     lithoScrollView.setOnInterceptTouchListener(onInterceptTouchListener);
+    lithoScrollView.setOverScrollMode(overScrollMode);
 
     if (eventsController != null) {
       eventsController.setScrollView(lithoScrollView);


### PR DESCRIPTION
## Summary

Add overScrollMode to HorizontalScrollSpec and VerticalScrollSpec. This allows users to set overScrollMode of the underlying scrollViews. The default property value is the Android default, i.e. OVER_SCROLL_IF_CONTENT_SCROLLS. 

## Changelog

Add overScrollMode property to HorizontalScrollSpec and VerticalScrollSpec.

## Test Plan

N/A - this change simply propagates values of overScrollMode to the underlying scrollViews. There are no existing tests for HorizontalScrollSpec or VerticalScrollSpec to modify.
