### PR TITLE
Fix the issue that local reference overflows in Yoga 1

### DIFF
--- a/lib/yoga/src/main/cpp/yoga/YGEnums.cpp
+++ b/lib/yoga/src/main/cpp/yoga/YGEnums.cpp
@@ -109,6 +109,8 @@ const char* YGExperimentalFeatureToString(const YGExperimentalFeature value) {
       return "absolute-percentage-against-padding-edge";
     case YGExperimentalFeatureFixAbsoluteTrailingColumnMargin:
       return "fix-absolute-trailing-column-margin";
+    case YGExperimentalFeatureFixJNILocalRefOverflows:
+      return "fix-jnilocal-ref-overflows";
   }
   return "unknown";
 }

--- a/lib/yoga/src/main/cpp/yoga/YGEnums.h
+++ b/lib/yoga/src/main/cpp/yoga/YGEnums.h
@@ -66,7 +66,8 @@ YG_ENUM_SEQ_DECL(
     YGExperimentalFeature,
     YGExperimentalFeatureWebFlexBasis,
     YGExperimentalFeatureAbsolutePercentageAgainstPaddingEdge,
-    YGExperimentalFeatureFixAbsoluteTrailingColumnMargin)
+    YGExperimentalFeatureFixAbsoluteTrailingColumnMargin,
+    YGExperimentalFeatureFixJNILocalRefOverflows)
 
 YG_ENUM_SEQ_DECL(
     YGFlexDirection,

--- a/lib/yoga/src/main/java/com/facebook/yoga/YogaExperimentalFeature.java
+++ b/lib/yoga/src/main/java/com/facebook/yoga/YogaExperimentalFeature.java
@@ -12,7 +12,8 @@ package com.facebook.yoga;
 public enum YogaExperimentalFeature {
   WEB_FLEX_BASIS(0),
   ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE(1),
-  FIX_ABSOLUTE_TRAILING_COLUMN_MARGIN(2);
+  FIX_ABSOLUTE_TRAILING_COLUMN_MARGIN(2),
+  FIX_JNILOCAL_REF_OVERFLOWS(3);
 
   private final int mIntValue;
 
@@ -29,6 +30,7 @@ public enum YogaExperimentalFeature {
       case 0: return WEB_FLEX_BASIS;
       case 1: return ABSOLUTE_PERCENTAGE_AGAINST_PADDING_EDGE;
       case 2: return FIX_ABSOLUTE_TRAILING_COLUMN_MARGIN;
+      case 3: return FIX_JNILOCAL_REF_OVERFLOWS;
       default: throw new IllegalArgumentException("Unknown enum value: " + value);
     }
   }

--- a/litho-core/src/main/java/com/facebook/litho/NodeConfig.kt
+++ b/litho-core/src/main/java/com/facebook/litho/NodeConfig.kt
@@ -16,8 +16,10 @@
 
 package com.facebook.litho
 
+import com.facebook.litho.config.ComponentsConfiguration
 import com.facebook.litho.yoga.LithoYogaFactory
 import com.facebook.yoga.YogaConfig
+import com.facebook.yoga.YogaExperimentalFeature
 import com.facebook.yoga.YogaNode
 import kotlin.jvm.JvmField
 
@@ -31,7 +33,13 @@ object NodeConfig {
   @JvmField @Volatile var yogaNodeFactory: InternalYogaNodeFactory? = null
 
   /** Allows access to the internal YogaConfig instance */
-  @get:JvmStatic val yogaConfig: YogaConfig = LithoYogaFactory.createYogaConfig()
+  @get:JvmStatic
+  val yogaConfig: YogaConfig =
+      LithoYogaFactory.createYogaConfig().apply {
+        if (ComponentsConfiguration.enableFixForJniLocalRefOverflow) {
+          setExperimentalFeatureEnabled(YogaExperimentalFeature.FIX_JNILOCAL_REF_OVERFLOWS, true)
+        }
+      }
 
   @JvmStatic
   fun createYogaNode(): YogaNode {

--- a/litho-core/src/main/java/com/facebook/litho/config/ComponentsConfiguration.java
+++ b/litho-core/src/main/java/com/facebook/litho/config/ComponentsConfiguration.java
@@ -244,6 +244,8 @@ public class ComponentsConfiguration {
 
   public static boolean enableMeasurePendingSubtrees = false;
 
+  public static boolean enableFixForJniLocalRefOverflow = false;
+
   public static int recyclerBinderStrategy = 0;
 
   public static boolean enableMountableRecycler = false;


### PR DESCRIPTION
Summary: Long story in short, we're trying to fix an issue with Yoga that could potentially lead to an overflow in the JNI local reference table.

Reviewed By: NickGerleman

Differential Revision: D46653732

