### PR TITLE
Remove Multidex from sample apps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ allprojects {
         // build.
         if (project.name != "sample-barebones") {
             // These are to prevent upgrade problems where second-party dependencies like Fresco may be
-            // dependencing on a specific, older version of Litho causing dex merging conflicts.
+            // depending on a specific, older version of Litho causing dex merging conflicts.
             resolutionStrategy.dependencySubstitution {
                 substitute module('com.facebook.litho:litho-annotations') using project(':litho-annotations')
                 substitute module('com.facebook.litho:litho-widget') using project(':litho-widget')
@@ -151,7 +151,6 @@ ext.deps = [
         supportTestRunner  : 'androidx.test:runner:1.1.1',
         supportTestRules   : 'androidx.test:rules:1.1.1',
         supportTestJunit   : 'androidx.test.ext:junit:1.1.2',
-        supportMultidex    : 'androidx.multidex:multidex:2.0.0',
         supportViewPager   : 'androidx.viewpager:viewpager:1.0.0',
         supportViewPager2  : 'androidx.viewpager2:viewpager2:1.1.0',
         supportMaterial    : 'com.google.android.material:material:1.2.0',

--- a/litho-rendercore-sample/build.gradle
+++ b/litho-rendercore-sample/build.gradle
@@ -28,7 +28,6 @@ android {
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
 
-        multiDexEnabled true
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     namespace 'com.facebook.rendercore.sample'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -29,7 +29,6 @@ android {
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
 
-        multiDexEnabled true
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     namespace 'com.facebook.samples.litho'


### PR DESCRIPTION
## Summary

Since the min SDK version is at least 21 (either 22 or 24 depending on the module), using Multidex is no longer necessary.

## Changelog

Remove Multidex declaration from sample apps.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, output of 
the test runner and how you invoked it (you've added tests, right?), screenshots/videos if the pull 
request changes UI. -->