### PR TITLE
Deprecate Java YogaConfig.setUseLegacyStretchBehaviour()

### DIFF
--- a/lib/yoga/src/main/java/com/facebook/yoga/YogaConfig.java
+++ b/lib/yoga/src/main/java/com/facebook/yoga/YogaConfig.java
@@ -22,7 +22,13 @@ public abstract class YogaConfig {
    * Yoga previously had an error where containers would take the maximum space possible instead of the minimum
    * like they are supposed to. In practice this resulted in implicit behaviour similar to align-self: stretch;
    * Because this was such a long-standing bug we must allow legacy users to switch back to this behaviour.
+   *
+   * @deprecated "setUseLegacyStretchBehaviour" will be removed in the next release. Usage should be replaced with
+   * "setErrata(YogaErrata.ALL)" to opt out of all future breaking conformance fixes, or
+   * "setErrata(YogaErrata.STRETCH_FLEX_BASIS)" to opt out of the specific conformance fix previously disabled by
+   * "UseLegacyStretchBehaviour".
    */
+  @Deprecated
   public abstract void setUseLegacyStretchBehaviour(boolean useLegacyStretchBehaviour);
 
   public abstract void setErrata(YogaErrata errata);

--- a/litho-core/src/main/java/com/facebook/litho/yoga/LithoYogaFactory.java
+++ b/litho-core/src/main/java/com/facebook/litho/yoga/LithoYogaFactory.java
@@ -18,6 +18,7 @@ package com.facebook.litho.yoga;
 
 import com.facebook.yoga.YogaConfig;
 import com.facebook.yoga.YogaConfigFactory;
+import com.facebook.yoga.YogaErrata;
 import com.facebook.yoga.YogaNode;
 import com.facebook.yoga.YogaNodeFactory;
 
@@ -25,6 +26,7 @@ public abstract class LithoYogaFactory {
   public static YogaConfig createYogaConfig() {
     YogaConfig yogaConfig = YogaConfigFactory.create();
     yogaConfig.setUseWebDefaults(true);
+    yogaConfig.setErrata(YogaErrata.CLASSIC);
     return yogaConfig;
   }
 

--- a/litho-rendercore-yoga/src/main/java/com/facebook/rendercore/YogaLayoutFunction.java
+++ b/litho-rendercore-yoga/src/main/java/com/facebook/rendercore/YogaLayoutFunction.java
@@ -30,6 +30,7 @@ import com.facebook.yoga.YogaConfig;
 import com.facebook.yoga.YogaConstants;
 import com.facebook.yoga.YogaDirection;
 import com.facebook.yoga.YogaDisplay;
+import com.facebook.yoga.YogaErrata;
 import com.facebook.yoga.YogaMeasureFunction;
 import com.facebook.yoga.YogaMeasureMode;
 import com.facebook.yoga.YogaMeasureOutput;
@@ -60,6 +61,7 @@ public class YogaLayoutFunction {
 
   static {
     DEFAULT_YOGA_CONFIG.setUseWebDefaults(true);
+    DEFAULT_YOGA_CONFIG.setErrata(YogaErrata.CLASSIC);
   }
 
   private YogaLayoutFunction() {}


### PR DESCRIPTION
Summary: Now that our own usages are removed, mark this as deprecated to encourage users to move to the errata API. The same will be done to variants of this function on other platforms before releasing, and the functions will be removed after releasing.

Differential Revision: D45300343

