### PR TITLE
Fix build on GitHub

### DIFF
--- a/litho-core/build.gradle
+++ b/litho-core/build.gradle
@@ -74,6 +74,7 @@ dependencies {
     api project(':litho-rendercore')
     api project(':litho-rendercore-incremental-mount')
     api project(':litho-rendercore-primitives')
+    api project(':litho-rendercore-text')
     api project(':litho-rendercore-transitions')
     api project(':litho-rendercore-visibility')
 

--- a/litho-core/build.gradle
+++ b/litho-core/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     api project(':litho-rendercore')
     api project(':litho-rendercore-incremental-mount')
     api project(':litho-rendercore-primitives')
-    api project(':litho-rendercore-text')
+    implementation project(':litho-rendercore-text')
     api project(':litho-rendercore-transitions')
     api project(':litho-rendercore-visibility')
 

--- a/litho-rendercore-text/build.gradle
+++ b/litho-rendercore-text/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     testImplementation deps.assertjCore
     testImplementation deps.junit
     testImplementation deps.mockitoCore
+    testImplementation deps.mockitokotlin
     testImplementation deps.robolectric
     testImplementation deps.supportTestCore
 }


### PR DESCRIPTION
## Summary

This PR fixes the build on GitHub by adding missing dependencies to Gradle configuration files:
- Add dependency to `:litho-rendercore-text` in `:litho-core`.
- Add dependency to `deps.mockitokotlin` in `:litho-rendercore-text`.

## Changelog

Fix build on GitHub.

## Test Plan

GitHub Actions build successfully.