### PR TITLE
Disable docs generation for litho-testing

### DIFF
--- a/litho-testing/build.gradle
+++ b/litho-testing/build.gradle
@@ -75,4 +75,8 @@ dependencies {
     testImplementation deps.supportTestJunit
 }
 
+tasks.withType(Javadoc).all {
+    enabled = false
+}
+
 apply plugin: "com.vanniktech.maven.publish"


### PR DESCRIPTION
Disable docs generation for litho-testing

Summary:
It appears to be timing out in the dokka task here: https://github.com/facebook/litho/actions/runs/8635428192/job/23756165085

Test Plan:
CI

Reviewers:

Subscribers:

Tasks:

Tags:
