### PR TITLE
Fix fragile use of TypeMirror#toString in SpecElementTypeDeterminator

### DIFF
--- a/litho-it/src/test/com/facebook/litho/specmodels/processor/SpecElementTypeDeterminatorTest.java
+++ b/litho-it/src/test/com/facebook/litho/specmodels/processor/SpecElementTypeDeterminatorTest.java
@@ -20,9 +20,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.facebook.litho.specmodels.model.SpecElementType;
 import com.google.testing.compile.CompilationRule;
-import javax.annotation.Nullable;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,7 +38,7 @@ public class SpecElementTypeDeterminatorTest {
    * for.
    */
   public static class FakeKotlinSingleton {
-    @Nullable public static final FakeKotlinSingleton INSTANCE = null;
+    @NotNull public static final FakeKotlinSingleton INSTANCE = null;
   }
 
   @Test

--- a/litho-processor/src/main/java/com/facebook/litho/specmodels/processor/SpecElementTypeDeterminator.java
+++ b/litho-processor/src/main/java/com/facebook/litho/specmodels/processor/SpecElementTypeDeterminator.java
@@ -22,28 +22,29 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
 
 public class SpecElementTypeDeterminator {
   static boolean isKotlinSingleton(TypeElement element) {
-    final String className = element.getQualifiedName().toString();
     return element.getKind() == ElementKind.CLASS
         && element.getEnclosedElements().stream()
             .anyMatch(
                 e ->
                     isPublicStaticFinalElement(e)
-                        && isElementWithTypeName(e, className)
+                        && isElementWithType(e, element)
                         && e.getSimpleName().contentEquals("INSTANCE"));
   }
 
   static boolean isKotlinClass(TypeElement element) {
-    final String companionClassName = element.getQualifiedName().toString() + ".Companion";
     return element.getKind() == ElementKind.CLASS
         /* should contain a companion static field instance */
         && element.getEnclosedElements().stream()
             .anyMatch(
                 e ->
                     isPublicStaticFinalElement(e)
-                        && isElementWithTypeName(e, companionClassName)
+                        && isElementWithType(e, element)
                         && e.getSimpleName().contentEquals("Companion"))
         /* should contain a Companion class declaration. */
         && element.getEnclosedElements().stream()
@@ -71,7 +72,9 @@ public class SpecElementTypeDeterminator {
         .containsAll(ImmutableList.of(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL));
   }
 
-  static boolean isElementWithTypeName(Element e, String name) {
-    return e.asType().toString().equals(name);
+  static boolean isElementWithType(Element e, TypeElement typeElement) {
+    TypeMirror type = e.asType();
+    return type.getKind() == TypeKind.DECLARED
+        && ((DeclaredType) type).asElement().equals(typeElement);
   }
 }

--- a/litho-processor/src/main/java/com/facebook/litho/specmodels/processor/SpecElementTypeDeterminator.java
+++ b/litho-processor/src/main/java/com/facebook/litho/specmodels/processor/SpecElementTypeDeterminator.java
@@ -28,23 +28,25 @@ import javax.lang.model.type.TypeMirror;
 
 public class SpecElementTypeDeterminator {
   static boolean isKotlinSingleton(TypeElement element) {
+    final String className = element.getQualifiedName().toString();
     return element.getKind() == ElementKind.CLASS
         && element.getEnclosedElements().stream()
             .anyMatch(
                 e ->
                     isPublicStaticFinalElement(e)
-                        && isElementWithType(e, element)
+                        && isElementWithTypeName(e, className)
                         && e.getSimpleName().contentEquals("INSTANCE"));
   }
 
   static boolean isKotlinClass(TypeElement element) {
+    final String companionClassName = element.getQualifiedName().toString() + ".Companion";
     return element.getKind() == ElementKind.CLASS
         /* should contain a companion static field instance */
         && element.getEnclosedElements().stream()
             .anyMatch(
                 e ->
                     isPublicStaticFinalElement(e)
-                        && isElementWithType(e, element)
+                        && isElementWithTypeName(e, companionClassName)
                         && e.getSimpleName().contentEquals("Companion"))
         /* should contain a Companion class declaration. */
         && element.getEnclosedElements().stream()
@@ -72,9 +74,9 @@ public class SpecElementTypeDeterminator {
         .containsAll(ImmutableList.of(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL));
   }
 
-  static boolean isElementWithType(Element e, TypeElement typeElement) {
+  static boolean isElementWithTypeName(Element e, String name) {
     TypeMirror type = e.asType();
     return type.getKind() == TypeKind.DECLARED
-        && ((DeclaredType) type).asElement().equals(typeElement);
+        && ((TypeElement) ((DeclaredType) type).asElement()).getQualifiedName().contentEquals(name);
   }
 }


### PR DESCRIPTION
This fixes the issue described in https://github.com/facebook/litho/issues/1083, by comparing types using their underlying element instead of relying on `TypeMirror#toString`.