### PR TITLE
[maven] Add missing POM name and description for rendercore-glide

### DIFF
--- a/litho-rendercore-glide/gradle.properties
+++ b/litho-rendercore-glide/gradle.properties
@@ -1,0 +1,18 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+POM_NAME=RenderCoreGlide
+POM_DESCRIPTION=A RenderUnit that can be used to render network images with Glide
+POM_ARTIFACT_ID=litho-rendercore-glide
+POM_PACKAGING=aar


### PR DESCRIPTION
[maven] Add missing POM name and description for rendercore-glide

Summary:

The 0.48.0 release failed at POM validation with this error:

![370755387_237457212127301_6722818338210090440_n](https://github.com/facebook/litho/assets/9906/5c5f99f5-d00e-4e9c-8cd9-97983ff3fae0)

Test Plan:

Land and re-release.

Reviewers:

Subscribers:

Tasks:

Tags:
