### PR TITLE
Fix gradle tests due to lack of MockMaker definition

### DIFF
--- a/litho-it/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/litho-it/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Summary: Some gradle tests were failing to create mocks due to the lack of the mock maker plugin.

Differential Revision: D52624556


