### PR TITLE
Fix Use After Free With Concurrent Java GC

### DIFF
--- a/lib/yoga/src/main/cpp/yoga/Yoga-internal.h
+++ b/lib/yoga/src/main/cpp/yoga/Yoga-internal.h
@@ -27,6 +27,10 @@ void YGNodeCalculateLayoutWithContext(
     YGDirection ownerDirection,
     void* layoutContext);
 
+// Deallocates a Yoga Node. Unlike YGNodeFree, does not remove the node from
+// its parent or children.
+void YGNodeDeallocate(YGNodeRef node);
+
 YG_EXTERN_C_END
 
 namespace facebook {

--- a/lib/yoga/src/main/cpp/yoga/Yoga.cpp
+++ b/lib/yoga/src/main/cpp/yoga/Yoga.cpp
@@ -230,6 +230,10 @@ YOGA_EXPORT void YGNodeFree(const YGNodeRef node) {
   }
 
   node->clearChildren();
+  YGNodeDeallocate(node);
+}
+
+YOGA_EXPORT void YGNodeDeallocate(const YGNodeRef node) {
   Event::publish<Event::NodeDeallocation>(node, {node->getConfig()});
   delete node;
 }

--- a/lib/yoga/src/main/java/com/facebook/yoga/YogaNative.java
+++ b/lib/yoga/src/main/java/com/facebook/yoga/YogaNative.java
@@ -32,7 +32,7 @@ public class YogaNative {
   // YGNode related
   static native long jni_YGNodeNewJNI();
   static native long jni_YGNodeNewWithConfigJNI(long configPointer);
-  static native void jni_YGNodeFreeJNI(long nativePointer);
+  static native void jni_YGNodeDeallocateJNI(long nativePointer);
   static native void jni_YGNodeResetJNI(long nativePointer);
   static native void jni_YGNodeInsertChildJNI(long nativePointer, long childPointer, int index);
   static native void jni_YGNodeSwapChildJNI(long nativePointer, long childPointer, int index);

--- a/lib/yoga/src/main/java/com/facebook/yoga/YogaNodeJNIFinalizer.java
+++ b/lib/yoga/src/main/java/com/facebook/yoga/YogaNodeJNIFinalizer.java
@@ -29,7 +29,7 @@ public class YogaNodeJNIFinalizer extends YogaNodeJNIBase {
     if (mNativePointer != 0) {
       long nativePointer = mNativePointer;
       mNativePointer = 0;
-      YogaNative.jni_YGNodeFreeJNI(nativePointer);
+      YogaNative.jni_YGNodeDeallocateJNI(nativePointer);
     }
   }
 }

--- a/lib/yogajni/src/main/cpp/jni/YGJNIVanilla.cpp
+++ b/lib/yogajni/src/main/cpp/jni/YGJNIVanilla.cpp
@@ -199,7 +199,10 @@ static void jni_YGConfigSetLoggerJNI(
   }
 }
 
-static void jni_YGNodeFreeJNI(JNIEnv* env, jobject obj, jlong nativePointer) {
+static void jni_YGNodeDeallocateJNI(
+    JNIEnv* env,
+    jobject obj,
+    jlong nativePointer) {
   if (nativePointer == 0) {
     return;
   }
@@ -769,7 +772,7 @@ static JNINativeMethod methods[] = {
      (void*) jni_YGConfigSetLoggerJNI},
     {"jni_YGNodeNewJNI", "()J", (void*) jni_YGNodeNewJNI},
     {"jni_YGNodeNewWithConfigJNI", "(J)J", (void*) jni_YGNodeNewWithConfigJNI},
-    {"jni_YGNodeFreeJNI", "(J)V", (void*) jni_YGNodeFreeJNI},
+    {"jni_YGNodeDeallocateJNI", "(J)V", (void*) jni_YGNodeDeallocateJNI},
     {"jni_YGNodeResetJNI", "(J)V", (void*) jni_YGNodeResetJNI},
     {"jni_YGNodeInsertChildJNI", "(JJI)V", (void*) jni_YGNodeInsertChildJNI},
     {"jni_YGNodeSwapChildJNI", "(JJI)V", (void*) jni_YGNodeSwapChildJNI},


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebook/yoga/issues/1271

Java bindings for Yoga rely solely on garbage collection for memory management. Each Java `YogaNode` has references to its children and parent, along with an `YGNodeRef` which it owns. When the `YogaNode` is garbage collected, a finalizer is run to call `YGNodeFree` and free the underlying native Yoga Node.

This may cause a use-after-free if finalizers are run from multiple threads. This is because `YGNodeFree` does more than just freeing, but instead also interacts with its parent and children nodes to detach itself, and remove any dangling pointers. If multiple threads run finalizers at once, one may traverse and try to mutate a node which another is freeing.

Because we know the entire connected tree is dead, there is no point to trying to remove dangling pointers, and this bit of behavior is counterintuitive from the API name anyway. This diff makes a breaking change to `YGNodeFree` to instead mostly just be a `free()` (with a tracing step whose publishing should be thread safe). The existing behavior is exposed in an added function `YGNodeDetachAndFree()`.

The majority of existing `YGNodeFree` usages will probably still work under the new behavior, but we don't have that many in fbsource (many instead call `YGNodeFreeRecursive` to free a whole tree at once). So for safety, I replaced existing usages of `YGNodeFree` outside of Yoga with `YGNodeDetachAndFree` to preserve existing behavior.

JavaScript and C# bindings also use `YGNodeFree()`, and both allow explicit freeing. For now I switched both of their behavior to detachment, to avoid exposing the ability to managed languages to corrupt memory.

Differential Revision: D45556206

