### PR TITLE
Remove Apache HTTP dependency

### DIFF
--- a/litho-rendercore-center/build.gradle
+++ b/litho-rendercore-center/build.gradle
@@ -28,8 +28,6 @@ android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
 
-    useLibrary 'org.apache.http.legacy'
-
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
     }

--- a/litho-rendercore-default-node/build.gradle
+++ b/litho-rendercore-default-node/build.gradle
@@ -24,9 +24,6 @@ android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
 
-    // We're on an old version of Robolectric which requires this, sadly.
-    useLibrary 'org.apache.http.legacy'
-
     buildFeatures {
         buildConfig = false
     }

--- a/litho-rendercore-default-text-node/build.gradle
+++ b/litho-rendercore-default-text-node/build.gradle
@@ -24,9 +24,6 @@ android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
 
-    // We're on an old version of Robolectric which requires this, sadly.
-    useLibrary 'org.apache.http.legacy'
-
     buildFeatures {
         buildConfig = false
     }

--- a/litho-rendercore-extensions/build.gradle
+++ b/litho-rendercore-extensions/build.gradle
@@ -24,9 +24,6 @@ android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
 
-    // We're on an old version of Robolectric which requires this, sadly.
-    useLibrary 'org.apache.http.legacy'
-
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
     }

--- a/litho-rendercore-glide/build.gradle
+++ b/litho-rendercore-glide/build.gradle
@@ -28,8 +28,6 @@ android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
 
-    useLibrary 'org.apache.http.legacy'
-
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
     }

--- a/litho-rendercore-primitive-components/canvas/build.gradle
+++ b/litho-rendercore-primitive-components/canvas/build.gradle
@@ -26,9 +26,6 @@ android {
     buildToolsVersion rootProject.buildToolsVersion
     namespace 'com.facebook.primitive.canvas'
 
-    // We're on an old version of Robolectric which requires this, sadly.
-    useLibrary 'org.apache.http.legacy'
-
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
     }

--- a/litho-rendercore-primitive-components/utils/build.gradle
+++ b/litho-rendercore-primitive-components/utils/build.gradle
@@ -26,9 +26,6 @@ android {
     buildToolsVersion rootProject.buildToolsVersion
     namespace 'com.facebook.primitive.utils'
 
-    // We're on an old version of Robolectric which requires this, sadly.
-    useLibrary 'org.apache.http.legacy'
-
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
     }

--- a/litho-rendercore-primitives/build.gradle
+++ b/litho-rendercore-primitives/build.gradle
@@ -25,9 +25,6 @@ android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
 
-    // We're on an old version of Robolectric which requires this, sadly.
-    useLibrary 'org.apache.http.legacy'
-
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
     }

--- a/litho-rendercore-res/build.gradle
+++ b/litho-rendercore-res/build.gradle
@@ -24,8 +24,6 @@ android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
 
-    useLibrary 'org.apache.http.legacy'
-
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
     }

--- a/litho-rendercore-testing/build.gradle
+++ b/litho-rendercore-testing/build.gradle
@@ -20,8 +20,6 @@ android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
 
-    useLibrary 'org.apache.http.legacy'
-
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
     }

--- a/litho-rendercore-text/build.gradle
+++ b/litho-rendercore-text/build.gradle
@@ -22,8 +22,6 @@ android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
 
-    useLibrary 'org.apache.http.legacy'
-
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
     }

--- a/litho-rendercore-thread-utils/build.gradle
+++ b/litho-rendercore-thread-utils/build.gradle
@@ -25,9 +25,6 @@ android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
 
-    // We're on an old version of Robolectric which requires this, sadly.
-    useLibrary 'org.apache.http.legacy'
-
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
     }

--- a/litho-rendercore-visibility/build.gradle
+++ b/litho-rendercore-visibility/build.gradle
@@ -24,9 +24,6 @@ android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
 
-    // We're on an old version of Robolectric which requires this, sadly.
-    useLibrary 'org.apache.http.legacy'
-
     kotlinOptions {
         freeCompilerArgs = ['-Xjvm-default=all']
     }

--- a/litho-rendercore-yoga/build.gradle
+++ b/litho-rendercore-yoga/build.gradle
@@ -20,8 +20,6 @@ android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
 
-    useLibrary 'org.apache.http.legacy'
-
     buildFeatures {
         buildConfig = false
     }

--- a/litho-rendercore/build.gradle
+++ b/litho-rendercore/build.gradle
@@ -25,8 +25,6 @@ android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
 
-    useLibrary 'org.apache.http.legacy'
-
     kotlinOptions {
         freeCompilerArgs = ['-Xjvm-default=all']
     }

--- a/sample-codelab/build.gradle
+++ b/sample-codelab/build.gradle
@@ -20,8 +20,6 @@ android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
 
-    useLibrary 'org.apache.http.legacy'
-
     targetCompatibility = targetCompatibilityVersion
     sourceCompatibility = sourceCompatibilityVersion
 


### PR DESCRIPTION
## Summary

Apache HTTP classes have been removed from the Android SDK in Android 6.0. Developers needing these classes can add `useLibrary 'org.apache.http.legacy'` to their Gradle file to keep using that library.
Robolectric now provides shadows for this library in a separate module (`org.robolectric:shadows-httpclient`), so it is no longer part of the main module.

## Changelog

Remove dependency on Apache HTTP.

## Test Plan

As per [CONTRIBUTING.md](https://github.com/facebook/litho/blob/master/CONTRIBUTING.md#testing), I've ran `./gradlew test`, but the task fails with the following message:
```
* What went wrong:
Execution failed for task ':yoga:buckBuild'.
> execCommand == null!
```

Note that I have the same result from `master`.