### PR TITLE
Replace "facebook.proguard.annotations" with "facebook.yoga.annotations"

### DIFF
--- a/lib/yoga/BUCK
+++ b/lib/yoga/BUCK
@@ -12,6 +12,7 @@ litho_android_library(
     name = "yoga",
     srcs = glob(["src/main/java/**/*.java"]),
     autoglob = False,
+    proguard_config = "proguard-rules.pro",
     language = "JAVA",
     visibility = LITHO_VISIBILITY,
     deps = [

--- a/lib/yoga/build.gradle
+++ b/lib/yoga/build.gradle
@@ -7,6 +7,7 @@ android {
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
+        consumerProguardFiles 'proguard-rules.pro'
     }
 }
 
@@ -15,7 +16,6 @@ dependencies {
     implementation deps.jsr305
     implementation deps.inferAnnotations
     implementation project(':litho-annotations')
-    compileOnly    deps.proguardAnnotations
 }
 
 // Our current NDK setup only gets us half-way there to a way to run Yoga

--- a/lib/yoga/proguard-rules.pro
+++ b/lib/yoga/proguard-rules.pro
@@ -1,0 +1,10 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+-keep,allowobfuscation @interface com.facebook.yoga.annotations.DoNotStrip
+-keep @com.facebook.yoga.annotations.DoNotStrip class *
+-keepclassmembers class * {
+    @com.facebook.yoga.annotations.DoNotStrip *;
+}

--- a/lib/yoga/src/main/java/com/facebook/yoga/YogaLogLevel.java
+++ b/lib/yoga/src/main/java/com/facebook/yoga/YogaLogLevel.java
@@ -9,7 +9,7 @@
 
 package com.facebook.yoga;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import com.facebook.yoga.annotations.DoNotStrip;
 
 @DoNotStrip
 public enum YogaLogLevel {

--- a/lib/yoga/src/main/java/com/facebook/yoga/YogaLogger.java
+++ b/lib/yoga/src/main/java/com/facebook/yoga/YogaLogger.java
@@ -7,7 +7,7 @@
 
 package com.facebook.yoga;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import com.facebook.yoga.annotations.DoNotStrip;
 
 /**
  * Interface for receiving logs from native layer. Use by setting YogaNode.setLogger(myLogger);

--- a/lib/yoga/src/main/java/com/facebook/yoga/YogaNative.java
+++ b/lib/yoga/src/main/java/com/facebook/yoga/YogaNative.java
@@ -7,7 +7,7 @@
 
 package com.facebook.yoga;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import com.facebook.yoga.annotations.DoNotStrip;
 import com.facebook.soloader.SoLoader;
 
 @DoNotStrip

--- a/lib/yoga/src/main/java/com/facebook/yoga/YogaNodeJNIBase.java
+++ b/lib/yoga/src/main/java/com/facebook/yoga/YogaNodeJNIBase.java
@@ -7,7 +7,7 @@
 
 package com.facebook.yoga;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import com.facebook.yoga.annotations.DoNotStrip;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;

--- a/lib/yoga/src/main/java/com/facebook/yoga/annotations/DoNotStrip.java
+++ b/lib/yoga/src/main/java/com/facebook/yoga/annotations/DoNotStrip.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.yoga.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+@Target({ ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.CONSTRUCTOR })
+@Retention(CLASS)
+public @interface DoNotStrip { }


### PR DESCRIPTION
Summary:
The Yoga JNI bindings use Reflection, so we need to let ProGuard know not to strip certain annotated fields.

This is done internally using a single copy of `com.facebook.proguard.annotations` from fbandroid (sometimes), which is then repackaged externally, and published as its own whole Yoga specific package. We never actually inform the stock Gradle project of the rules for the annotations though, so apps must add these manually.

This simplifies the setup, where Yoga has its own self-contained annotations/rules. The rules are exposed for Gradle/Buck dependencies, but RN and Litho both consume Yoga via dirsync + custom Gradle logic, so we need to duplicate the proguard rules to them instead of them being propagated automatically.

Changelog: [Internal]

Reviewed By: rshest

Differential Revision: D42406641

