### PR TITLE
Ensure release builds depend on correct yoga version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
         chmod +x buck/buck && \
         ls -l buck)
     - name: Upload Android Archives
-      run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
+      run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache -PforceReleaseBuild=true
     - name: Clean secrets
       if: always()
       run: rm /tmp/secring.gpg

--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,7 @@ ext {
 
 ext.forceReleaseBuild = project.hasProperty('forceReleaseBuild')
 ext.isRelease = { forceReleaseBuild ||
-        ['publish', 'publishToMavenLocal'].any { gradle.startParameter.taskNames.contains(it) } }
+        ['publish', 'publishToMavenLocal', 'publishToMavenCentral', 'publishAndReleaseToMavenCentral'].any { gradle.startParameter.taskNames.contains(it) } }
 ext.isSnapshot = { VERSION_NAME.endsWith('-SNAPSHOT') }
 ext.isDokkaBuild = getGradle().getStartParameter().getTaskNames().toString().toLowerCase().contains("dokka")
 


### PR DESCRIPTION
Summary:
See the error here: https://www.internalfb.com/sandcastle/workflow/2346375405863549594/artifact/actionlog.2346375405930486497.stderr.1

That's because the release command changed. Adding a property as well for forwards-compat.

Reviewed By: pengj

Differential Revision: D59584210
