### PR TITLE
feat(gap-support): Modified PostWithActionsKComponent and UserFeedWithStoriesKComponent to add some gaps

### DIFF
--- a/sample/src/main/java/com/facebook/samples/litho/onboarding/PostWithActionsKComponent.kt
+++ b/sample/src/main/java/com/facebook/samples/litho/onboarding/PostWithActionsKComponent.kt
@@ -45,9 +45,9 @@ class PostWithActionsKComponent(val post: Post) : KComponent() {
     val isLiked = useState { false }
     // end_state_hook
 
-    return Column {
+    return Column(gap = 40.dp) {
       child(
-          Row(alignItems = YogaAlign.CENTER, style = Style.padding(all = 8.dp)) {
+          Row(gap = 40.dp, alignItems = YogaAlign.CENTER, style = Style.padding(all = 8.dp)) {
             child(
                 Image(
                     drawable = drawableRes(post.user.avatarRes),

--- a/sample/src/main/java/com/facebook/samples/litho/onboarding/UserFeedWithStoriesKComponent.kt
+++ b/sample/src/main/java/com/facebook/samples/litho/onboarding/UserFeedWithStoriesKComponent.kt
@@ -49,7 +49,7 @@ class UserFeedWithStoriesKComponent(
                 usersWithStories.forEach { user -> child(StoryKComponent(user = user)) }
               })
 
-      child(Row(style = Style.height(1.px).backgroundColor(0x22888888)))
+      child(Row(gap = 40.dp, style = Style.height(1.px).backgroundColor(0x22888888)))
 
       posts.forEach { post ->
         child(id = post.id, component = PostWithActionsKComponent(post = post))


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you taking the time to work on these 
changes. Please provide enough information so that others can review your pull request. The three 
fields below are mandatory. -->

## Summary

Gaps don't seem to be working as show in the sample app by manually adding gaps to the rows and columns in the list examples. 
Tracing the code through it seems the YogaNode does have the values set suggesting the result isn't being used but I'm not sure where the fix is. Any support would be appreciated. 

<img width="300" alt="Screenshot 2024-10-09 at 09 09 10" src="https://github.com/user-attachments/assets/0a9c50c4-c6d5-4a34-9754-2f386d39d19f">

In terms of where I'd expect to see gaps, I'd expect to see a gap between the items in the first row and then between the elements in the root column.

<img width="200" alt="Screenshot 2024-10-09 at 09 11 38" src="https://github.com/user-attachments/assets/ca7638a6-3e4c-42a5-a6dc-1859916ac79b">


<!-- Explain the **motivation** for making this change. What existing problem does the pull request 
solve? -->

We want gap support against the latest version of Litho which also has fixes we need for item sizes in lazy lists. 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be
a brief one line we can mention in our release notes: https://github.com/facebook/litho/releases -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, output of 
the test runner and how you invoked it (you've added tests, right?), screenshots/videos if the pull 
request changes UI. -->
