### PR TITLE
Add errata for fix to marginStart/End for row-reverse flex direction

### DIFF
--- a/lib/yoga/src/main/cpp/yoga/YGEnums.cpp
+++ b/lib/yoga/src/main/cpp/yoga/YGEnums.cpp
@@ -93,6 +93,8 @@ const char* YGErrataToString(const YGErrata value) {
       return "none";
     case YGErrataStretchFlexBasis:
       return "stretch-flex-basis";
+    case YGErrataStartingEndingEdgeFromFlexDirection:
+      return "starting-ending-edge-from-flex-direction";
     case YGErrataAll:
       return "all";
     case YGErrataClassic:

--- a/lib/yoga/src/main/cpp/yoga/YGEnums.h
+++ b/lib/yoga/src/main/cpp/yoga/YGEnums.h
@@ -55,6 +55,7 @@ YG_ENUM_DECL(
     YGErrata,
     YGErrataNone = 0,
     YGErrataStretchFlexBasis = 1,
+    YGErrataStartingEndingEdgeFromFlexDirection = 2,
     YGErrataAll = 2147483647,
     YGErrataClassic = 2147483646)
 YG_DEFINE_ENUM_FLAG_OPERATORS(YGErrata)

--- a/lib/yoga/src/main/cpp/yoga/enums/Errata.h
+++ b/lib/yoga/src/main/cpp/yoga/enums/Errata.h
@@ -18,6 +18,7 @@ namespace facebook::yoga {
 enum class Errata : uint32_t {
   None = YGErrataNone,
   StretchFlexBasis = YGErrataStretchFlexBasis,
+  StartingEndingEdgeFromFlexDirection = YGErrataStartingEndingEdgeFromFlexDirection,
   All = YGErrataAll,
   Classic = YGErrataClassic,
 };
@@ -26,12 +27,12 @@ YG_DEFINE_ENUM_FLAG_OPERATORS(Errata)
 
 template <>
 constexpr inline int32_t ordinalCount<Errata>() {
-  return 4;
+  return 5;
 } 
 
 template <>
 constexpr inline int32_t bitCount<Errata>() {
-  return 2;
+  return 3;
 } 
 
 constexpr inline Errata scopedEnum(YGErrata unscoped) {

--- a/lib/yoga/src/main/java/com/facebook/yoga/YogaErrata.java
+++ b/lib/yoga/src/main/java/com/facebook/yoga/YogaErrata.java
@@ -12,6 +12,7 @@ package com.facebook.yoga;
 public enum YogaErrata {
   NONE(0),
   STRETCH_FLEX_BASIS(1),
+  STARTING_ENDING_EDGE_FROM_FLEX_DIRECTION(2),
   ALL(2147483647),
   CLASSIC(2147483646);
 
@@ -29,6 +30,7 @@ public enum YogaErrata {
     switch (value) {
       case 0: return NONE;
       case 1: return STRETCH_FLEX_BASIS;
+      case 2: return STARTING_ENDING_EDGE_FROM_FLEX_DIRECTION;
       case 2147483647: return ALL;
       case 2147483646: return CLASSIC;
       default: throw new IllegalArgumentException("Unknown enum value: " + value);


### PR DESCRIPTION
Summary:
This stack is ultimately aiming to solve https://github.com/facebook/yoga/issues/1208

This adds an value to the Errata enum. I will use this to gate this fix as there is potential for users to rely on this bug or have a hack in place to fix it and this would be a breaking change.

Differential Revision: D50145273


