### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Check if SNAPSHOT version
         id: check_snapshot
         run: |
-          echo ::set-output name=IS_SNAPSHOT::`grep 'VERSION_NAME=[0-9\.]\+-SNAPSHOT' gradle.properties)`
+          echo "IS_SNAPSHOT=`grep 'VERSION_NAME=[0-9\.]\+-SNAPSHOT' gradle.properties)`" >> $GITHUB_OUTPUT
   deploy:
     needs: [deploy-check]
     if: ${{ needs.deploy-check.outputs.is-snapshot == 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       uses: actions/checkout@v3
     - name: Extract version info
       id: version_info
-      run: echo ::set-output name=VERSION_INFO::`git log --format=%B -n 1 . | egrep '^[rR]elease version' | egrep -o '([[:digit:]]+\.){2}[[:digit:]]+' | xargs -0 printf v%s`
+      run: echo "VERSION_INFO=`git log --format=%B -n 1 . | egrep '^[rR]elease version' | egrep -o '([[:digit:]]+\.){2}[[:digit:]]+' | xargs -0 printf v%s`" >> $GITHUB_OUTPUT
     - name: Check version
       id: check_version
       if: ${{ steps.version_info.outputs.VERSION_INFO != 'v' }}

--- a/.github/workflows/tagit-weekly.yml
+++ b/.github/workflows/tagit-weekly.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Get tag for the current date
         id: tag_info
-        run: echo "::set-output name=TAG_NAME::$(date +'v%Y.%m.%d')"
+        run: echo "TAG_NAME=$(date +'v%Y.%m.%d')" >> $GITHUB_OUTPUT
 
       - name: Tag the latest commit
         uses: weareyipyip/walking-tag-action@v2


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter