### PR TITLE
Bump actions versions to remove warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,22 +11,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'adopt'
           java-version: 11
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.9.16'
       - name: Gradle caches
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle/caches
           key: caches-${{ runner.os }}-${{ hashFiles('**/*.gradle') }}
       - name: Gradle wrapper caches
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle/wrapper
           key: wrapper-${{ runner.os }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
@@ -43,22 +44,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'adopt'
           java-version: 11
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.9.16'
       - name: Gradle caches
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle/caches
           key: caches-${{ runner.os }}-${{ hashFiles('**/*.gradle') }}
       - name: Gradle wrapper caches
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle/wrapper
           key: wrapper-${{ runner.os }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
@@ -75,22 +77,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'adopt'
           java-version: 11
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.9.16'
       - name: Gradle caches
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle/caches
           key: caches-${{ runner.os }}-${{ hashFiles('**/*.gradle') }}
       - name: Gradle wrapper caches
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle/wrapper
           key: wrapper-${{ runner.os }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
@@ -112,7 +115,7 @@ jobs:
       is-snapshot: ${{ steps.check_snapshot.outputs.IS_SNAPSHOT != '' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check if SNAPSHOT version
         id: check_snapshot
         run: |
@@ -123,22 +126,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'adopt'
           java-version: 11
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.9.16'
       - name: Gradle caches
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle/caches
           key: caches-${{ runner.os }}-${{ hashFiles('**/*.gradle') }}
       - name: Gradle wrapper caches
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle/wrapper
           key: wrapper-${{ runner.os }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,20 +11,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'adopt'
           java-version: 11
       - name: Gradle caches
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle/caches
           key: caches-${{ runner.os }}-${{ hashFiles('**/*.gradle') }}
       - name: Gradle wrapper caches
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle/wrapper
           key: wrapper-${{ runner.os }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
@@ -40,7 +41,7 @@ jobs:
         working-directory: website/
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4.1.0
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
           folder: website/build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       release-version-info: ${{ steps.version_info.outputs.VERSION_INFO }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Extract version info
       id: version_info
       run: echo ::set-output name=VERSION_INFO::`git log --format=%B -n 1 . | egrep '^[rR]elease version' | egrep -o '([[:digit:]]+\.){2}[[:digit:]]+' | xargs -0 printf v%s`
@@ -61,10 +61,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up JDK
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
+        distribution: 'adopt'
         java-version: '11'
     - name: Setup Python
       uses: actions/setup-python@v4
@@ -89,10 +90,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up JDK
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
+        distribution: 'adopt'
         java-version: '11'
     - name: Setup Python
       uses: actions/setup-python@v4
@@ -113,10 +115,11 @@ jobs:
     needs: [test-job, sample-app-job]
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up JDK
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
+        distribution: 'adopt'
         java-version: '11'
     - name: Setup Python
       uses: actions/setup-python@v4
@@ -146,7 +149,7 @@ jobs:
     needs: [check-release-job, publish-job]
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set Git tag
       uses: tvdias/github-tagger@v0.0.1
       with:

--- a/.github/workflows/tagit-weekly.yml
+++ b/.github/workflows/tagit-weekly.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get tag for the current date
         id: tag_info


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you taking the time to work on these 
changes. Please provide enough information so that others can review your pull request. The three 
fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request 
solve? -->
We can see following warnings while running Actions:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-java@v1, actions/cache@v2, JamesIves/github-pages-deploy-action@4.1.0. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

Bump versions to remove it.
- actions/setup-java@v1 -> actions/setup-java@v3
- actions/checkout@v2 -> actions/checkout@v3
- actions/cache@v2 -> actions/cache@v3
- JamesIves/github-pages-deploy-action@4.1.0 -> JamesIves/github-pages-deploy-action@v4

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be
a brief one line we can mention in our release notes: https://github.com/facebook/litho/releases -->
- .github
  - workflows
    - ci.yml
    - docs.yml
    - release.yml
    - tagit-weekly.yml
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, output of 
the test runner and how you invoked it (you've added tests, right?), screenshots/videos if the pull 
request changes UI. -->
It has been verified through Actions.
