### PR TITLE
fix LifecycleStep dependency for litho-it module

### DIFF
--- a/litho-it/build.gradle
+++ b/litho-it/build.gradle
@@ -96,6 +96,7 @@ dependencies {
     implementation project(':litho-core-kotlin')
     implementation project(':litho-widget')
     implementation project(':litho-sections-core')
+    implementation project(':litho-testing')
     implementation deps.supportAppCompat
     implementation deps.supportRecyclerView
     implementation deps.supportSwipeRefresh
@@ -106,7 +107,6 @@ dependencies {
 
     // Test project dependencies
     testCompileOnly project(':litho-sections-annotations')
-    testImplementation project(':litho-testing')
     testImplementation project(':litho-rendercore-testing')
     testImplementation project(':litho-widget')
     testImplementation project(':litho-widget-kotlin')


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you taking the time to work on these 
changes. Please provide enough information so that others can review your pull request. The three 
fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request 
solve? -->

- Issue: When building the `litho-it` module, there is a dependency issue that it can't find `LifecycleStep`, 

- Reason: The `LifecycleStep` was moved to test package in `litho-testing` from the `litho-it` main package at [commit](https://github.com/facebook/litho/commit/1b459f22ed96057646da95e35643ab7433a47754), but `LifecycleStep` still used in main package in `litho-it` module. 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be
a brief one line we can mention in our release notes: https://github.com/facebook/litho/releases -->

- Replace `testImplementation project(':litho-testing')` with `implementation project(':litho-testing')` in `litho-it`'s [build.gradle](https://github.com/facebook/litho/blob/master/litho-it/build.gradle)

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, output of 
the test runner and how you invoked it (you've added tests, right?), screenshots/videos if the pull 
request changes UI. -->

- build `litho-it` module
