### PR TITLE
Fix for some links not tappable in RTL languages.

### DIFF
--- a/litho-widget/src/main/java/com/facebook/litho/widget/TextDrawable.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/TextDrawable.java
@@ -80,6 +80,7 @@ public class TextDrawable extends Drawable implements Touchable, TextContent, Dr
   private @Nullable ClickableSpanListener mSpanListener;
   private @Nullable TouchableSpanListener mTouchableSpanListener;
   private @Nullable String mContextLogTag;
+  private boolean mRtl;
 
   @Override
   public void draw(Canvas canvas) {
@@ -351,7 +352,8 @@ public class TextDrawable extends Drawable implements Touchable, TextContent, Dr
         -1,
         -1,
         0f,
-        null);
+        null,
+        false);
   }
 
   public void mount(
@@ -370,7 +372,8 @@ public class TextDrawable extends Drawable implements Touchable, TextContent, Dr
       int highlightStartOffset,
       int highlightEndOffset,
       float clickableSpanExpandedOffset,
-      String contextLogTag) {
+      String contextLogTag,
+      boolean rtl) {
     mLayout = layout;
     mLayoutTranslationY = layoutTranslationY;
     mClipToBounds = clipToBounds;
@@ -385,6 +388,7 @@ public class TextDrawable extends Drawable implements Touchable, TextContent, Dr
     mShouldHandleTouch = (clickableSpans != null && clickableSpans.length > 0);
     mHighlightColor = highlightColor;
     mClickableSpanExpandedOffset = clickableSpanExpandedOffset;
+    mRtl = rtl;
     if (userColor != 0) {
       mColorStateList = null;
       mUserColor = userColor;
@@ -444,6 +448,7 @@ public class TextDrawable extends Drawable implements Touchable, TextContent, Dr
     mTextOffsetOnTouchListener = null;
     mColorStateList = null;
     mUserColor = 0;
+    mRtl = false;
     if (mImageSpans != null) {
       for (int i = 0, size = mImageSpans.length; i < size; i++) {
         Drawable drawable = mImageSpans[i].getDrawable();
@@ -538,9 +543,8 @@ public class TextDrawable extends Drawable implements Touchable, TextContent, Dr
        * direction, and {@link Layout#getLineMax} gives the extent *plus* the leading margin, so we
        * can figure out the rest from there.
        */
-      final boolean rtl = mLayout.getParagraphDirection(line) == Layout.DIR_RIGHT_TO_LEFT;
-      left = rtl ? mLayout.getWidth() - mLayout.getLineMax(line) : mLayout.getParagraphLeft(line);
-      right = rtl ? mLayout.getParagraphRight(line) : mLayout.getLineMax(line);
+      left = mRtl ? mLayout.getWidth() - mLayout.getLineMax(line) : mLayout.getParagraphLeft(line);
+      right = mRtl ? mLayout.getParagraphRight(line) : mLayout.getLineMax(line);
     }
 
     if (x < left || x > right) {

--- a/litho-widget/src/main/java/com/facebook/litho/widget/TextSpec.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/TextSpec.java
@@ -16,6 +16,8 @@
 
 package com.facebook.litho.widget;
 
+import static android.content.res.Configuration.SCREENLAYOUT_LAYOUTDIR_MASK;
+import static android.content.res.Configuration.SCREENLAYOUT_LAYOUTDIR_RTL;
 import static androidx.customview.widget.ExploreByTouchHelper.INVALID_ID;
 import static com.facebook.litho.SizeSpec.AT_MOST;
 import static com.facebook.litho.SizeSpec.EXACTLY;
@@ -906,7 +908,8 @@ class TextSpec {
         highlightStartOffset,
         highlightEndOffset,
         clickableSpanExpandedOffset,
-        c.getLogTag());
+        c.getLogTag(),
+        isRtl(c.getAndroidContext()));
 
     if (processedText instanceof MountableCharSequence) {
       ((MountableCharSequence) processedText).onMount(textDrawable);
@@ -1177,5 +1180,10 @@ class TextSpec {
         break;
     }
     return alignment;
+  }
+
+  private static boolean isRtl(Context context) {
+    return (context.getResources().getConfiguration().screenLayout & SCREENLAYOUT_LAYOUTDIR_MASK)
+        == SCREENLAYOUT_LAYOUTDIR_RTL;
   }
 }


### PR DESCRIPTION
## Summary

The call to `mLayout.getParagraphDirection(line)` sometimes doesn't return the correct direction. It should not be used from a drawable. Instead this PR passes isRtl via the spec file which uses the screen layout from the context to determine RTL.
