### PR TITLE
Support ViewPager2 for IncrementalMountHelper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,6 +153,7 @@ ext.deps = [
         supportTestJunit   : 'androidx.test.ext:junit:1.1.2',
         supportMultidex    : 'androidx.multidex:multidex:2.0.0',
         supportViewPager   : 'androidx.viewpager:viewpager:1.0.0',
+        supportViewPager2  : 'androidx.viewpager2:viewpager2:1.1.0',
         supportMaterial    : 'com.google.android.material:material:1.2.0',
         supportTransition  : 'androidx.transition:transition:1.0.0',
         supportSwipeRefresh: 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0',

--- a/litho-core/build.gradle
+++ b/litho-core/build.gradle
@@ -92,6 +92,7 @@ dependencies {
     implementation deps.supportCore
     implementation deps.supportCustomView
     implementation deps.supportViewPager
+    implementation deps.supportViewPager2
     implementation deps.supportDynamicAnimations
     implementation deps.lifecycle
 

--- a/litho-core/src/main/java/com/facebook/litho/BUCK
+++ b/litho-core/src/main/java/com/facebook/litho/BUCK
@@ -62,6 +62,7 @@ litho_android_library(
         "//third-party/java/androidx/activity/activity:activity",
         "//third-party/java/androidx/lifecycle/lifecycle-runtime:lifecycle-runtime",
         "//third-party/java/androidx/viewpager/viewpager:viewpager",
+        "//third-party/java/androidx/viewpager2/viewpager2:viewpager2",
         LITHO_ANDROIDSUPPORT_ANNOTATION_TARGET,
         LITHO_ANDROIDSUPPORT_DYNAMICANIMATION_TARGET,
         LITHO_BUILD_CONFIG_TARGET,

--- a/litho-core/src/main/java/com/facebook/litho/config/ComponentsConfiguration.kt
+++ b/litho-core/src/main/java/com/facebook/litho/config/ComponentsConfiguration.kt
@@ -154,6 +154,9 @@ internal constructor(
     /** This flag is used to enable the redesigned event handler rebinding logic. */
     @JvmField val useStateForEventDispatchInfo: Boolean = true,
     val useNonRebindingEventHandlers: Boolean = true,
+
+    /** This flag is used to enable incremental mount helper for ViewPager2. */
+    @JvmField val enableIMHelperForViewPager2: Boolean = false,
 ) {
 
   val shouldAddRootHostViewOrDisableBgFgOutputs: Boolean =
@@ -347,6 +350,7 @@ internal constructor(
     private var enableFixForResolveWithoutSizeSpec = baseConfig.enableFixForResolveWithoutSizeSpec
     private var enableFixForCachedNestedTree = baseConfig.enableFixForCachedNestedTree
     private var isHostViewAttributesCleanUpEnabled = baseConfig.isHostViewAttributesCleanUpEnabled
+    private var enableIMHelperForViewPager2 = baseConfig.enableIMHelperForViewPager2
 
     fun shouldAddHostViewForRootComponent(enabled: Boolean): Builder = also {
       shouldAddHostViewForRootComponent = enabled
@@ -454,6 +458,10 @@ internal constructor(
       isHostViewAttributesCleanUpEnabled = enabled
     }
 
+    fun enableIMHelperForViewPager2(enabled: Boolean): Builder = also {
+      enableIMHelperForViewPager2 = enabled
+    }
+
     fun build(): ComponentsConfiguration {
       return baseConfig.copy(
           shouldAddHostViewForRootComponent = shouldAddHostViewForRootComponent,
@@ -490,6 +498,7 @@ internal constructor(
           enableFixForResolveWithoutSizeSpec = enableFixForResolveWithoutSizeSpec,
           enableFixForCachedNestedTree = enableFixForCachedNestedTree,
           isHostViewAttributesCleanUpEnabled = isHostViewAttributesCleanUpEnabled,
+          enableIMHelperForViewPager2 = enableIMHelperForViewPager2,
       )
     }
   }


### PR DESCRIPTION
Summary:
Since IncrementalMountHelper only integrated with ViewPager which ends up IM broken for ViewPager2, to make it scalable I add support for ViewPager2 as well. 

Given most product teams are integrating it themselves, we have to roll this out slowly after migrating all callsites.

Reviewed By: zielinskimz

Differential Revision: D70901425


