### PR TITLE
Enable Clang Tidy

### DIFF
--- a/lib/yoga/src/main/cpp/yoga/YGNode.cpp
+++ b/lib/yoga/src/main/cpp/yoga/YGNode.cpp
@@ -216,12 +216,12 @@ void YGNodeSetChildren(
   auto owner = resolveRef(ownerRef);
   auto children = reinterpret_cast<yoga::Node* const*>(childrenRefs);
 
-  if (!owner) {
+  if (owner == nullptr) {
     return;
   }
 
   const std::vector<yoga::Node*> childrenVector = {children, children + count};
-  if (childrenVector.size() == 0) {
+  if (childrenVector.empty()) {
     if (owner->getChildCount() > 0) {
       for (auto* child : owner->getChildren()) {
         child->setLayout({});

--- a/lib/yoga/src/main/cpp/yoga/algorithm/AbsoluteLayout.h
+++ b/lib/yoga/src/main/cpp/yoga/algorithm/AbsoluteLayout.h
@@ -13,16 +13,16 @@
 namespace facebook::yoga {
 
 void layoutAbsoluteChild(
-    const yoga::Node* const containingNode,
-    const yoga::Node* const node,
-    yoga::Node* const child,
-    const float containingBlockWidth,
-    const float containingBlockHeight,
-    const SizingMode widthMode,
-    const Direction direction,
+    const yoga::Node* containingNode,
+    const yoga::Node* node,
+    yoga::Node* child,
+    float containingBlockWidth,
+    float containingBlockHeight,
+    SizingMode widthMode,
+    Direction direction,
     LayoutData& layoutMarkerData,
-    const uint32_t depth,
-    const uint32_t generationCount);
+    uint32_t depth,
+    uint32_t generationCount);
 
 void layoutAbsoluteDescendants(
     yoga::Node* containingNode,

--- a/lib/yoga/src/main/cpp/yoga/algorithm/CalculateLayout.h
+++ b/lib/yoga/src/main/cpp/yoga/algorithm/CalculateLayout.h
@@ -15,24 +15,24 @@
 namespace facebook::yoga {
 
 void calculateLayout(
-    yoga::Node* const node,
-    const float ownerWidth,
-    const float ownerHeight,
-    const Direction ownerDirection);
+    yoga::Node* node,
+    float ownerWidth,
+    float ownerHeight,
+    Direction ownerDirection);
 
 bool calculateLayoutInternal(
-    yoga::Node* const node,
-    const float availableWidth,
-    const float availableHeight,
-    const Direction ownerDirection,
-    const SizingMode widthSizingMode,
-    const SizingMode heightSizingMode,
-    const float ownerWidth,
-    const float ownerHeight,
-    const bool performLayout,
-    const LayoutPassReason reason,
+    yoga::Node* node,
+    float availableWidth,
+    float availableHeight,
+    Direction ownerDirection,
+    SizingMode widthSizingMode,
+    SizingMode heightSizingMode,
+    float ownerWidth,
+    float ownerHeight,
+    bool performLayout,
+    LayoutPassReason reason,
     LayoutData& layoutMarkerData,
-    const uint32_t depth,
-    const uint32_t generationCount);
+    uint32_t depth,
+    uint32_t generationCount);
 
 } // namespace facebook::yoga

--- a/lib/yoga/src/main/cpp/yoga/algorithm/FlexLine.cpp
+++ b/lib/yoga/src/main/cpp/yoga/algorithm/FlexLine.cpp
@@ -69,7 +69,7 @@ FlexLine calculateFlexLine(
     if (sizeConsumedIncludingMinConstraint + flexBasisWithMinAndMaxConstraints +
                 childMarginMainAxis + childLeadingGapMainAxis >
             availableInnerMainDim &&
-        isNodeFlexWrap && itemsInFlow.size() > 0) {
+        isNodeFlexWrap && !itemsInFlow.empty()) {
       break;
     }
 

--- a/lib/yoga/src/main/cpp/yoga/algorithm/FlexLine.h
+++ b/lib/yoga/src/main/cpp/yoga/algorithm/FlexLine.h
@@ -63,7 +63,7 @@ struct FlexLine {
 // computedFlexBasis properly computed(To do this use
 // computeFlexBasisForChildren function).
 FlexLine calculateFlexLine(
-    yoga::Node* const node,
+    yoga::Node* node,
     Direction ownerDirection,
     float mainAxisownerSize,
     float availableInnerWidth,

--- a/lib/yoga/src/main/cpp/yoga/algorithm/PixelGrid.h
+++ b/lib/yoga/src/main/cpp/yoga/algorithm/PixelGrid.h
@@ -15,15 +15,15 @@ namespace facebook::yoga {
 // Round a point value to the nearest physical pixel based on DPI
 // (pointScaleFactor)
 float roundValueToPixelGrid(
-    const double value,
-    const double pointScaleFactor,
-    const bool forceCeil,
-    const bool forceFloor);
+    double value,
+    double pointScaleFactor,
+    bool forceCeil,
+    bool forceFloor);
 
 // Round the layout results of a node and its subtree to the pixel grid.
 void roundLayoutResultsToPixelGrid(
-    yoga::Node* const node,
-    const double absoluteLeft,
-    const double absoluteTop);
+    yoga::Node* node,
+    double absoluteLeft,
+    double absoluteTop);
 
 } // namespace facebook::yoga

--- a/lib/yoga/src/main/cpp/yoga/config/Config.cpp
+++ b/lib/yoga/src/main/cpp/yoga/config/Config.cpp
@@ -20,7 +20,7 @@ bool configUpdateInvalidatesLayout(
       oldConfig.useWebDefaults() != newConfig.useWebDefaults();
 }
 
-Config::Config(YGLogger logger) : cloneNodeCallback_{nullptr} {
+Config::Config(YGLogger logger) {
   setLogger(logger);
 }
 

--- a/lib/yoga/src/main/cpp/yoga/config/Config.h
+++ b/lib/yoga/src/main/cpp/yoga/config/Config.h
@@ -32,7 +32,7 @@ bool configUpdateInvalidatesLayout(
 
 class YG_EXPORT Config : public ::YGConfig {
  public:
-  Config(YGLogger logger);
+  explicit Config(YGLogger logger);
 
   void setUseWebDefaults(bool useWebDefaults);
   bool useWebDefaults() const;
@@ -67,8 +67,8 @@ class YG_EXPORT Config : public ::YGConfig {
   static const Config& getDefault();
 
  private:
-  YGCloneNodeFunc cloneNodeCallback_;
-  YGLogger logger_;
+  YGCloneNodeFunc cloneNodeCallback_{nullptr};
+  YGLogger logger_{};
 
   bool useWebDefaults_ : 1 = false;
 

--- a/lib/yoga/src/main/cpp/yoga/debug/Log.h
+++ b/lib/yoga/src/main/cpp/yoga/debug/Log.h
@@ -20,7 +20,7 @@ void log(LogLevel level, const char* format, ...) noexcept;
 void log(
     const yoga::Node* node,
     LogLevel level,
-    const char* message,
+    const char* format,
     ...) noexcept;
 
 void log(

--- a/lib/yoga/src/main/cpp/yoga/event/event.cpp
+++ b/lib/yoga/src/main/cpp/yoga/event/event.cpp
@@ -40,14 +40,14 @@ struct Node {
   std::function<Event::Subscriber> subscriber = nullptr;
   Node* next = nullptr;
 
-  Node(std::function<Event::Subscriber>&& subscriber)
+  explicit Node(std::function<Event::Subscriber>&& subscriber)
       : subscriber{std::move(subscriber)} {}
 };
 
 std::atomic<Node*> subscribers{nullptr};
 
 Node* push(Node* newHead) {
-  Node* oldHead;
+  Node* oldHead = nullptr;
   do {
     oldHead = subscribers.load(std::memory_order_relaxed);
     if (newHead != nullptr) {

--- a/lib/yoga/src/main/cpp/yoga/event/event.h
+++ b/lib/yoga/src/main/cpp/yoga/event/event.h
@@ -9,8 +9,8 @@
 
 #include <yoga/Yoga.h>
 
-#include <stdint.h>
 #include <array>
+#include <cstdint>
 #include <functional>
 #include <vector>
 
@@ -46,7 +46,7 @@ struct LayoutData {
       measureCallbackReasonsCount;
 };
 
-const char* LayoutPassReasonToString(const LayoutPassReason value);
+const char* LayoutPassReasonToString(LayoutPassReason value);
 
 struct YG_EXPORT Event {
   enum Type {
@@ -72,7 +72,7 @@ struct YG_EXPORT Event {
 
    public:
     template <Type E>
-    Data(const TypedData<E>& data) : data_{&data} {}
+    explicit Data(const TypedData<E>& data) : data_{&data} {}
 
     template <Type E>
     const TypedData<E>& get() const {
@@ -90,7 +90,10 @@ struct YG_EXPORT Event {
   }
 
  private:
-  static void publish(YGNodeConstRef, Type, const Data&);
+  static void publish(
+      YGNodeConstRef /*node*/,
+      Type /*eventType*/,
+      const Data& /*eventData*/);
 };
 
 template <>

--- a/lib/yoga/src/main/cpp/yoga/node/Node.cpp
+++ b/lib/yoga/src/main/cpp/yoga/node/Node.cpp
@@ -26,23 +26,23 @@ Node::Node(const yoga::Config* config) : config_{config} {
   }
 }
 
-Node::Node(Node&& node) {
-  hasNewLayout_ = node.hasNewLayout_;
-  isReferenceBaseline_ = node.isReferenceBaseline_;
-  isDirty_ = node.isDirty_;
-  alwaysFormsContainingBlock_ = node.alwaysFormsContainingBlock_;
-  nodeType_ = node.nodeType_;
-  context_ = node.context_;
-  measureFunc_ = node.measureFunc_;
-  baselineFunc_ = node.baselineFunc_;
-  dirtiedFunc_ = node.dirtiedFunc_;
-  style_ = node.style_;
-  layout_ = node.layout_;
-  lineIndex_ = node.lineIndex_;
-  owner_ = node.owner_;
-  children_ = std::move(node.children_);
-  config_ = node.config_;
-  resolvedDimensions_ = node.resolvedDimensions_;
+Node::Node(Node&& node) noexcept
+    : hasNewLayout_(node.hasNewLayout_),
+      isReferenceBaseline_(node.isReferenceBaseline_),
+      isDirty_(node.isDirty_),
+      alwaysFormsContainingBlock_(node.alwaysFormsContainingBlock_),
+      nodeType_(node.nodeType_),
+      context_(node.context_),
+      measureFunc_(node.measureFunc_),
+      baselineFunc_(node.baselineFunc_),
+      dirtiedFunc_(node.dirtiedFunc_),
+      style_(std::move(node.style_)),
+      layout_(node.layout_),
+      lineIndex_(node.lineIndex_),
+      owner_(node.owner_),
+      children_(std::move(node.children_)),
+      config_(node.config_),
+      resolvedDimensions_(node.resolvedDimensions_) {
   for (auto c : children_) {
     c->setOwner(this);
   }
@@ -83,7 +83,7 @@ void Node::setMeasureFunc(YGMeasureFunc measureFunc) {
   } else {
     yoga::assertFatalWithNode(
         this,
-        children_.size() == 0,
+        children_.empty(),
         "Cannot set measure function: Nodes with measure functions cannot have "
         "children.");
     // TODO: t18095186 Move nodeType to opt-in function and mark appropriate
@@ -122,18 +122,17 @@ void Node::setConfig(yoga::Config* config) {
 }
 
 void Node::setDirty(bool isDirty) {
-  if (isDirty == isDirty_) {
+  if (static_cast<int>(isDirty) == isDirty_) {
     return;
   }
   isDirty_ = isDirty;
-  if (isDirty && dirtiedFunc_) {
+  if (isDirty && (dirtiedFunc_ != nullptr)) {
     dirtiedFunc_(this);
   }
 }
 
 bool Node::removeChild(Node* child) {
-  std::vector<Node*>::iterator p =
-      std::find(children_.begin(), children_.end(), child);
+  auto p = std::find(children_.begin(), children_.end(), child);
   if (p != children_.end()) {
     children_.erase(p);
     return true;
@@ -307,7 +306,7 @@ void Node::markDirtyAndPropagate() {
   if (!isDirty_) {
     setDirty(true);
     setLayoutComputedFlexBasis(FloatOptional());
-    if (owner_) {
+    if (owner_ != nullptr) {
       owner_->markDirtyAndPropagate();
     }
   }
@@ -351,7 +350,7 @@ bool Node::isNodeFlexible() {
 void Node::reset() {
   yoga::assertFatalWithNode(
       this,
-      children_.size() == 0,
+      children_.empty(),
       "Cannot reset a node which still has children attached");
   yoga::assertFatalWithNode(
       this, owner_ == nullptr, "Cannot reset a node still attached to a owner");

--- a/lib/yoga/src/main/cpp/yoga/node/Node.h
+++ b/lib/yoga/src/main/cpp/yoga/node/Node.h
@@ -7,8 +7,8 @@
 
 #pragma once
 
-#include <stdio.h>
 #include <cstdint>
+#include <cstdio>
 #include <vector>
 
 #include <yoga/Yoga.h>
@@ -34,7 +34,7 @@ class YG_EXPORT Node : public ::YGNode {
   Node();
   explicit Node(const Config* config);
 
-  Node(Node&&);
+  Node(Node&& node) noexcept;
 
   // Does not expose true value semantics, as children are not cloned eagerly.
   // Should we remove this?
@@ -65,7 +65,11 @@ class YG_EXPORT Node : public ::YGNode {
     return measureFunc_ != nullptr;
   }
 
-  YGSize measure(float, MeasureMode, float, MeasureMode);
+  YGSize measure(
+      float width,
+      MeasureMode widthMode,
+      float height,
+      MeasureMode heightMode);
 
   bool hasBaselineFunc() const noexcept {
     return baselineFunc_ != nullptr;
@@ -73,9 +77,9 @@ class YG_EXPORT Node : public ::YGNode {
 
   float baseline(float width, float height) const;
 
-  float dimensionWithMargin(const FlexDirection axis, const float widthSize);
+  float dimensionWithMargin(FlexDirection axis, float widthSize);
 
-  bool isLayoutDimensionDefined(const FlexDirection axis);
+  bool isLayoutDimensionDefined(FlexDirection axis);
 
   /**
    * Whether the node has a "definite length" along the given axis.
@@ -214,7 +218,7 @@ class YG_EXPORT Node : public ::YGNode {
 
   void setDirty(bool isDirty);
   void setLayoutLastOwnerDirection(Direction direction);
-  void setLayoutComputedFlexBasis(const FloatOptional computedFlexBasis);
+  void setLayoutComputedFlexBasis(FloatOptional computedFlexBasis);
   void setLayoutComputedFlexBasisGeneration(
       uint32_t computedFlexBasisGeneration);
   void setLayoutMeasuredDimension(float measuredDimension, Dimension dimension);
@@ -226,15 +230,15 @@ class YG_EXPORT Node : public ::YGNode {
   void setLayoutPadding(float padding, PhysicalEdge edge);
   void setLayoutPosition(float position, PhysicalEdge edge);
   void setPosition(
-      const Direction direction,
-      const float mainSize,
-      const float crossSize,
-      const float ownerWidth);
+      Direction direction,
+      float mainSize,
+      float crossSize,
+      float ownerWidth);
 
   // Other methods
   Style::Length resolveFlexBasisPtr() const;
   void resolveDimension();
-  Direction resolveDirection(const Direction ownerDirection);
+  Direction resolveDirection(Direction ownerDirection);
   void clearChildren();
   /// Replaces the occurrences of oldChild with newChild
   void replaceChild(Node* oldChild, Node* newChild);
@@ -253,12 +257,12 @@ class YG_EXPORT Node : public ::YGNode {
 
  private:
   // Used to allow resetting the node
-  Node& operator=(Node&&) = default;
+  Node& operator=(Node&&) noexcept = default;
 
   float relativePosition(
       FlexDirection axis,
       Direction direction,
-      const float axisSize) const;
+      float axisSize) const;
 
   void useWebDefaults() {
     style_.setFlexDirection(FlexDirection::Row);

--- a/lib/yoga/src/main/cpp/yoga/style/SmallValueBuffer.h
+++ b/lib/yoga/src/main/cpp/yoga/style/SmallValueBuffer.h
@@ -26,7 +26,7 @@ class SmallValueBuffer {
   SmallValueBuffer(const SmallValueBuffer& other) {
     *this = other;
   }
-  SmallValueBuffer(SmallValueBuffer&& other) = default;
+  SmallValueBuffer(SmallValueBuffer&& other) noexcept = default;
 
   // Add a new element to the buffer, returning the index of the element
   uint16_t push(uint32_t value) {
@@ -116,7 +116,7 @@ class SmallValueBuffer {
     return *this;
   }
 
-  SmallValueBuffer& operator=(SmallValueBuffer&& other) = default;
+  SmallValueBuffer& operator=(SmallValueBuffer&& other) noexcept = default;
 
  private:
   struct Overflow {
@@ -125,7 +125,7 @@ class SmallValueBuffer {
   };
 
   uint16_t count_{0};
-  std::array<uint32_t, BufferSize> buffer_;
+  std::array<uint32_t, BufferSize> buffer_{};
   std::bitset<BufferSize> wideElements_;
   std::unique_ptr<Overflow> overflow_;
 };

--- a/lib/yoga/src/main/cpp/yoga/style/StyleValuePool.h
+++ b/lib/yoga/src/main/cpp/yoga/style/StyleValuePool.h
@@ -101,7 +101,7 @@ class StyleValuePool {
   static constexpr bool isIntegerPackable(float f) {
     constexpr uint16_t kMaxInlineAbsValue = (1 << 11) - 1;
 
-    int32_t i = static_cast<int32_t>(f);
+    auto i = static_cast<int32_t>(f);
     return static_cast<float>(i) == f && i >= -kMaxInlineAbsValue &&
         i <= +kMaxInlineAbsValue;
   }
@@ -110,7 +110,7 @@ class StyleValuePool {
     uint16_t isNegative = value < 0 ? 1 : 0;
     return static_cast<uint16_t>(
         (isNegative << 11) |
-        (static_cast<int32_t>(value) * (isNegative ? -1 : 1)));
+        (static_cast<int32_t>(value) * (isNegative != 0u ? -1 : 1)));
   }
 
   static constexpr float unpackInlineInteger(uint16_t value) {

--- a/lib/yogajni/src/main/cpp/jni/ScopedGlobalRef.h
+++ b/lib/yogajni/src/main/cpp/jni/ScopedGlobalRef.h
@@ -62,7 +62,7 @@ class ScopedGlobalRef {
    *
    * @param globalRef the global reference to wrap. Can be NULL.
    */
-  ScopedGlobalRef(T globalRef) : mGlobalRef(globalRef) {}
+  explicit ScopedGlobalRef(T globalRef) : mGlobalRef(globalRef) {}
 
   /**
    * Equivalent to ScopedGlobalRef(NULL)
@@ -72,12 +72,12 @@ class ScopedGlobalRef {
   /**
    * Move construction is allowed.
    */
-  ScopedGlobalRef(ScopedGlobalRef&& s) : mGlobalRef(s.release()) {}
+  ScopedGlobalRef(ScopedGlobalRef&& s) noexcept : mGlobalRef(s.release()) {}
 
   /**
    * Move assignment is allowed.
    */
-  ScopedGlobalRef& operator=(ScopedGlobalRef&& s) {
+  ScopedGlobalRef& operator=(ScopedGlobalRef&& s) noexcept {
     reset(s.release());
     return *this;
   }

--- a/lib/yogajni/src/main/cpp/jni/ScopedLocalRef.h
+++ b/lib/yogajni/src/main/cpp/jni/ScopedLocalRef.h
@@ -70,12 +70,13 @@ class ScopedLocalRef {
   /**
    * Move construction is allowed.
    */
-  ScopedLocalRef(ScopedLocalRef&& s) : mEnv(s.mEnv), mLocalRef(s.release()) {}
+  ScopedLocalRef(ScopedLocalRef&& s) noexcept
+      : mEnv(s.mEnv), mLocalRef(s.release()) {}
 
   /**
    * Move assignment is allowed.
    */
-  ScopedLocalRef& operator=(ScopedLocalRef&& s) {
+  ScopedLocalRef& operator=(ScopedLocalRef&& s) noexcept {
     reset(s.release());
     mEnv = s.mEnv;
     return *this;

--- a/lib/yogajni/src/main/cpp/jni/YGJNI.h
+++ b/lib/yogajni/src/main/cpp/jni/YGJNI.h
@@ -36,7 +36,7 @@ class YGNodeEdges {
     BORDER = 4,
   };
 
-  YGNodeEdges(YGNodeRef node) {
+  explicit YGNodeEdges(YGNodeRef node) {
     auto context = YGNodeContext{};
     context.asVoidPtr = YGNodeGetContext(node);
     edges_ = context.edgesSet;

--- a/lib/yogajni/src/main/cpp/jni/YGJNIVanilla.cpp
+++ b/lib/yogajni/src/main/cpp/jni/YGJNIVanilla.cpp
@@ -54,7 +54,9 @@ static void jni_YGConfigSetExperimentalFeatureEnabledJNI(
     jboolean enabled) {
   const YGConfigRef config = _jlong2YGConfigRef(nativePointer);
   YGConfigSetExperimentalFeatureEnabled(
-      config, static_cast<YGExperimentalFeature>(feature), enabled);
+      config,
+      static_cast<YGExperimentalFeature>(feature),
+      static_cast<bool>(enabled));
 }
 
 static void jni_YGConfigSetUseWebDefaultsJNI(
@@ -63,7 +65,7 @@ static void jni_YGConfigSetUseWebDefaultsJNI(
     jlong nativePointer,
     jboolean useWebDefaults) {
   const YGConfigRef config = _jlong2YGConfigRef(nativePointer);
-  YGConfigSetUseWebDefaults(config, useWebDefaults);
+  YGConfigSetUseWebDefaults(config, static_cast<bool>(useWebDefaults));
 }
 
 static void jni_YGConfigSetPointScaleFactorJNI(
@@ -161,7 +163,7 @@ static void jni_YGConfigSetLoggerJNI(
   auto context =
       reinterpret_cast<ScopedGlobalRef<jobject>*>(YGConfigGetContext(config));
 
-  if (logger) {
+  if (logger != nullptr) {
     if (context == nullptr) {
       context = new ScopedGlobalRef<jobject>();
       YGConfigSetContext(config, context);
@@ -225,14 +227,15 @@ static void jni_YGNodeSetIsReferenceBaselineJNI(
     jlong nativePointer,
     jboolean isReferenceBaseline) {
   YGNodeSetIsReferenceBaseline(
-      _jlong2YGNodeRef(nativePointer), isReferenceBaseline);
+      _jlong2YGNodeRef(nativePointer), static_cast<bool>(isReferenceBaseline));
 }
 
 static jboolean jni_YGNodeIsReferenceBaselineJNI(
     JNIEnv* /*env*/,
     jobject /*obj*/,
     jlong nativePointer) {
-  return YGNodeIsReferenceBaseline(_jlong2YGNodeRef(nativePointer));
+  return static_cast<jboolean>(
+      YGNodeIsReferenceBaseline(_jlong2YGNodeRef(nativePointer)));
 }
 
 static void jni_YGNodeRemoveAllChildrenJNI(
@@ -340,7 +343,7 @@ static void jni_YGNodeCalculateLayoutJNI(
   try {
     PtrJNodeMapVanilla* layoutContext = nullptr;
     auto map = PtrJNodeMapVanilla{};
-    if (nativePointers) {
+    if (nativePointers != nullptr) {
       map = PtrJNodeMapVanilla{nativePointers, javaNodes};
       layoutContext = &map;
     }
@@ -356,7 +359,7 @@ static void jni_YGNodeCalculateLayoutJNI(
     YGTransferLayoutOutputsRecursive(env, obj, root);
   } catch (const YogaJniException& jniException) {
     ScopedLocalRef<jthrowable> throwable = jniException.getThrowable();
-    if (throwable.get()) {
+    if (throwable.get() != nullptr) {
       env->Throw(throwable.get());
     }
   } catch (const std::logic_error& ex) {
@@ -626,8 +629,8 @@ static YGSize YGJNIMeasureFunc(
 
     uint32_t wBits = 0xFFFFFFFF & (measureResult >> 32);
     uint32_t hBits = 0xFFFFFFFF & measureResult;
-    float measuredWidth = std::bit_cast<float>(wBits);
-    float measuredHeight = std::bit_cast<float>(hBits);
+    auto measuredWidth = std::bit_cast<float>(wBits);
+    auto measuredHeight = std::bit_cast<float>(hBits);
 
     return YGSize{measuredWidth, measuredHeight};
   } else {
@@ -645,7 +648,7 @@ static void jni_YGNodeSetHasMeasureFuncJNI(
     jboolean hasMeasureFunc) {
   YGNodeSetMeasureFunc(
       _jlong2YGNodeRef(nativePointer),
-      hasMeasureFunc ? YGJNIMeasureFunc : nullptr);
+      static_cast<bool>(hasMeasureFunc) ? YGJNIMeasureFunc : nullptr);
 }
 
 static float YGJNIBaselineFunc(YGNodeConstRef node, float width, float height) {
@@ -669,7 +672,7 @@ static void jni_YGNodeSetHasBaselineFuncJNI(
     jboolean hasBaselineFunc) {
   YGNodeSetBaselineFunc(
       _jlong2YGNodeRef(nativePointer),
-      hasBaselineFunc ? YGJNIBaselineFunc : nullptr);
+      static_cast<bool>(hasBaselineFunc) ? YGJNIBaselineFunc : nullptr);
 }
 
 static void jni_YGNodeSetAlwaysFormsContainingBlockJNI(
@@ -678,7 +681,8 @@ static void jni_YGNodeSetAlwaysFormsContainingBlockJNI(
     jlong nativePointer,
     jboolean alwaysFormsContainingBlock) {
   YGNodeSetAlwaysFormsContainingBlock(
-      _jlong2YGNodeRef(nativePointer), alwaysFormsContainingBlock);
+      _jlong2YGNodeRef(nativePointer),
+      static_cast<bool>(alwaysFormsContainingBlock));
 }
 
 static jlong

--- a/lib/yogajni/src/main/cpp/jni/YogaJniException.cpp
+++ b/lib/yogajni/src/main/cpp/jni/YogaJniException.cpp
@@ -25,7 +25,7 @@ YogaJniException::YogaJniException(jthrowable throwable) {
   throwable_ = newGlobalRef(getCurrentEnv(), throwable);
 }
 
-YogaJniException::YogaJniException(YogaJniException&& rhs)
+YogaJniException::YogaJniException(YogaJniException&& rhs) noexcept
     : throwable_(std::move(rhs.throwable_)) {}
 
 YogaJniException::YogaJniException(const YogaJniException& rhs) {

--- a/lib/yogajni/src/main/cpp/jni/YogaJniException.h
+++ b/lib/yogajni/src/main/cpp/jni/YogaJniException.h
@@ -22,9 +22,9 @@ class YogaJniException : public std::exception {
 
   explicit YogaJniException(jthrowable throwable);
 
-  YogaJniException(YogaJniException&& rhs);
+  YogaJniException(YogaJniException&& rhs) noexcept;
 
-  YogaJniException(const YogaJniException& other);
+  YogaJniException(const YogaJniException& rhs);
 
   ScopedLocalRef<jthrowable> getThrowable() const noexcept;
 

--- a/lib/yogajni/src/main/cpp/jni/common.cpp
+++ b/lib/yogajni/src/main/cpp/jni/common.cpp
@@ -16,7 +16,7 @@ void registerNatives(
     size_t numMethods) {
   jclass clazz = env->FindClass(className);
 
-  assertNoPendingJniExceptionIf(env, !clazz);
+  assertNoPendingJniExceptionIf(env, clazz == nullptr);
 
   auto result =
       env->RegisterNatives(clazz, methods, static_cast<int32_t>(numMethods));
@@ -31,7 +31,7 @@ jmethodID getStaticMethodId(
     const char* methodDescriptor) {
   jmethodID methodId =
       env->GetStaticMethodID(clazz, methodName, methodDescriptor);
-  assertNoPendingJniExceptionIf(env, !methodId);
+  assertNoPendingJniExceptionIf(env, methodId == nullptr);
   return methodId;
 }
 
@@ -41,7 +41,7 @@ jmethodID getMethodId(
     const char* methodName,
     const char* methodDescriptor) {
   jmethodID methodId = env->GetMethodID(clazz, methodName, methodDescriptor);
-  assertNoPendingJniExceptionIf(env, !methodId);
+  assertNoPendingJniExceptionIf(env, methodId == nullptr);
   return methodId;
 }
 
@@ -51,7 +51,7 @@ jfieldID getFieldId(
     const char* fieldName,
     const char* fieldSignature) {
   jfieldID fieldId = env->GetFieldID(clazz, fieldName, fieldSignature);
-  assertNoPendingJniExceptionIf(env, !fieldId);
+  assertNoPendingJniExceptionIf(env, fieldId == nullptr);
   return fieldId;
 }
 
@@ -82,14 +82,14 @@ callStaticObjectMethod(JNIEnv* env, jclass clazz, jmethodID methodId, ...) {
   va_start(args, methodId);
   jobject result = env->CallStaticObjectMethodV(clazz, methodId, args);
   va_end(args);
-  assertNoPendingJniExceptionIf(env, !result);
+  assertNoPendingJniExceptionIf(env, result == nullptr);
   return make_local_ref(env, result);
 }
 
 ScopedGlobalRef<jobject> newGlobalRef(JNIEnv* env, jobject obj) {
   jobject result = env->NewGlobalRef(obj);
 
-  if (!result) {
+  if (result == nullptr) {
     logErrorMessageAndDie("Could not obtain global reference from object");
   }
 
@@ -97,9 +97,9 @@ ScopedGlobalRef<jobject> newGlobalRef(JNIEnv* env, jobject obj) {
 }
 
 ScopedGlobalRef<jthrowable> newGlobalRef(JNIEnv* env, jthrowable obj) {
-  jthrowable result = static_cast<jthrowable>(env->NewGlobalRef(obj));
+  auto result = static_cast<jthrowable>(env->NewGlobalRef(obj));
 
-  if (!result) {
+  if (result == nullptr) {
     logErrorMessageAndDie("Could not obtain global reference from object");
   }
 

--- a/lib/yogajni/src/main/cpp/jni/corefunctions.cpp
+++ b/lib/yogajni/src/main/cpp/jni/corefunctions.cpp
@@ -12,9 +12,9 @@
 namespace facebook::yoga::vanillajni {
 
 namespace {
-JavaVM* globalVm = NULL;
+JavaVM* globalVm = nullptr;
 struct JavaVMInitializer {
-  JavaVMInitializer(JavaVM* vm) {
+  explicit JavaVMInitializer(JavaVM* vm) {
     if (!vm) {
       logErrorMessageAndDie(
           "You cannot pass a NULL JavaVM to ensureInitialized");
@@ -27,7 +27,7 @@ struct JavaVMInitializer {
 jint ensureInitialized(JNIEnv** env, JavaVM* vm) {
   static JavaVMInitializer init(vm);
 
-  if (!env) {
+  if (env == nullptr) {
     logErrorMessageAndDie(
         "Need to pass a valid JNIEnv pointer to vanillajni initialization "
         "routine");
@@ -43,7 +43,7 @@ jint ensureInitialized(JNIEnv** env, JavaVM* vm) {
 
 // TODO why we need JNIEXPORT for getCurrentEnv ?
 JNIEXPORT JNIEnv* getCurrentEnv() {
-  JNIEnv* env;
+  JNIEnv* env = nullptr;
   jint ret = globalVm->GetEnv((void**)&env, JNI_VERSION_1_6);
   if (ret != JNI_OK) {
     logErrorMessageAndDie(
@@ -68,7 +68,7 @@ void assertNoPendingJniException(JNIEnv* env) {
   }
 
   auto throwable = env->ExceptionOccurred();
-  if (!throwable) {
+  if (throwable == nullptr) {
     logErrorMessageAndDie("Unable to get pending JNI exception.");
   }
   env->ExceptionClear();

--- a/lib/yogajni/src/main/cpp/jni/yogajni.cpp
+++ b/lib/yogajni/src/main/cpp/jni/yogajni.cpp
@@ -10,8 +10,8 @@
 
 using namespace facebook::yoga;
 
-jint JNI_OnLoad(JavaVM* vm, void*) {
-  JNIEnv* env;
+jint JNI_OnLoad(JavaVM* vm, void* /*unused*/) {
+  JNIEnv* env = nullptr;
   jint ret = vanillajni::ensureInitialized(&env, vm);
   YGJNIVanilla::registerNatives(env);
   return ret;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/yoga/pull/1586

X-link: https://github.com/facebook/react-native/pull/43299

Add the React Clang Tidy config to Yoga, run the auto fixes (with some mechanical manual tweaks).

Notably, the automatic changes to the infra for generating a Yoga tree from JSON capture make it 70% faster.

Before:
{F1463947076} 

After:
{F1463946802} 

This also cleans up all the no-op shallow const parameters in headers.

{F1463943386} 

Not all checks are available in all environments, but that is okay, as Clang Tidy will gracefully skip them.

Changelog: [Internal]

Differential Revision: D54461054


