### PR TITLE
Update the `ci` and `docs` workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: 17
@@ -27,7 +27,7 @@ jobs:
         with:
           ndk-version: r26b
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9.16'
       - name: Setup Android SDK
@@ -35,15 +35,7 @@ jobs:
       - name: Install CMake
         run: sdkmanager 'cmake;3.18.1'
       - name: Gradle caches
-        uses: actions/cache@v3
-        with:
-          path: ~/.gradle/caches
-          key: caches-${{ runner.os }}-${{ hashFiles('**/*.gradle') }}
-      - name: Gradle wrapper caches
-        uses: actions/cache@v3
-        with:
-          path: ~/.gradle/wrapper
-          key: wrapper-${{ runner.os }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+        uses: gradle/actions/setup-gradle@v4
       - name: Fetch buck
         run: |
           (rm -rf buck && mkdir buck && \
@@ -57,9 +49,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: 17
@@ -73,19 +65,11 @@ jobs:
         with:
           ndk-version: r26b
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9.16'
       - name: Gradle caches
-        uses: actions/cache@v3
-        with:
-          path: ~/.gradle/caches
-          key: caches-${{ runner.os }}-${{ hashFiles('**/*.gradle') }}
-      - name: Gradle wrapper caches
-        uses: actions/cache@v3
-        with:
-          path: ~/.gradle/wrapper
-          key: wrapper-${{ runner.os }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+        uses: gradle/actions/setup-gradle@v4
       - name: Fetch buck
         run: |
           (rm -rf buck && mkdir buck && \
@@ -104,7 +88,7 @@ jobs:
       is-snapshot: ${{ steps.check_snapshot.outputs.IS_SNAPSHOT != '' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Check if SNAPSHOT version
         id: check_snapshot
         run: |
@@ -115,9 +99,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: 17
@@ -131,19 +115,11 @@ jobs:
         with:
           ndk-version: r26b
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9.16'
       - name: Gradle caches
-        uses: actions/cache@v3
-        with:
-          path: ~/.gradle/caches
-          key: caches-${{ runner.os }}-${{ hashFiles('**/*.gradle') }}
-      - name: Gradle wrapper caches
-        uses: actions/cache@v3
-        with:
-          path: ~/.gradle/wrapper
-          key: wrapper-${{ runner.os }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+        uses: gradle/actions/setup-gradle@v4
       - name: Fetch buck
         run: |
           (rm -rf buck && mkdir buck && \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,28 +11,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: 17
       - name: Gradle caches
-        uses: actions/cache@v3
-        with:
-          path: ~/.gradle/caches
-          key: caches-${{ runner.os }}-${{ hashFiles('**/*.gradle') }}
-      - name: Gradle wrapper caches
-        uses: actions/cache@v3
-        with:
-          path: ~/.gradle/wrapper
-          key: wrapper-${{ runner.os }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-
+        uses: gradle/actions/setup-gradle@v4
       - name: Generate Reference Docs
-        run:
-          ./gradlew dokkaHtmlMultiModule
+        run: ./gradlew dokkaHtmlMultiModule
 
       - name: Install and Build
         run: |


### PR DESCRIPTION
## Summary

This PR updates the `ci.yml` and `docs.yml` workflows to use the latest Actions versions as well as Gradle's own `gradle/actions/setup-gradle` action for cache.

## Changelog

Update the CI and Docs workflows.

## Test Plan

The build on GitHub is successful.