### PR TITLE
Quality: Map equality treats missing keys as equal when mapped value is null

### DIFF
--- a/litho-core/src/main/java/com/facebook/litho/utils/MapDiffUtils.kt
+++ b/litho-core/src/main/java/com/facebook/litho/utils/MapDiffUtils.kt
@@ -31,6 +31,6 @@ object MapDiffUtils {
     if (prev.size != next.size) {
       return false
     }
-    return prev.none { (key, value) -> !equals(value, next[key]) }
+    return prev.all { (key, value) -> next.containsKey(key) && equals(value, next[key]) }
   }
 }


### PR DESCRIPTION
## ✨ Code Quality

### Problem
`areMapsEqual` compares values via `next[key]` without verifying key presence. If `prev` has `{a: null}` and `next` has `{b: null}` (same size, different keys), `next[a]` returns `null`, the value comparison passes, and the method incorrectly returns `true`. This can cause silent diffing errors (e.g., skipping updates when maps actually changed), leading to stale UI/state.


**Severity**: `high`
**File**: `litho-core/src/main/java/com/facebook/litho/utils/MapDiffUtils.kt`

### Solution
Require key existence before value comparison:

@JvmStatic
fun <K, V> areMapsEqual(prev: Map<K, V>?, next: Map<K, V>?): Boolean {
  if (prev === next) return true
  if (prev == null || next == null) return false
  if (prev.size != next.size) return false

  return prev.all { (key, value) ->
    next.containsKey(key) && equals(value, next[key])
  }
}


### Changes
- `litho-core/src/main/java/com/facebook/litho/utils/MapDiffUtils.kt` (modified)



## Summary



## Changelog



## Test Plan



---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #1079