### PR TITLE
Avoid NSE Exceptions

### DIFF
--- a/litho-testing/src/main/java/com/facebook/litho/testing/LegacyLithoViewRule.kt
+++ b/litho-testing/src/main/java/com/facebook/litho/testing/LegacyLithoViewRule.kt
@@ -427,7 +427,7 @@ constructor(
   }
 
   private fun findViewWithPredicateOrNull(viewTree: ViewTree, predicate: Predicate<View>): View? {
-    return viewTree.findChild(predicate)?.last()
+    return viewTree.findChild(predicate)?.lastOrNull()
   }
 
   /**

--- a/litho-testing/src/main/java/com/facebook/litho/testing/TestLithoView.kt
+++ b/litho-testing/src/main/java/com/facebook/litho/testing/TestLithoView.kt
@@ -394,7 +394,7 @@ internal constructor(
   }
 
   private fun findViewWithPredicateOrNull(viewTree: ViewTree, predicate: Predicate<View>): View? {
-    return viewTree.findChild(predicate)?.last()
+    return viewTree.findChild(predicate)?.lastOrNull()
   }
 
   /** Returns the first [LazyCollection] from the ComponentTree, or null if not found. */


### PR DESCRIPTION
Summary:
Crashes like https://fburl.com/logview/p23dzrkw (https://fburl.com/logview/8z9nspug) happen when a list is non-null but empty. I reason that if null was a reasonable return, then an empty list can be a null instead of crashing.  This isn't common, but spiked during SEV 0 S475626. 

Basically `?.first()` -> `?.firstOrNull()` as a dumb codemod:
```
for i in `xbgs -l -f '.*\.kt' '?.last()' | sed -e 's/^fbsource\///'`; do sed -i '' 's/\?\.last()/?.lastOrNull()/g' $i; done
for i in `xbgs -l -f '.*\.kt' '?.first()' | sed -e 's/^fbsource\///'`; do sed -i '' 's/\?\.first()/?.firstOrNull()/g' $i; done
arc f
```

Differential Revision: D67113975


