### PR TITLE
Website - Features section image alt text displays as [object Object].

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -27,6 +27,7 @@ import styles from './styles.module.scss';
 const features = [
   {
     title: <>Declarative</>,
+    alt: 'Declarative',
     imageUrl: 'images/home-code.png',
     description: (
       <>
@@ -41,6 +42,7 @@ const features = [
   },
   {
     title: <>Asynchronous layout</>,
+    alt: 'Asynchronous layout',
     imageUrl: 'images/home-async.png',
     description: (
       <>
@@ -53,6 +55,7 @@ const features = [
   },
   {
     title: <>Flatter view hierarchies</>,
+    alt: 'Flatter view hierarchies',
     imageUrl: 'images/home-flat-not-flat.png',
     description: (
       <>
@@ -66,6 +69,7 @@ const features = [
   },
   {
     title: <>Fine-grained recycling</>,
+    alt: 'Fine-grained recycling',
     imageUrl: 'images/home-incremental-mount.png',
     description: (
       <>
@@ -80,7 +84,7 @@ const features = [
   },
 ];
 
-function Feature({imageUrl, title, description, dark}) {
+function Feature({imageUrl, alt, title, description, dark}) {
   const imgUrl = useBaseUrl(imageUrl);
   return (
     <section
@@ -89,7 +93,7 @@ function Feature({imageUrl, title, description, dark}) {
         !dark && styles.lightFeature,
       )}>
       <div className={styles.featureContent}>
-        <img className={styles.featureImage} src={imgUrl} alt={title} />
+        <img className={styles.featureImage} src={imgUrl} alt={alt} />
         <div className={styles.featureText}>
           <h3 className={styles.featureTitle}>{title}</h3>
           <p className={styles.featureBody}>{description}</p>


### PR DESCRIPTION
**Title:** Website - Features section image alt text displays as [object Object]

**Description:**

![Screenshot_20230102_071959](https://user-images.githubusercontent.com/91380384/210190327-c693c6fd-526e-48e7-8d54-881ec040478e.png)

I noticed that when I tried to render an image in the project, the alt text was displayed as [object Object] instead of the expected value - title.

I traced the issue back to the code that was setting the alt attribute of the img element. It was passing React Fragment(object) to the alt attribute, rather than a string.

To fix this, I have added another key 'alt' in the features array, with String as it's value and passed in the Props. This resulted in the expected alt text being displayed.
I have also tried rendering alt attribute this way - alt={title.props.children} which worked. But felt that adding a new key-value pair would be more concise and better.

Please review and consider merging this fix.

**Steps to reproduce:**

Run the project in a browser
Observe the image alt text being displayed as [object Object]

**Expected result:**

The image alt text should be displayed correctly.

**Actual result:**

The image alt text is displayed as [object Object].