### PR TITLE
docs: add eli5 video to home page 

### DIFF
--- a/docs/mainconcepts/passing-data-to-components/treeprops.mdx
+++ b/docs/mainconcepts/passing-data-to-components/treeprops.mdx
@@ -94,7 +94,7 @@ If you want to access a TreeProp from the component that created it, you can tra
 
 ## TreeProps with Lists
 
-TreeProps can be used in Components, Sections and [Lazy Collections](../../fb/kotlin/collections.mdx). They can even be modified between them.
+TreeProps can be used in Components, Sections and Lazy Collections. They can even be modified between them.
 
 The following code is an example of a logging data structure that is passed down from the root component to capture information about the hierarchy.
 

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -99,6 +99,29 @@ function Feature({imageUrl, title, description, dark}) {
   );
 }
 
+function VideoContainer() {
+  return (
+    <div className="container text--center margin-bottom--xl margin-top--lg">
+      <div className="row">
+        <div className="col">
+          <h2>Check it out in the intro video</h2>
+          <div className={styles.ytVideo}>
+            <iframe
+              width="560"
+              height="315"
+              src="https://www.youtube.com/embed/RFI-fuiMRK4"
+              title="Explain Like I'm 5: Litho"
+              frameBorder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function Home() {
   const context = useDocusaurusContext();
   const {siteConfig = {}} = context;
@@ -133,6 +156,7 @@ function Home() {
         </div>
       </div>
       <main>
+        <VideoContainer />
         {features &&
           features.length > 0 &&
           features.map((props, idx) => <Feature key={idx} {...props} />)}


### PR DESCRIPTION
Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible. We started embedding these videos into project pages as you can see in [Hermes home page](https://hermesengine.dev/) or in Docusaurus home page](https://docusaurus.io/)

Test plan
This is how the video appears on the home page:
![image](https://user-images.githubusercontent.com/12485205/153950480-ac783efd-a70c-45e5-b8f3-992110516527.png)

