### PR TITLE
Minor: removed extra semicolon (#1240)

### DIFF
--- a/lib/yoga/src/main/cpp/yoga/event/event.h
+++ b/lib/yoga/src/main/cpp/yoga/event/event.h
@@ -80,7 +80,7 @@ struct YOGA_EXPORT Event {
     template <Type E>
     const TypedData<E>& get() const {
       return *static_cast<const TypedData<E>*>(data_);
-    };
+    }
   };
 
   static void reset();


### PR DESCRIPTION
Summary:
Latest `emscripten` compiler shows the next warning:
```
yoga/event/event.h:83:6: warning: extra ‘;’ [-Wpedantic]
   83 |     };
      |      ^
```

This small PR fixes it

X-link: https://github.com/facebook/yoga/pull/1240

Reviewed By: cortinico, mdvacca

Differential Revision: D44775620

Pulled By: philIip

