### PR TITLE
[docs] Remove JCenter reference

### DIFF
--- a/docs/tutorial/project-setup.mdx
+++ b/docs/tutorial/project-setup.mdx
@@ -9,17 +9,7 @@ import VersionedCodeBlock from '@theme/VersionedCodeBlock';
 
 After creating an Android app project in Android Studio, take the steps detailed in this page to configure it with the correct settings and dependencies.
 
-## 1. Link to the JCenter repository
-
-Litho artifacts are published to Bintray's JCenter, so you need to ensure you have the JCenter repository in your projects's root `build.gradle` file:
-
-```groovy title="build.gradle"
-repositories {
-  jcenter()
-}
-```
-
-## 2. Add Litho core dependencies
+## 1. Add Litho core dependencies
 
 Add the following to the `build.gradle` file, after the 'jcenter' entry of step 1:
 
@@ -38,7 +28,7 @@ dependencies {
 }
 `} />
 
-## 3. Using the Annotation Processor
+## 2. Using the Annotation Processor
 
 The Annotation Processor is a part of the application build/compile process that generates code by reading annotations (such as @Override and @SuppressWanings).
 
@@ -48,7 +38,7 @@ In order to use your project's dependencies (from Step 2) with Annotation Proces
 apply plugin: 'kotlin-kapt'
 ```
 
-## 4. Wire up native libs
+## 3. Wire up native libs
 
 Litho has a dependency on [SoLoader](https://github.com/facebook/SoLoader) to help load native libraries provided by the underlying layout engine, [Yoga](https://yogalayout.com/docs/)[^1].
 


### PR DESCRIPTION
The artefacts are published to Maven Central now which is already part of the default scaffolding of a new Android project, so we can probably safely leave out that part in its entirety.