### PR TITLE
Disable broken tests

### DIFF
--- a/litho-it/src/test/java/com/facebook/litho/LithoViewMountTest.kt
+++ b/litho-it/src/test/java/com/facebook/litho/LithoViewMountTest.kt
@@ -19,6 +19,7 @@ package com.facebook.litho
 import android.content.Context
 import android.graphics.Rect
 import androidx.test.core.app.ApplicationProvider
+import com.facebook.litho.config.ComponentsConfiguration
 import com.facebook.litho.testing.TestViewComponent
 import com.facebook.litho.testing.helper.ComponentTestHelper
 import com.facebook.litho.testing.inlinelayoutspec.InlineLayoutSpec
@@ -27,6 +28,7 @@ import com.facebook.litho.widget.MountSpecLifecycleTester
 import com.facebook.litho.widget.SimpleMountSpecTester
 import com.facebook.rendercore.MountState
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assume.assumeFalse
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -62,6 +64,8 @@ class LithoViewMountTest {
 
   @Test
   fun testIncrementalMountTriggeredAfterUnmountAllWithSameDimensions() {
+    // TODO(T193117797): Reenable this test.
+    assumeFalse(ComponentsConfiguration.defaultInstance.enableFixForIM)
     componentTree =
         createComponentTree(useSpy = true, incMountEnabled = true, width = 100, height = 100)
     val width = 50
@@ -93,6 +97,8 @@ class LithoViewMountTest {
 
   @Test
   fun testSetSameSizeComponentAndAttachRequestsLayout() {
+    // TODO(T193117797): Reenable this test.
+    assumeFalse(ComponentsConfiguration.defaultInstance.enableFixForIM)
     lithoView.setMeasured(100, 100)
     lithoView.componentTree = componentTree
     lithoView.onAttachedToWindow()
@@ -101,6 +107,8 @@ class LithoViewMountTest {
 
   @Test
   fun testSetComponentTwiceWithResetAndAttachRequestsLayout() {
+    // TODO(T193117797): Reenable this test.
+    assumeFalse(ComponentsConfiguration.defaultInstance.enableFixForIM)
     val ct = createComponentTree(useSpy = false, incMountEnabled = false, width = 100, height = 100)
     lithoView.componentTree = ct
     lithoView.setMeasured(100, 100)
@@ -131,6 +139,8 @@ class LithoViewMountTest {
 
   @Test
   fun testReAttachRequestsLayout() {
+    // TODO(T193117797): Reenable this test.
+    assumeFalse(ComponentsConfiguration.defaultInstance.enableFixForIM)
     lithoView.setMeasured(100, 100)
     lithoView.componentTree = componentTree
     lithoView.onAttachedToWindow()

--- a/litho-it/src/test/java/com/facebook/litho/LithoViewTest.kt
+++ b/litho-it/src/test/java/com/facebook/litho/LithoViewTest.kt
@@ -19,6 +19,7 @@ package com.facebook.litho
 import android.content.Context
 import android.view.ViewGroup
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
+import com.facebook.litho.config.ComponentsConfiguration
 import com.facebook.litho.testing.LithoStatsRule
 import com.facebook.litho.testing.assertj.LithoViewAssert.Companion.assertThat
 import com.facebook.litho.testing.atMost
@@ -29,6 +30,7 @@ import com.facebook.litho.testing.unspecified
 import com.facebook.litho.widget.SimpleMountSpecTester
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assumptions
+import org.junit.Assume.assumeFalse
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -117,6 +119,8 @@ class LithoViewTest {
   /** This verifies that the width is 0 with normal layout params. */
   @Test
   fun measureWithLayoutParams() {
+    // TODO(T193117797): Reenable this test.
+    assumeFalse(ComponentsConfiguration.defaultInstance.enableFixForIM)
     val component: Component =
         object : InlineLayoutSpec() {
           override fun onCreateLayout(c: ComponentContext): Component {


### PR DESCRIPTION
Summary:
I noticed on GitHub that a bunch of tests are now failing on master. The same is true in Sandcastle:

https://www.internalfb.com/sandcastle/workflow/382805968329783817/artifact/actionlog.382805968392335671.stdout.1

```
7 TESTS FAILED
  ✗ fbsource//fbandroid/javatests/instagram/features/clips/viewer/adapter/organic/mediainfo/authorinfo:authorinfo - test ClipsAuthorInfoComponent is rendered for Clips items (instagram.features.clips.viewer.adapter.organic.mediainfo.authorinfo.ClipsAuthorInfoComponentTest)
  ✗ fbsource//fbandroid/libraries/components/litho-it/src/test/java/com/facebook/litho:litho - testIncrementalMountTriggeredAfterUnmountAllWithSameDimensions[IncrementalMountConfiguration:][api=33][looperMode=LEGACY] (com.facebook.litho.LithoViewMountTest)
  ✗ fbsource//fbandroid/libraries/components/litho-it/src/test/java/com/facebook/litho:litho - testSetComponentTwiceWithResetAndAttachRequestsLayout[IncrementalMountConfiguration:][api=33][looperMode=LEGACY] (com.facebook.litho.LithoViewMountTest)
  ✗ fbsource//fbandroid/libraries/components/litho-it/src/test/java/com/facebook/litho:litho - testSetSameSizeComponentAndAttachRequestsLayout[IncrementalMountConfiguration:][api=33][looperMode=LEGACY] (com.facebook.litho.LithoViewMountTest)
  ✗ fbsource//fbandroid/libraries/components/litho-it/src/test/java/com/facebook/litho:litho - testReAttachRequestsLayout[IncrementalMountConfiguration:][api=33][looperMode=LEGACY] (com.facebook.litho.LithoViewMountTest)
  ✗ fbsource//fbandroid/libraries/components/litho-it/src/test/java/com/facebook/litho:litho - measureWithLayoutParams[IncrementalMountConfiguration:][api=33][looperMode=LEGACY] (com.facebook.litho.LithoViewTest)
  ✗ fbsource//fbandroid/javatests/com/oculus/socialplatform/receivers:receivers - main
```

Based on adityasharat's recommendation, I first tried to change the LooperMode which sadly didn't change the outcome, and then disabled the tests based on a config flag.

Differential Revision: D58818690
