### PR TITLE
Remove duplicated Robolectric dependency

### DIFF
--- a/litho-core/build.gradle
+++ b/litho-core/build.gradle
@@ -107,7 +107,6 @@ dependencies {
     testImplementation deps.junit
     testImplementation deps.robolectric
     testImplementation deps.mockitokotlin
-    testImplementation deps.robolectric
     testImplementation deps.supportRecyclerView
     testImplementation deps.supportTestJunit
     testImplementation project(':litho-rendercore-testing')


### PR DESCRIPTION
## Summary

The Robolectric dependency is declared twice in the `:litho-core` module.

## Changelog

Remove duplicated Robolectric dependency.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, output of 
the test runner and how you invoked it (you've added tests, right?), screenshots/videos if the pull 
request changes UI. -->