### PR TITLE
Expose Gap Percentage to ReactNative

### DIFF
--- a/lib/yoga/src/main/cpp/yoga/YGNodeStyle.cpp
+++ b/lib/yoga/src/main/cpp/yoga/YGNodeStyle.cpp
@@ -267,6 +267,11 @@ void YGNodeStyleSetGap(
       node, scopedEnum(gutter), value::points(gapLength));
 }
 
+void YGNodeStyleSetGapAuto(YGNodeRef node, YGGutter gutter) {
+  updateStyle<&Style::gap, &Style::setGap>(
+      node, scopedEnum(gutter), value::ofAuto());
+}
+
 void YGNodeStyleSetGapPercent(YGNodeRef node, YGGutter gutter, float percent) {
   updateStyle<&Style::gap, &Style::setGap>(
       node, scopedEnum(gutter), value::percent(percent));

--- a/lib/yoga/src/main/cpp/yoga/YGNodeStyle.h
+++ b/lib/yoga/src/main/cpp/yoga/YGNodeStyle.h
@@ -89,6 +89,7 @@ YG_EXPORT float YGNodeStyleGetBorder(YGNodeConstRef node, YGEdge edge);
 
 YG_EXPORT void
 YGNodeStyleSetGap(YGNodeRef node, YGGutter gutter, float gapLength);
+YG_EXPORT void YGNodeStyleSetGapAuto(YGNodeRef node, YGGutter gutter);
 YG_EXPORT void
 YGNodeStyleSetGapPercent(YGNodeRef node, YGGutter gutter, float gapLength);
 YG_EXPORT float YGNodeStyleGetGap(YGNodeConstRef node, YGGutter gutter);

--- a/lib/yoga/src/main/java/com/facebook/yoga/YogaNative.java
+++ b/lib/yoga/src/main/java/com/facebook/yoga/YogaNative.java
@@ -109,6 +109,7 @@ public class YogaNative {
   static native float jni_YGNodeStyleGetGapJNI(long nativePointer, int gutter);
   static native void jni_YGNodeStyleSetGapJNI(long nativePointer, int gutter, float gapLength);
   static native void jni_YGNodeStyleSetGapPercentJNI(long nativePointer, int gutter, float gapLength);
+  static native void jni_YGNodeStyleSetGapAutoJNI(long nativePointer, int gutter);
   static native void jni_YGNodeSetHasMeasureFuncJNI(long nativePointer, boolean hasMeasureFunc);
   static native void jni_YGNodeSetHasBaselineFuncJNI(long nativePointer, boolean hasMeasureFunc);
   static native void jni_YGNodeSetStyleInputsJNI(long nativePointer, float[] styleInputsArray, int size);

--- a/lib/yoga/src/main/java/com/facebook/yoga/YogaNode.java
+++ b/lib/yoga/src/main/java/com/facebook/yoga/YogaNode.java
@@ -194,6 +194,8 @@ public abstract class YogaNode implements YogaProps {
 
   public abstract void setGapPercent(YogaGutter gutter, float gapLength);
 
+  public abstract void setGapAuto(YogaGutter gutter);
+
   public abstract float getLayoutX();
 
   public abstract float getLayoutY();

--- a/lib/yoga/src/main/java/com/facebook/yoga/YogaNodeJNIBase.java
+++ b/lib/yoga/src/main/java/com/facebook/yoga/YogaNodeJNIBase.java
@@ -726,4 +726,9 @@ public abstract class YogaNodeJNIBase extends YogaNode implements Cloneable {
   public void setGapPercent(YogaGutter gutter, float gapLength) {
     YogaNative.jni_YGNodeStyleSetGapPercentJNI(mNativePointer, gutter.intValue(), gapLength);
   }
+
+  @Override
+  public void setGapAuto(YogaGutter gutter) {
+    YogaNative.jni_YGNodeStyleSetGapAutoJNI(mNativePointer, gutter.intValue());
+  }
 }

--- a/lib/yogajni/src/main/cpp/jni/YGJNIVanilla.cpp
+++ b/lib/yogajni/src/main/cpp/jni/YGJNIVanilla.cpp
@@ -727,6 +727,15 @@ static void jni_YGNodeStyleSetGapPercentJNI(
       static_cast<float>(gapLength));
 }
 
+static void jni_YGNodeStyleSetGapAutoJNI(
+    JNIEnv* /*env*/,
+    jobject /*obj*/,
+    jlong nativePointer,
+    jint gutter) {
+  YGNodeStyleSetGapAuto(
+      _jlong2YGNodeRef(nativePointer), static_cast<YGGutter>(gutter));
+}
+
 // Yoga specific properties, not compatible with flexbox specification
 YG_NODE_JNI_STYLE_PROP(jfloat, float, AspectRatio);
 
@@ -959,6 +968,9 @@ static JNINativeMethod methods[] = {
     {"jni_YGNodeStyleSetGapPercentJNI",
      "(JIF)V",
      (void*)jni_YGNodeStyleSetGapPercentJNI},
+    {"jni_YGNodeStyleSetGapAutoJNI",
+     "(JI)V",
+     (void*)jni_YGNodeStyleSetGapAutoJNI},
     {"jni_YGNodeSetHasBaselineFuncJNI",
      "(JZ)V",
      (void*)jni_YGNodeSetHasBaselineFuncJNI},


### PR DESCRIPTION
Summary:
Expose the Gap Percent from Yoga to RN Layer

Changelog: [Internal]
- Enable flex gap percentage value for RN.

Differential Revision: D56160597


