### PR TITLE
[flipper] Update flipper deps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -164,8 +164,8 @@ ext.deps = [
         soloader           : 'com.facebook.soloader:soloader:0.10.5',
         textlayoutbuilder  : 'com.facebook.fbui.textlayoutbuilder:textlayoutbuilder:1.7.0',
         screenshot         : 'com.facebook.testing.screenshot:core:0.5.0',
-        flipper            : 'com.facebook.flipper:flipper:0.250.0',
-        flipperLithoPlugin : 'com.facebook.flipper:flipper-litho-plugin:0.250.0',
+        flipper            : 'com.facebook.flipper:flipper:0.258.0',
+        flipperLithoPlugin : 'com.facebook.flipper:flipper-litho-plugin:0.258.0',
         // Annotations
         jsr305             : 'com.google.code.findbugs:jsr305:3.0.1',
         inferAnnotations   : 'com.facebook.infer.annotation:infer-annotation:0.18.0',

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -101,3 +101,7 @@ dependencies {
     testImplementation deps.assertjCore
     testImplementation deps.mockitoCore
 }
+
+kotlin {
+    jvmToolchain(17)
+}


### PR DESCRIPTION
Summary:
Preparing to backout the Flipper removal. Finally got the new Flipper release out. This will require a new JDK version though to compile.

Test Plan:
./gradlew :sample:installDebug

Next diff in stack:

<img width="1448" alt="Screenshot 2024-07-17 at 15 26 43" src="https://github.com/user-attachments/assets/dfd8a700-8477-4e47-96e0-db271ed7de54">

Reviewers:

Subscribers:

Tasks:

Tags:
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/litho/pull/1005).
* #1006
* __->__ #1005