### PR TITLE
Fix Gradle warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+import com.android.build.gradle.tasks.JavaDocGenerationTask
+import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
+import org.jetbrains.dokka.gradle.DokkaTaskPartial
+import org.jetbrains.kotlin.gradle.internal.KaptWithoutKotlincTask
+import org.jetbrains.kotlin.gradle.plugin.KotlinBasePlugin
+
 def latestSdkVersion = 34
 
 buildscript {
@@ -44,14 +50,14 @@ allprojects {
         maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
     }
 
-    tasks.withType(Javadoc).all {
+    tasks.withType(Javadoc).configureEach {
         options.addStringOption('Xdoclint:none', '-quiet')
     }
     // Disabled until there's a workaround/fix for https://github.com/Kotlin/dokka/issues/2472
-    tasks.withType(com.android.build.gradle.tasks.JavaDocGenerationTask).all {
+    tasks.withType(JavaDocGenerationTask).configureEach {
         enabled = false
     }
-    configurations.all {
+    configurations.configureEach {
         // Temporarily exclude sample-barebones project from substitution in order to fix the gradle
         // build.
         if (project.name != "sample-barebones") {
@@ -66,11 +72,11 @@ allprojects {
 }
 
 subprojects {
-    tasks.withType(Javadoc).all {
+    tasks.withType(Javadoc).configureEach {
         enabled = false
     }
 
-    tasks.withType(org.jetbrains.dokka.gradle.DokkaTaskPartial).configureEach {
+    tasks.withType(DokkaTaskPartial).configureEach {
         dokkaSourceSets {
             configureEach {
                 def module_docs_file = 'module-docs.md'
@@ -79,10 +85,10 @@ subprojects {
                 }
             }
         }
-        dependsOn(tasks.withType(org.jetbrains.kotlin.gradle.internal.KaptWithoutKotlincTask))
+        dependsOn(tasks.withType(KaptWithoutKotlincTask))
     }
 
-    tasks.withType(Test) {
+    tasks.withType(Test).configureEach {
         systemProperty "robolectric.looperMode", "LEGACY"
 
         testLogging {
@@ -91,14 +97,14 @@ subprojects {
         }
     }
 
-    plugins.withType(org.jetbrains.kotlin.gradle.plugin.KotlinBasePlugin) {
+    plugins.withType(KotlinBasePlugin).configureEach {
         kotlin {
             jvmToolchain(17)
         }
     }
 
     afterEvaluate {
-        tasks.withType(Test) {
+        tasks.withType(Test).configureEach {
             it.dependsOn copyYogaLibs
             systemProperty 'java.library.path', "${rootDir}/build/jniLibs"
             environment 'LD_LIBRARY_PATH', "${rootDir}/build/jniLibs"
@@ -114,7 +120,7 @@ subprojects {
 
 apply plugin: 'org.jetbrains.dokka'
 
-tasks.withType(org.jetbrains.dokka.gradle.DokkaMultiModuleTask).configureEach {
+tasks.withType(DokkaMultiModuleTask).configureEach {
     outputDirectory = file("${rootDir}/website/static/reference")
     moduleName = "Litho"
 }
@@ -207,7 +213,8 @@ ext.deps.yoga =
 
 // This should hopefully only serve as a temporary measure until
 // we have a proper Gradle setup for Yoga and JNI.
-task copyYogaLibs(type: Copy, dependsOn: ':yoga:buckBuild') {
+tasks.register('copyYogaLibs', Copy) {
+    dependsOn ':yoga:buckBuild'
     from 'buck-out/gen/lib/yogajni/jni#default,shared/'
     include '*.so'
     include '*.dylib'

--- a/lib/yoga/build.gradle
+++ b/lib/yoga/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 // Our current NDK setup only gets us half-way there to a way to run Yoga
 // locally for unit tests. We're reusing the buck builds for now and hopefully
 // someone (maybe you!) will fix this and get CMake to help us out.
-task buckBuild(type: Exec) {
+tasks.register('buckBuild', Exec) {
     workingDir rootDir
     environment BUCKVERSION: System.getenv('BUCKVERSION') ?: 'last'
     def buckPath = System.getenv('BUCK_PATH')

--- a/lib/yogajni/build.gradle
+++ b/lib/yogajni/build.gradle
@@ -28,10 +28,10 @@ android {
             version '3.18.1'
         }
     }
+}
 
-    dependencies {
-        // We want to export the Java APIs
-        api project(':yoga')
-        compileOnly deps.inferAnnotations
-    }
+dependencies {
+    // We want to export the Java APIs
+    api project(':yoga')
+    compileOnly deps.inferAnnotations
 }

--- a/litho-core/build.gradle
+++ b/litho-core/build.gradle
@@ -59,11 +59,10 @@ android {
         buildConfig true
     }
     namespace 'com.facebook.litho'
+    // TODO(#62): Re-enable abort on error.
     lint {
         abortOnError false
     }
-
-    // TODO(#62): Re-enable abort on error.
 }
 
 dependencies {

--- a/litho-coroutines-kotlin/build.gradle
+++ b/litho-coroutines-kotlin/build.gradle
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'org.jetbrains.dokka'
@@ -28,23 +30,21 @@ android {
     }
 
     testOptions {
-        unitTests {
-            includeAndroidResources = true
+        unitTests.includeAndroidResources = true
 
-            all {
-                // Because of native libraries loading (Yoga), we can never reuse a class loader and
-                // need to fork a new process per class.
-                forkEvery = 1
-                maxParallelForks = 2
+        unitTests.all {
+            // Because of native libraries loading (Yoga), we can never reuse a class loader and
+            // need to fork a new process per class.
+            forkEvery = 1
+            maxParallelForks = 2
 
-                testLogging {
-                    events 'skipped', 'failed', 'standardOut', 'standardError'
-                    showCauses = true
-                    showExceptions = true
-                    showStackTraces = true
-                    exceptionFormat = 'full'
-                    stackTraceFilters = []
-                }
+            testLogging {
+                events 'skipped', 'failed', 'standardOut', 'standardError'
+                showCauses = true
+                showExceptions = true
+                showStackTraces = true
+                exceptionFormat = 'full'
+                stackTraceFilters = []
             }
         }
     }
@@ -56,7 +56,7 @@ android {
     namespace 'com.facebook.litho.coroutines'
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+tasks.withType(KotlinCompile).configureEach {
     kotlinOptions {
         freeCompilerArgs = ["-XXLanguage:+InlineClasses"]
     }

--- a/litho-editor-core/build.gradle
+++ b/litho-editor-core/build.gradle
@@ -27,19 +27,20 @@ android {
         targetSdkVersion rootProject.targetSdkVersion
     }
 
-    // TODO(#62): Re-enable abort on error.
-
-    dependencies {
-        api project(':litho-core')
-        compileOnly deps.jsr305
-        compileOnly deps.proguardAnnotations
-        compileOnly deps.supportAnnotations
-        compileOnly deps.inferAnnotations
-    }
     namespace 'com.facebook.litho.editor'
+
+    // TODO(#62): Re-enable abort on error.
     lint {
         abortOnError false
     }
+}
+
+dependencies {
+    api project(':litho-core')
+    compileOnly deps.jsr305
+    compileOnly deps.proguardAnnotations
+    compileOnly deps.supportAnnotations
+    compileOnly deps.inferAnnotations
 }
 
 apply plugin: "com.vanniktech.maven.publish"

--- a/litho-editor-flipper/build.gradle
+++ b/litho-editor-flipper/build.gradle
@@ -28,41 +28,8 @@ android {
         targetSdkVersion rootProject.targetSdkVersion
     }
 
-    // TODO(#62): Re-enable abort on error.
-
-    dependencies {
-        kapt project(':litho-processor')
-        kapt project(':litho-sections-processor')
-
-        implementation deps.kotlinStandardLib
-        implementation project(':litho-core')
-        implementation project(':litho-widget')
-        implementation project(':litho-editor-core')
-        implementation project(':litho-sections-core')
-        implementation project(':litho-sections-debug')
-        implementation deps.flipper
-        implementation deps.supportAppCompat
-        implementation deps.guava
-        compileOnly deps.jsr305
-        compileOnly deps.proguardAnnotations
-        compileOnly project(':litho-annotations')
-        compileOnly deps.inferAnnotations
-
-        testImplementation deps.junit
-        testImplementation deps.robolectric
-        testImplementation project(':litho-rendercore-testing')
-        testImplementation project(':litho-testing')
-        testImplementation project(':litho-widget-kotlin')
-        testAnnotationProcessor project(':litho-processor')
-        testImplementation deps.assertjCore
-        testImplementation deps.supportRecyclerView
-        testImplementation deps.supportTestJunit
-        testImplementation deps.mockitokotlin
-        testImplementation deps.supportTestCore
-
-        kaptTest project(':litho-processor')
-    }
     namespace 'com.facebook.litho.editor.flipper'
+    // TODO(#62): Re-enable abort on error.
     lint {
         abortOnError false
     }
@@ -70,6 +37,39 @@ android {
 
 kotlin {
     jvmToolchain(17)
+}
+
+dependencies {
+    kapt project(':litho-processor')
+    kapt project(':litho-sections-processor')
+
+    implementation deps.kotlinStandardLib
+    implementation project(':litho-core')
+    implementation project(':litho-widget')
+    implementation project(':litho-editor-core')
+    implementation project(':litho-sections-core')
+    implementation project(':litho-sections-debug')
+    implementation deps.flipper
+    implementation deps.supportAppCompat
+    implementation deps.guava
+    compileOnly deps.jsr305
+    compileOnly deps.proguardAnnotations
+    compileOnly project(':litho-annotations')
+    compileOnly deps.inferAnnotations
+
+    testImplementation deps.junit
+    testImplementation deps.robolectric
+    testImplementation project(':litho-rendercore-testing')
+    testImplementation project(':litho-testing')
+    testImplementation project(':litho-widget-kotlin')
+    testAnnotationProcessor project(':litho-processor')
+    testImplementation deps.assertjCore
+    testImplementation deps.supportRecyclerView
+    testImplementation deps.supportTestJunit
+    testImplementation deps.mockitokotlin
+    testImplementation deps.supportTestCore
+
+    kaptTest project(':litho-processor')
 }
 
 apply plugin: "com.vanniktech.maven.publish"

--- a/litho-fresco-kotlin/build.gradle
+++ b/litho-fresco-kotlin/build.gradle
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'com.facebook.kotlin.compilerplugins.dataclassgenerate'
@@ -33,7 +35,7 @@ android {
     namespace 'com.facebook.litho.fresco.kotlin'
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+tasks.withType(KotlinCompile).configureEach {
     kotlinOptions {
         freeCompilerArgs = ["-XXLanguage:+InlineClasses"]
     }

--- a/litho-fresco/build.gradle
+++ b/litho-fresco/build.gradle
@@ -24,11 +24,10 @@ android {
         minSdkVersion rootProject.minSdkVersion
     }
     namespace 'com.facebook.litho.fresco'
+    // TODO(#62): Re-enable abort on error.
     lint {
         abortOnError false
     }
-
-    // TODO(#62): Re-enable abort on error.
 }
 
 dependencies {

--- a/litho-intellij-plugin/build.gradle
+++ b/litho-intellij-plugin/build.gradle
@@ -29,6 +29,7 @@ apply plugin: "org.jetbrains.intellij"
 group 'com.facebook.litho.intellij'
 
 sourceCompatibility = rootProject.sourceCompatibilityVersion
+targetCompatibility = rootProject.targetCompatibilityVersion
 
 compileKotlin {
     kotlinOptions.jvmTarget = rootProject.targetCompatibilityVersion
@@ -67,7 +68,7 @@ intellij {
     plugins = ['java', 'org.jetbrains.kotlin',]
 }
 
-task merge {
+tasks.register('merge') {
     doLast {
         def output = new File(project.buildDir, "patchedPluginXmlFiles/plugin.xml")
 

--- a/litho-it/build.gradle
+++ b/litho-it/build.gradle
@@ -144,7 +144,7 @@ gradle.projectsEvaluated {
         def variationName = variant.name.capitalize()
         def variationPath = variant.buildType.name
 
-        task "copyTest${variationName}Resources"(type: Copy) {
+        tasks.register("copyTest${variationName}Resources", Copy) {
             from "${projectDir}/src/test/resources"
             into "${testClassesPath}/${variationPath}"
         }

--- a/litho-live-data/build.gradle
+++ b/litho-live-data/build.gradle
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'com.facebook.kotlin.compilerplugins.dataclassgenerate'
@@ -27,23 +29,21 @@ android {
     }
 
     testOptions {
-        unitTests {
-            includeAndroidResources = true
+        unitTests.includeAndroidResources = true
 
-            all {
-                // Because of native libraries loading (Yoga), we can never reuse a class loader and
-                // need to fork a new process per class.
-                forkEvery = 1
-                maxParallelForks = 2
+        unitTests.all {
+            // Because of native libraries loading (Yoga), we can never reuse a class loader and
+            // need to fork a new process per class.
+            forkEvery = 1
+            maxParallelForks = 2
 
-                testLogging {
-                    events 'skipped', 'failed', 'standardOut', 'standardError'
-                    showCauses = true
-                    showExceptions = true
-                    showStackTraces = true
-                    exceptionFormat = 'full'
-                    stackTraceFilters = []
-                }
+            testLogging {
+                events 'skipped', 'failed', 'standardOut', 'standardError'
+                showCauses = true
+                showExceptions = true
+                showStackTraces = true
+                exceptionFormat = 'full'
+                stackTraceFilters = []
             }
         }
     }
@@ -55,7 +55,7 @@ android {
     namespace 'com.facebook.litho.livedata'
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+tasks.withType(KotlinCompile).configureEach {
     kotlinOptions {
         freeCompilerArgs = ["-XXLanguage:+InlineClasses"]
     }

--- a/litho-perf-logger/build.gradle
+++ b/litho-perf-logger/build.gradle
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'com.facebook.kotlin.compilerplugins.dataclassgenerate'
@@ -32,7 +34,7 @@ android {
     namespace 'com.facebook.litho.performance'
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+tasks.withType(KotlinCompile).configureEach {
     kotlinOptions {
         freeCompilerArgs = ["-XXLanguage:+InlineClasses"]
     }

--- a/litho-processor/build.gradle
+++ b/litho-processor/build.gradle
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import org.gradle.internal.jvm.Jvm
-
 apply plugin: 'java'
 
 sourceCompatibility = rootProject.sourceCompatibilityVersion
@@ -37,10 +35,6 @@ dependencies {
 
     testImplementation deps.junit
     testImplementation deps.assertjCore
-    compileJava {
-        sourceCompatibility = rootProject.sourceCompatibilityVersion
-        targetCompatibility = rootProject.targetCompatibilityVersion
-    }
 }
 
 apply plugin: "com.vanniktech.maven.publish"

--- a/litho-rendercore-center/build.gradle
+++ b/litho-rendercore-center/build.gradle
@@ -34,11 +34,10 @@ android {
         minSdkVersion rootProject.minSdkVersion
     }
     namespace 'com.facebook.rendercore'
+    // TODO(#62): Re-enable abort on error.
     lint {
         abortOnError false
     }
-
-    // TODO(#62): Re-enable abort on error.
 }
 
 dependencies {

--- a/litho-rendercore-default-node/build.gradle
+++ b/litho-rendercore-default-node/build.gradle
@@ -44,11 +44,10 @@ android {
         }
     }
     namespace 'com.facebook.rendercore'
+    // TODO(#62): Re-enable abort on error.
     lint {
         abortOnError false
     }
-
-    // TODO(#62): Re-enable abort on error.
 }
 
 dependencies {

--- a/litho-rendercore-default-text-node/build.gradle
+++ b/litho-rendercore-default-text-node/build.gradle
@@ -44,11 +44,10 @@ android {
         }
     }
     namespace 'com.facebook.rendercore'
+    // TODO(#62): Re-enable abort on error.
     lint {
         abortOnError false
     }
-
-    // TODO(#62): Re-enable abort on error.
 }
 
 dependencies {

--- a/litho-rendercore-extensions/build.gradle
+++ b/litho-rendercore-extensions/build.gradle
@@ -40,11 +40,10 @@ android {
         }
     }
     namespace 'com.facebook.rendercore.extensions'
+    // TODO(#62): Re-enable abort on error.
     lint {
         abortOnError false
     }
-
-    // TODO(#62): Re-enable abort on error.
 }
 
 dependencies {

--- a/litho-rendercore-glide/build.gradle
+++ b/litho-rendercore-glide/build.gradle
@@ -34,11 +34,10 @@ android {
         minSdkVersion rootProject.minSdkVersion
     }
     namespace 'com.facebook.rendercore'
+    // TODO(#62): Re-enable abort on error.
     lint {
         abortOnError false
     }
-
-    // TODO(#62): Re-enable abort on error.
 }
 
 dependencies {

--- a/litho-rendercore-primitives/build.gradle
+++ b/litho-rendercore-primitives/build.gradle
@@ -41,11 +41,10 @@ android {
         }
     }
     namespace 'com.facebook.rendercore.primitives'
+    // TODO(#62): Re-enable abort on error.
     lint {
         abortOnError false
     }
-
-    // TODO(#62): Re-enable abort on error.
 }
 
 dependencies {

--- a/litho-rendercore-res/build.gradle
+++ b/litho-rendercore-res/build.gradle
@@ -30,11 +30,10 @@ android {
         minSdkVersion rootProject.minSdkVersion
     }
     namespace 'com.facebook'
+    // TODO(#62): Re-enable abort on error.
     lint {
         abortOnError false
     }
-
-    // TODO(#62): Re-enable abort on error.
 }
 
 dependencies {

--- a/litho-rendercore-sample/build.gradle
+++ b/litho-rendercore-sample/build.gradle
@@ -31,11 +31,10 @@ android {
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     namespace 'com.facebook.rendercore.sample'
+    // TODO(#62): Re-enable abort on error.
     lint {
         abortOnError false
     }
-
-    // TODO(#62): Re-enable abort on error.
 }
 
 dependencies {

--- a/litho-rendercore-testing/build.gradle
+++ b/litho-rendercore-testing/build.gradle
@@ -31,10 +31,10 @@ android {
         targetCompatibility rootProject.targetCompatibilityVersion
     }
     namespace 'com.facebook.rendercore.testing'
+    // TODO(#62): Re-enable abort on error.
     lint {
         abortOnError false
     }
-    // TODO(#62): Re-enable abort on error.
 }
 
 dependencies {

--- a/litho-rendercore-text/build.gradle
+++ b/litho-rendercore-text/build.gradle
@@ -28,11 +28,10 @@ android {
         minSdkVersion rootProject.minSdkVersion
     }
     namespace 'com.facebook.rendercore.text'
+    // TODO(#62): Re-enable abort on error.
     lint {
         abortOnError false
     }
-
-    // TODO(#62): Re-enable abort on error.
 }
 
 dependencies {

--- a/litho-rendercore-thread-utils/build.gradle
+++ b/litho-rendercore-thread-utils/build.gradle
@@ -41,11 +41,10 @@ android {
         }
     }
     namespace 'com.facebook.rendercore.thread.utils'
+    // TODO(#62): Re-enable abort on error.
     lint {
         abortOnError false
     }
-
-    // TODO(#62): Re-enable abort on error.
 }
 
 dependencies {

--- a/litho-rendercore-visibility/build.gradle
+++ b/litho-rendercore-visibility/build.gradle
@@ -44,11 +44,10 @@ android {
         }
     }
     namespace 'com.facebook.rendercore.visibility'
+    // TODO(#62): Re-enable abort on error.
     lint {
         abortOnError false
     }
-
-    // TODO(#62): Re-enable abort on error.
 }
 
 dependencies {

--- a/litho-rendercore-yoga/build.gradle
+++ b/litho-rendercore-yoga/build.gradle
@@ -30,11 +30,10 @@ android {
         minSdkVersion rootProject.minSdkVersion
     }
     namespace 'com.facebook.rendercore'
+    // TODO(#62): Re-enable abort on error.
     lint {
         abortOnError false
     }
-
-    // TODO(#62): Re-enable abort on error.
 }
 
 dependencies {

--- a/litho-rendercore/build.gradle
+++ b/litho-rendercore/build.gradle
@@ -51,11 +51,10 @@ android {
         }
     }
     namespace 'com.facebook.rendercore'
+    // TODO(#62): Re-enable abort on error.
     lint {
         abortOnError false
     }
-
-    // TODO(#62): Re-enable abort on error.
 }
 
 dependencies {

--- a/litho-testing/build.gradle
+++ b/litho-testing/build.gradle
@@ -77,7 +77,7 @@ dependencies {
     testImplementation deps.supportTestJunit
 }
 
-tasks.withType(Javadoc).all {
+tasks.withType(Javadoc).configureEach {
     enabled = false
 }
 

--- a/litho-widget-kotlin/build.gradle
+++ b/litho-widget-kotlin/build.gradle
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
@@ -37,7 +39,7 @@ android {
     namespace 'com.facebook.litho.widget.kotlin'
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+tasks.withType(KotlinCompile).configureEach {
     kotlinOptions {
         freeCompilerArgs = ["-XXLanguage:+InlineClasses"]
     }

--- a/litho-widget/build.gradle
+++ b/litho-widget/build.gradle
@@ -33,11 +33,10 @@ android {
         minSdkVersion rootProject.minSdkVersion
     }
     namespace 'com.facebook.litho.widget'
+    // TODO(#62): Re-enable abort on error.
     lint {
         abortOnError false
     }
-
-    // TODO(#62): Re-enable abort on error.
 }
 
 dependencies {

--- a/sample-barebones/build.gradle
+++ b/sample-barebones/build.gradle
@@ -30,11 +30,10 @@ android {
         targetSdkVersion rootProject.targetSdkVersion
     }
     namespace 'com.facebook.samples.lithoktbarebones'
+    // TODO(#62): Re-enable abort on error.
     lint {
         abortOnError false
     }
-
-    // TODO(#62): Re-enable abort on error.
 }
 
 kapt {

--- a/sample-codelab/build.gradle
+++ b/sample-codelab/build.gradle
@@ -30,11 +30,10 @@ android {
         targetSdkVersion rootProject.targetSdkVersion
     }
     namespace 'com.facebook.samples.lithocodelab'
+    // TODO(#62): Re-enable abort on error.
     lint {
         abortOnError false
     }
-
-    // TODO(#62): Re-enable abort on error.
 }
 
 dependencies {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -32,11 +32,10 @@ android {
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     namespace 'com.facebook.samples.litho'
+    // TODO(#62): Re-enable abort on error.
     lint {
         abortOnError false
     }
-
-    // TODO(#62): Re-enable abort on error.
 }
 
 dependencies {


### PR DESCRIPTION
## Summary

This PR fixes some warnings in Gradle files, in particular:
- Use `configureEach` instead of `all` to favor lazy access to objects.
- Use `Task.register()` for creating new tasks.
- Use imports instead of fully qualified class names.
- Move the `dependencies` block out of the `android` block.
- Move the TODO for Lint error back where it belongs.

## Changelog

Fix Gradle warnings.

## Test Plan

GitHub Actions workflow run is successful (minus the currently failing tests).