### PR TITLE
Fix compilation of the `tests` step on GitHub Actions

### DIFF
--- a/litho-coroutines-kotlin/build.gradle
+++ b/litho-coroutines-kotlin/build.gradle
@@ -86,6 +86,7 @@ dependencies {
     testImplementation deps.supportRecyclerView
     testImplementation deps.supportTestJunit
     testImplementation project(':litho-rendercore-testing')
+    testImplementation project(':litho-rendercore-text')
     testImplementation project(':litho-testing')
     testImplementation project(':litho-widget-kotlin')
 }


### PR DESCRIPTION
## Summary

This PR fixes the compilation of the `tests` step on GitHub Actions. Some test dependencies were missing in a couple of modules, preventing the compilation from succeeding.
Note that the step is still failing due to some failing tests.

## Changelog

Add missing test dependencies to `:litho-coroutines-kotlin` and `:litho-rendercore-text`.

## Test Plan

Run the GitHub Actions `tests` step.