### PR TITLE
Fix OSS build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,6 +159,7 @@ ext.deps = [
         supportDynamicAnimations : 'androidx.dynamicanimation:dynamicanimation-ktx:1.0.0-alpha03',
         // lifecycle
         lifecycle      : 'androidx.lifecycle:lifecycle-runtime:2.6.1',
+        lifecycleKtx       : 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.1',
         viewModel      : 'androidx.lifecycle:lifecycle-viewmodel:2.3.1',
         liveData           : 'androidx.lifecycle:lifecycle-livedata:2.6.1',
         lifecycleService   : 'androidx.lifecycle:lifecycle-service:2.6.1',

--- a/litho-coroutines-kotlin/build.gradle
+++ b/litho-coroutines-kotlin/build.gradle
@@ -73,6 +73,7 @@ dependencies {
     implementation deps.kotlinStandardLib
     implementation deps.supportCore
     implementation deps.supportDynamicAnimations
+    implementation deps.lifecycleKtx
 
     // Android Support Library
     compileOnly deps.supportAnnotations


### PR DESCRIPTION
Summary: OSS build is broken because lifecycle-ktx dependency was added in BUCK but not in gradle in litho-coroutines-kotlin module. This diff fixes the issue.

Differential Revision: D64459826


