### PR TITLE
Quality: Non-volatile mutable global test flag can be stale across threads

### DIFF
--- a/litho-rendercore-thread-utils/src/main/java/com/facebook/rendercore/thread/utils/RenderCoreThreadUtilsConfig.kt
+++ b/litho-rendercore-thread-utils/src/main/java/com/facebook/rendercore/thread/utils/RenderCoreThreadUtilsConfig.kt
@@ -25,5 +25,5 @@ object RenderCoreThreadUtilsConfig {
    *
    * system property at startup but can be overridden at runtime.
    */
-  @JvmField var isEndToEndTestRun: Boolean = System.getProperty("IS_TESTING") != null
+  @Volatile @JvmField var isEndToEndTestRun: Boolean = System.getProperty("IS_TESTING") != null
 }


### PR DESCRIPTION
## ✨ Code Quality

### Problem
`isEndToEndTestRun` is a mutable global (`object` field) that can be changed at runtime, but it is not `@Volatile` or atomic. Reads/writes from different threads are a data race on JVM memory visibility, so one thread may not observe updates made by another. This can produce inconsistent thread-utils behavior during runtime toggles.


**Severity**: `medium`
**File**: `litho-rendercore-thread-utils/src/main/java/com/facebook/rendercore/thread/utils/RenderCoreThreadUtilsConfig.kt`

### Solution
Make visibility guarantees explicit using `@Volatile` (or `AtomicBoolean` if compare/set is needed):

object RenderCoreThreadUtilsConfig {
  @JvmField
  @Volatile
  var isEndToEndTestRun: Boolean = System.getProperty("IS_TESTING") != null
}

# Alternative:
# private val isEndToEndTestRun = AtomicBoolean(System.getProperty("IS_TESTING") != null)


### Changes
- `litho-rendercore-thread-utils/src/main/java/com/facebook/rendercore/thread/utils/RenderCoreThreadUtilsConfig.kt` (modified)



## Summary



## Changelog



## Test Plan



---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #1081